### PR TITLE
"Freeze" the openapi version to 3.0.2

### DIFF
--- a/src/diracx/routers/fastapi_classes.py
+++ b/src/diracx/routers/fastapi_classes.py
@@ -35,6 +35,10 @@ class DiracFastAPI(FastAPI):
             title="Dirac",
             lifespan=lifespan,
         )
+        # FIXME: when autorest will support 3.1.0
+        # From 0.99.0, FastAPI is using openapi 3.1.0 by default
+        # This version is not supported by autorest yet
+        self.openapi_version = "3.0.2"
 
     def openapi(self, *args, **kwargs):
         if not self.openapi_schema:
@@ -45,6 +49,7 @@ class DiracFastAPI(FastAPI):
                     # remove 422 response, also can remove other status code
                     if "422" in responses:
                         del responses["422"]
+
         return self.openapi_schema
 
 

--- a/src/diracx/routers/job_manager/__init__.py
+++ b/src/diracx/routers/job_manager/__init__.py
@@ -324,7 +324,9 @@ async def search(
     user_info: Annotated[UserInfo, Depends(verify_dirac_token)],
     page: int = 0,
     per_page: int = 100,
-    body: Annotated[JobSearchParams | None, Body(examples=EXAMPLE_SEARCHES)] = None,
+    body: Annotated[
+        JobSearchParams | None, Body(openapi_examples=EXAMPLE_SEARCHES)
+    ] = None,
 ) -> list[dict[str, Any]]:
     """Retrieve information about jobs.
 


### PR DESCRIPTION
- FastAPI 0.99.0 is using openapi 3.1.0 by default: https://fastapi.tiangolo.com/release-notes/?h=0.99.0#features_3
- Autorest does not support it yet

```bash
error   | schema_violation | Schema violation: must match pattern "^3\.0\.\d(-.+)?$" (openapi)
  pattern: ^3\.0\.\d(-.+)?$
    - file:///tmp/pytest-of-aldbr/pytest-49/test_regenerate_client0/openapi.json:1:2
```