### PR TITLE
Partially adding sandbox metadata db

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,4 +33,4 @@ repos:
           - types-PyYAML
           - types-cachetools
           - types-requests
-        exclude: ^(src/diracx/client/|tests/)
+        exclude: ^(src/diracx/client/|tests/|build)

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,6 +76,7 @@ diracx =
 diracx.dbs =
 	AuthDB = diracx.db:AuthDB
 	JobDB = diracx.db:JobDB
+	SandboxMetadataDB = diracx.db:SandboxMetadataDB
 	#DummyDB = diracx.db:DummyDB
 diracx.services =
 	jobs = diracx.routers.job_manager:router

--- a/src/diracx/db/__init__.py
+++ b/src/diracx/db/__init__.py
@@ -1,6 +1,7 @@
-__all__ = ("AuthDB", "JobDB")
+__all__ = ("AuthDB", "JobDB", "SandboxMetadataDB")
 
 from .auth.db import AuthDB
 from .jobs.db import JobDB
+from .sandbox_metadata.db import SandboxMetadataDB
 
 # from .dummy.db import DummyDB

--- a/src/diracx/db/sandbox_metadata/db.py
+++ b/src/diracx/db/sandbox_metadata/db.py
@@ -1,0 +1,80 @@
+""" SandboxMetadataDB frontend
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import sqlalchemy
+
+from ..utils import BaseDB
+from .schema import Base as SandboxMetadataDBBase
+from .schema import sb_Owners, sb_SandBoxes
+
+
+class SandboxMetadataDB(BaseDB):
+    # This needs to be here for the BaseDB to create the engine
+    metadata = SandboxMetadataDBBase.metadata
+
+    async def _get_put_owner(self, owner: str, owner_group: str) -> int:
+        """adds a new owner/ownerGroup pairs, while returning their ID if already existing
+
+        Args:
+            owner (str): user name
+            owner_group (str): group of the owner
+        """
+        stmt = sqlalchemy.select(sb_Owners.OwnerID).where(
+            sb_Owners.Owner == owner, sb_Owners.OwnerGroup == owner_group
+        )
+        result = await self.conn.execute(stmt)
+        if owner_id := result.scalar_one_or_none():
+            return owner_id
+
+        stmt = sqlalchemy.insert(sb_Owners).values(Owner=owner, OwnerGroup=owner_group)
+        result = await self.conn.execute(stmt)
+        return result.lastrowid
+
+    async def insert(
+        self, owner: str, owner_group: str, sb_SE: str, se_PFN: str, size: int = 0
+    ) -> tuple[int, bool]:
+        """inserts a new sandbox in SandboxMetadataDB
+        this is "equivalent" of DIRAC registerAndGetSandbox
+
+        Args:
+            owner (str): user name_
+            owner_group (str): groupd of the owner
+            sb_SE (str): _description_
+            sb_PFN (str): _description_
+            size (int, optional): _description_. Defaults to 0.
+        """
+        owner_id = await self._get_put_owner(owner, owner_group)
+        stmt = sqlalchemy.insert(sb_SandBoxes).values(
+            OwnerId=owner_id, SEName=sb_SE, SEPFN=se_PFN, Bytes=size
+        )
+        try:
+            result = await self.conn.execute(stmt)
+            return result.lastrowid
+        except sqlalchemy.exc.IntegrityError:
+            # it is a duplicate, try to retrieve SBiD
+            stmt: sqlalchemy.Executable = sqlalchemy.select(sb_SandBoxes.SBId).where(  # type: ignore[no-redef]
+                sb_SandBoxes.SEPFN == se_PFN,
+                sb_SandBoxes.SEName == sb_SE,
+                sb_SandBoxes.OwnerId == owner_id,
+            )
+            result = await self.conn.execute(stmt)
+            sb_ID = result.scalar_one()
+            stmt: sqlalchemy.Executable = (  # type: ignore[no-redef]
+                sqlalchemy.update(sb_SandBoxes)
+                .where(sb_SandBoxes.SBId == sb_ID)
+                .values(LastAccessTime=datetime.datetime.utcnow())
+            )
+            await self.conn.execute(stmt)
+            return sb_ID
+
+    async def delete(self, sandbox_ids: list[int]) -> bool:
+        stmt: sqlalchemy.Executable = sqlalchemy.delete(sb_SandBoxes).where(
+            sb_SandBoxes.SBId.in_(sandbox_ids)
+        )
+        await self.conn.execute(stmt)
+
+        return True

--- a/src/diracx/db/sandbox_metadata/schema.py
+++ b/src/diracx/db/sandbox_metadata/schema.py
@@ -1,0 +1,51 @@
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    Index,
+    Integer,
+    PrimaryKeyConstraint,
+    String,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import declarative_base
+
+from ..utils import Column, DateNowColumn
+
+Base = declarative_base()
+
+
+class sb_Owners(Base):
+    __tablename__ = "sb_Owners"
+    OwnerID = Column(Integer, autoincrement=True)
+    Owner = Column(String(32))
+    OwnerGroup = Column(String(32))
+    __table_args__ = (PrimaryKeyConstraint("OwnerID"),)
+
+
+class sb_SandBoxes(Base):
+    __tablename__ = "sb_SandBoxes"
+    SBId = Column(Integer, autoincrement=True)
+    OwnerId = Column(Integer)
+    SEName = Column(String(64))
+    SEPFN = Column(String(512))
+    Bytes = Column(BigInteger)
+    RegistrationTime = DateNowColumn()
+    LastAccessTime = DateNowColumn()
+    Assigned = Column(Boolean, default=False)
+    __table_args__ = (
+        PrimaryKeyConstraint("SBId"),
+        Index("OwnerId", OwnerId),
+        UniqueConstraint("SEName", "SEPFN", name="Location"),
+    )
+
+
+class sb_EntityMapping(Base):
+    __tablename__ = "sb_EntityMapping"
+    SBId = Column(Integer)
+    EntityId = Column(String(128))
+    Type = Column(String(64))
+    __table_args__ = (
+        PrimaryKeyConstraint("SBId", "EntityId", "Type"),
+        Index("SBId", "EntityId"),
+        UniqueConstraint("SBId", "EntityId", "Type", name="Mapping"),
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,6 +74,7 @@ def with_app(test_auth_settings, with_config_repo):
         database_urls={
             "JobDB": "sqlite+aiosqlite:///:memory:",
             "AuthDB": "sqlite+aiosqlite:///:memory:",
+            "SandboxMetadataDB": "sqlite+aiosqlite:///:memory:",
         },
         config_source=ConfigSource.create_from_url(
             backend_url=f"git+file://{with_config_repo}"

--- a/tests/db/test_sandboxMetadataDB.py
+++ b/tests/db/test_sandboxMetadataDB.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import pytest
+import sqlalchemy
+
+from diracx.db.sandbox_metadata.db import SandboxMetadataDB
+
+
+@pytest.fixture
+async def sandbox_metadata_db(tmp_path):
+    sandbox_metadata_db = SandboxMetadataDB("sqlite+aiosqlite:///:memory:")
+    async with sandbox_metadata_db.engine_context():
+        yield sandbox_metadata_db
+
+
+async def test__get_put_owner(sandbox_metadata_db):
+    async with sandbox_metadata_db as sandbox_metadata_db:
+        result = await sandbox_metadata_db._get_put_owner("owner", "owner_group")
+        assert result == 1
+        result = await sandbox_metadata_db._get_put_owner("owner_2", "owner_group")
+        assert result == 2
+        result = await sandbox_metadata_db._get_put_owner("owner", "owner_group")
+        assert result == 1
+        result = await sandbox_metadata_db._get_put_owner("owner_2", "owner_group")
+        assert result == 2
+        result = await sandbox_metadata_db._get_put_owner("owner_2", "owner_group_2")
+        assert result == 3
+
+
+async def test_insert(sandbox_metadata_db):
+    async with sandbox_metadata_db as sandbox_metadata_db:
+        result = await sandbox_metadata_db.insert(
+            "owner",
+            "owner_group",
+            "sbSE",
+            "sbPFN",
+            123,
+        )
+        assert result == 1
+
+        result = await sandbox_metadata_db.insert(
+            "owner",
+            "owner_group",
+            "sbSE",
+            "sbPFN",
+            123,
+        )
+        assert result == 1
+
+        result = await sandbox_metadata_db.insert(
+            "owner_2",
+            "owner_group",
+            "sbSE",
+            "sbPFN_2",
+            123,
+        )
+        assert result == 2
+
+        # This would be incorrect
+        with pytest.raises(sqlalchemy.exc.NoResultFound):
+            await sandbox_metadata_db.insert(
+                "owner",
+                "owner_group",
+                "sbSE",
+                "sbPFN_2",
+                123,
+            )
+
+
+async def test_delete(sandbox_metadata_db):
+    async with sandbox_metadata_db as sandbox_metadata_db:
+        result = await sandbox_metadata_db.insert(
+            "owner",
+            "owner_group",
+            "sbSE",
+            "sbPFN",
+            123,
+        )
+        assert result == 1
+
+        result = await sandbox_metadata_db.delete([1])
+        assert result


### PR DESCRIPTION
This PR adds the basic functionalities of SandboxMetadataDB. Partially addresses https://github.com/DIRACGrid/diracx/issues/13 . Few notes:

- the DB schema added here is what is defined in https://github.com/DIRACGrid/DIRAC/pull/6566 (so, what is in DIRAC v8.1 but excluding OwnerDN).
- Only insertion of a new SB is added, no other functionalities (deletion is tentatively added)
- There are discussions going on in https://github.com/DIRACGrid/diracx/discussions/16 that might lead to a simplification of DIRAC's Sandbox (specifically if external Sandbox SEs are not supported) so I would wait before implementing further.