### PR TITLE
Move router dependencies to a submodule

### DIFF
--- a/src/diracx/routers/auth.py
+++ b/src/diracx/routers/auth.py
@@ -6,7 +6,7 @@ import json
 import re
 import secrets
 from datetime import datetime, timedelta
-from typing import Annotated, Literal, TypeAlias, TypedDict
+from typing import Annotated, Literal, TypedDict
 from uuid import UUID, uuid4
 
 import httpx
@@ -36,14 +36,14 @@ from diracx.core.properties import SecurityProperty, UnevaluatedProperty
 from diracx.core.settings import ServiceSettingsBase, TokenSigningKey
 from diracx.db.auth.schema import FlowStatus
 
-from .dependencies import AuthDB, Config
+from .dependencies import (
+    AuthDB,
+    AvailableSecurityProperties,
+    Config,
+)
 from .fastapi_classes import DiracxRouter
 
 oidc_scheme = OpenIdConnect(openIdConnectUrl="/.well-known/openid-configuration")
-
-AvailableSecurityProperties: TypeAlias = Annotated[
-    set[SecurityProperty], Depends(SecurityProperty.available_properties)
-]
 
 
 class AuthSettings(ServiceSettingsBase, env_prefix="DIRACX_SERVICE_AUTH_"):

--- a/src/diracx/routers/auth.py
+++ b/src/diracx/routers/auth.py
@@ -27,7 +27,6 @@ from fastapi.responses import RedirectResponse
 from fastapi.security import OpenIdConnect
 from pydantic import BaseModel, Field
 
-from diracx.core.config import Config, ConfigSource
 from diracx.core.exceptions import (
     DiracHttpResponse,
     ExpiredFlowError,
@@ -35,9 +34,9 @@ from diracx.core.exceptions import (
 )
 from diracx.core.properties import SecurityProperty, UnevaluatedProperty
 from diracx.core.settings import ServiceSettingsBase, TokenSigningKey
-from diracx.db import AuthDB
 from diracx.db.auth.schema import FlowStatus
 
+from .dependencies import AuthDB, Config
 from .fastapi_classes import DiracxRouter
 
 oidc_scheme = OpenIdConnect(openIdConnectUrl="/.well-known/openid-configuration")
@@ -283,8 +282,8 @@ async def initiate_device_flow(
     scope: str,
     audience: str,
     request: Request,
-    auth_db: Annotated[AuthDB, Depends(AuthDB.transaction)],
-    config: Annotated[Config, Depends(ConfigSource.create)],
+    auth_db: AuthDB,
+    config: Config,
     available_properties: AvailableSecurityProperties,
     settings: Annotated[AuthSettings, Depends(AuthSettings.create)],
 ) -> InitiateDeviceFlowResponse:
@@ -410,9 +409,9 @@ async def get_token_from_iam(
 @router.get("/device")
 async def do_device_flow(
     request: Request,
-    auth_db: Annotated[AuthDB, Depends(AuthDB.transaction)],
+    auth_db: AuthDB,
     user_code: str,
-    config: Annotated[Config, Depends(ConfigSource.create)],
+    config: Config,
     available_properties: AvailableSecurityProperties,
     settings: Annotated[AuthSettings, Depends(AuthSettings.create)],
 ) -> RedirectResponse:
@@ -461,8 +460,8 @@ async def finish_device_flow(
     request: Request,
     code: str,
     state: str,
-    auth_db: Annotated[AuthDB, Depends(AuthDB.transaction)],
-    config: Annotated[Config, Depends(ConfigSource.create)],
+    auth_db: AuthDB,
+    config: Config,
     settings: Annotated[AuthSettings, Depends(AuthSettings.create)],
 ):
     """
@@ -591,8 +590,8 @@ def parse_and_validate_scope(
 #         Form(description="OAuth2 Grant type"),
 #     ],
 #     client_id: Annotated[str, Form(description="OAuth2 client id")],
-#     auth_db: Annotated[AuthDB, Depends(AuthDB.transaction)],
-#     config: Annotated[Config, Depends(ConfigSource.create)],
+#     auth_db: AuthDB,
+#     config: Config,
 #     device_code: Annotated[str, Form(description="device code for OAuth2 device flow")],
 #     code: None,
 #     redirect_uri: None,
@@ -610,8 +609,8 @@ def parse_and_validate_scope(
 #         Form(description="OAuth2 Grant type"),
 #     ],
 #     client_id: Annotated[str, Form(description="OAuth2 client id")],
-#     auth_db: Annotated[AuthDB, Depends(AuthDB.transaction)],
-#     config: Annotated[Config, Depends(ConfigSource.create)],
+#     auth_db: AuthDB,
+#     config: Config,
 #     device_code: None,
 #     code: Annotated[str, Form(description="Code for OAuth2 authorization code flow")],
 #     redirect_uri: Annotated[
@@ -635,8 +634,8 @@ async def token(
         Form(description="OAuth2 Grant type"),
     ],
     client_id: Annotated[str, Form(description="OAuth2 client id")],
-    auth_db: Annotated[AuthDB, Depends(AuthDB.transaction)],
-    config: Annotated[Config, Depends(ConfigSource.create)],
+    auth_db: AuthDB,
+    config: Config,
     settings: Annotated[AuthSettings, Depends(AuthSettings.create)],
     available_properties: AvailableSecurityProperties,
     device_code: Annotated[
@@ -745,8 +744,8 @@ async def authorization_flow(
     redirect_uri: str,
     scope: str,
     state: str,
-    auth_db: Annotated[AuthDB, Depends(AuthDB.transaction)],
-    config: Annotated[Config, Depends(ConfigSource.create)],
+    auth_db: AuthDB,
+    config: Config,
     available_properties: AvailableSecurityProperties,
     settings: Annotated[AuthSettings, Depends(AuthSettings.create)],
 ):
@@ -797,8 +796,8 @@ async def authorization_flow_complete(
     code: str,
     state: str,
     request: Request,
-    auth_db: Annotated[AuthDB, Depends(AuthDB.transaction)],
-    config: Annotated[Config, Depends(ConfigSource.create)],
+    auth_db: AuthDB,
+    config: Config,
     settings: Annotated[AuthSettings, Depends(AuthSettings.create)],
 ):
     decrypted_state = decrypt_state(state)

--- a/src/diracx/routers/configuration.py
+++ b/src/diracx/routers/configuration.py
@@ -4,15 +4,13 @@ from datetime import datetime, timezone
 from typing import Annotated
 
 from fastapi import (
-    Depends,
     Header,
     HTTPException,
     Response,
     status,
 )
 
-from diracx.core.config import Config, ConfigSource
-
+from .dependencies import Config
 from .fastapi_classes import DiracxRouter
 
 LAST_MODIFIED_FORMAT = "%a, %d %b %Y %H:%M:%S GMT"
@@ -23,7 +21,7 @@ router = DiracxRouter()
 @router.get("/{vo}")
 async def serve_config(
     vo: str,
-    config: Annotated[Config, Depends(ConfigSource.create)],
+    config: Config,
     response: Response,
     if_none_match: Annotated[str | None, Header()] = None,
     if_modified_since: Annotated[str | None, Header()] = None,

--- a/src/diracx/routers/dependencies.py
+++ b/src/diracx/routers/dependencies.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+__all__ = ("Config", "AuthDB", "JobDB")
+
+from typing import Annotated
+
+from fastapi import Depends
+
+from diracx.core.config import Config as _Config
+from diracx.core.config import ConfigSource
+from diracx.db import AuthDB as _AuthDB
+from diracx.db import JobDB as _JobDB
+
+Config = Annotated[_Config, Depends(ConfigSource.create)]
+
+AuthDB = Annotated[_AuthDB, Depends(_AuthDB.transaction)]
+JobDB = Annotated[_JobDB, Depends(_JobDB.transaction)]

--- a/src/diracx/routers/dependencies.py
+++ b/src/diracx/routers/dependencies.py
@@ -4,6 +4,7 @@ __all__ = (
     "Config",
     "AuthDB",
     "JobDB",
+    "add_settings_annotation",
     "AvailableSecurityProperties",
 )
 
@@ -18,6 +19,11 @@ from diracx.db import AuthDB as _AuthDB
 from diracx.db import JobDB as _JobDB
 
 T = TypeVar("T")
+
+
+def add_settings_annotation(cls: T) -> T:
+    """Add a `Depends` annotation to a class that has a `create` classmethod."""
+    return Annotated[cls, Depends(cls.create)]  # type: ignore
 
 
 # Databases

--- a/src/diracx/routers/dependencies.py
+++ b/src/diracx/routers/dependencies.py
@@ -1,17 +1,31 @@
 from __future__ import annotations
 
-__all__ = ("Config", "AuthDB", "JobDB")
+__all__ = (
+    "Config",
+    "AuthDB",
+    "JobDB",
+    "AvailableSecurityProperties",
+)
 
-from typing import Annotated
+from typing import Annotated, TypeVar
 
 from fastapi import Depends
 
 from diracx.core.config import Config as _Config
 from diracx.core.config import ConfigSource
+from diracx.core.properties import SecurityProperty
 from diracx.db import AuthDB as _AuthDB
 from diracx.db import JobDB as _JobDB
 
-Config = Annotated[_Config, Depends(ConfigSource.create)]
+T = TypeVar("T")
 
+
+# Databases
 AuthDB = Annotated[_AuthDB, Depends(_AuthDB.transaction)]
 JobDB = Annotated[_JobDB, Depends(_JobDB.transaction)]
+
+# Miscellaneous
+Config = Annotated[_Config, Depends(ConfigSource.create)]
+AvailableSecurityProperties = Annotated[
+    set[SecurityProperty], Depends(SecurityProperty.available_properties)
+]

--- a/src/diracx/routers/job_manager/__init__.py
+++ b/src/diracx/routers/job_manager/__init__.py
@@ -11,9 +11,9 @@ from diracx.core.config import Config, ConfigSource
 from diracx.core.models import ScalarSearchOperator, SearchSpec, SortSpec
 from diracx.core.properties import JOB_ADMINISTRATOR, NORMAL_USER
 from diracx.core.utils import JobStatus
-from diracx.db import JobDB
 
 from ..auth import UserInfo, has_properties, verify_dirac_token
+from ..dependencies import JobDB
 from ..fastapi_classes import DiracxRouter
 
 MAX_PARAMETRIC_JOBS = 20
@@ -98,7 +98,7 @@ StdOutput = std.out;"""
 async def submit_bulk_jobs(
     # FIXME: Using mutliple doesn't work with swagger?
     job_definitions: Annotated[list[str], Body(example=EXAMPLE_JDLS["Simple JDL"])],
-    job_db: Annotated[JobDB, Depends(JobDB.transaction)],
+    job_db: JobDB,
     user_info: Annotated[UserInfo, Depends(verify_dirac_token)],
 ) -> list[InsertedJob]:
     from DIRAC.Core.Utilities.ClassAd.ClassAdLight import ClassAd
@@ -318,7 +318,7 @@ EXAMPLE_RESPONSES: dict[int | str, dict[str, Any]] = {
 @router.post("/search", responses=EXAMPLE_RESPONSES)
 async def search(
     config: Annotated[Config, Depends(ConfigSource.create)],
-    job_db: Annotated[JobDB, Depends(JobDB.transaction)],
+    job_db: JobDB,
     user_info: Annotated[UserInfo, Depends(verify_dirac_token)],
     page: int = 0,
     per_page: int = 100,
@@ -348,7 +348,7 @@ async def search(
 @router.post("/summary")
 async def summary(
     config: Annotated[Config, Depends(ConfigSource.create)],
-    job_db: Annotated[JobDB, Depends(JobDB.transaction)],
+    job_db: JobDB,
     user_info: Annotated[UserInfo, Depends(verify_dirac_token)],
     body: JobSummaryParams,
 ):

--- a/src/diracx/routers/well_known.py
+++ b/src/diracx/routers/well_known.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from typing import Annotated
-
-from fastapi import Depends, Request
+from fastapi import Request
 
 from diracx.routers.auth import AuthSettings
 
@@ -16,7 +14,7 @@ router = DiracxRouter(require_auth=False)
 async def openid_configuration(
     request: Request,
     config: Config,
-    settings: Annotated[AuthSettings, Depends(AuthSettings.create)],
+    settings: AuthSettings,
 ):
     print(dir(request))
     scopes_supported = []

--- a/src/diracx/routers/well_known.py
+++ b/src/diracx/routers/well_known.py
@@ -4,9 +4,9 @@ from typing import Annotated
 
 from fastapi import Depends, Request
 
-from diracx.core.config import Config, ConfigSource
 from diracx.routers.auth import AuthSettings
 
+from .dependencies import Config
 from .fastapi_classes import DiracxRouter
 
 router = DiracxRouter(require_auth=False)
@@ -15,7 +15,7 @@ router = DiracxRouter(require_auth=False)
 @router.get("/openid-configuration")
 async def openid_configuration(
     request: Request,
-    config: Annotated[Config, Depends(ConfigSource.create)],
+    config: Config,
     settings: Annotated[AuthSettings, Depends(AuthSettings.create)],
 ):
     print(dir(request))


### PR DESCRIPTION
This makes it possible to set the type of route arguments to `Config`/`AuthSettings`/`JobDB` without needing to specify the annotation on every route.