### PR TITLE
fix: add mypy option in pyproject to avoid module import errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,10 @@ allow_redefinition = true
 enable_error_code = ["import", "attr-defined"]
 
 [[tool.mypy.overrides]]
+module = 'DIRAC.*'
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
 module = 'authlib.*'
 ignore_missing_imports = true
 


### PR DESCRIPTION
Add a mypy option in pyproject file to avoid module import errors from DIRAC

(see https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports)