### PR TITLE
Implement OpenSearchJobParametersDB 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -77,6 +77,7 @@ diracx.dbs =
 	AuthDB = diracx.db:AuthDB
 	JobDB = diracx.db:JobDB
 	SandboxMetadataDB = diracx.db:SandboxMetadataDB
+	OpenSearchJobParametersDB = diracx.db:OpenSearchJobParametersDB
 	#DummyDB = diracx.db:DummyDB
 diracx.services =
 	jobs = diracx.routers.job_manager:router

--- a/src/diracx/db/__init__.py
+++ b/src/diracx/db/__init__.py
@@ -1,6 +1,7 @@
-__all__ = ("AuthDB", "JobDB", "SandboxMetadataDB")
+__all__ = ("AuthDB", "JobDB", "SandboxMetadataDB", "OpenSearchJobParametersDB")
 
 from .auth.db import AuthDB
+from .job_parameters.db import OpenSearchJobParametersDB
 from .jobs.db import JobDB
 from .sandbox_metadata.db import SandboxMetadataDB
 

--- a/src/diracx/db/job_parameters/db.py
+++ b/src/diracx/db/job_parameters/db.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from opensearchpy import OpenSearch
+
+try:
+    from opensearchpy import A, Q, Search
+except ImportError:
+    pass
+
+from ..utils import BaseDB
+
+
+class OpenSearchJobParametersDB(BaseDB):
+    async def set_client():
+        # TODO: get connection secrets from SettingsClass.create and connection details from configuration
+        host = "opensearch-cluster-master"
+        port = 9200
+        # For now credentials are hard coded, to be set here
+        auth = ("user", "pwd")
+        client = OpenSearch(
+            hosts=[{"host": host, "port": port}],
+            http_auth=auth,
+            use_ssl=True,
+            verify_certs=False,
+        )
+        return client

--- a/src/diracx/routers/dependencies.py
+++ b/src/diracx/routers/dependencies.py
@@ -17,6 +17,7 @@ from diracx.core.config import ConfigSource
 from diracx.core.properties import SecurityProperty
 from diracx.db import AuthDB as _AuthDB
 from diracx.db import JobDB as _JobDB
+from diracx.db import OpenSearchJobParametersDB as _OpenSearchJobParametersDB
 
 T = TypeVar("T")
 
@@ -29,6 +30,9 @@ def add_settings_annotation(cls: T) -> T:
 # Databases
 AuthDB = Annotated[_AuthDB, Depends(_AuthDB.transaction)]
 JobDB = Annotated[_JobDB, Depends(_JobDB.transaction)]
+OpenSearchJobParametersDB = Annotated[
+    _OpenSearchJobParametersDB, Depends(_OpenSearchJobParametersDB.set_client)
+]
 
 # Miscellaneous
 Config = Annotated[_Config, Depends(ConfigSource.create)]


### PR DESCRIPTION
Very preliminary implementation of OpenSearchJobParametersDB.
It allows to connect to the OpenSearch instance.
The set_single_job_parameters method allows to create an index with dummy job parameters.