### PR TITLE
Separate creating the DB schema from the engine creation

### DIFF
--- a/src/diracx/db/__main__.py
+++ b/src/diracx/db/__main__.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(required=True)
+
+    init_sql_parser = subparsers.add_parser(
+        "init-sql", help="Initialise schema for SQL databases"
+    )
+    init_sql_parser.set_defaults(func=init_sql)
+
+    args = parser.parse_args()
+    logger.setLevel(logging.INFO)
+    asyncio.run(args.func())
+
+
+async def init_sql():
+    logger.info("Initialising SQL databases")
+    from diracx.db.utils import BaseDB
+
+    for db_name, db_url in BaseDB.available_urls().items():
+        logger.info("Initialising %s", db_name)
+        db = BaseDB.available_implementations(db_name)[0](db_url)
+        async with db.engine_context():
+            async with db.engine.begin() as conn:
+                await conn.run_sync(db.metadata.create_all)
+
+
+if __name__ == "__main__":
+    parse_args()

--- a/src/diracx/routers/__init__.py
+++ b/src/diracx/routers/__init__.py
@@ -58,11 +58,7 @@ def create_app_inner(
     # Add the DBs to the application
     available_db_classes: set[type[BaseDB]] = set()
     for db_name, db_url in database_urls.items():
-        db_classes: list[type[BaseDB]] = [
-            entry_point.load()
-            for entry_point in select_from_extension(group="diracx.dbs", name=db_name)
-        ]
-        assert db_classes, f"Could not find {db_name=}"
+        db_classes = BaseDB.available_implementations(db_name)
         # The first DB is the highest priority one
         db = db_classes[0](db_url=db_url)
         app.lifetime_functions.append(db.engine_context)

--- a/tests/db/auth/test_authorization_flow.py
+++ b/tests/db/auth/test_authorization_flow.py
@@ -14,6 +14,8 @@ EXPIRED = 0
 async def auth_db(tmp_path):
     auth_db = AuthDB("sqlite+aiosqlite:///:memory:")
     async with auth_db.engine_context():
+        async with auth_db.engine.begin() as conn:
+            await conn.run_sync(auth_db.metadata.create_all)
         yield auth_db
 
 

--- a/tests/db/auth/test_device_flow.py
+++ b/tests/db/auth/test_device_flow.py
@@ -17,6 +17,8 @@ EXPIRED = 0
 async def auth_db(tmp_path):
     auth_db = AuthDB("sqlite+aiosqlite:///:memory:")
     async with auth_db.engine_context():
+        async with auth_db.engine.begin() as conn:
+            await conn.run_sync(auth_db.metadata.create_all)
         yield auth_db
 
 

--- a/tests/db/auth/test_refresh_token.py
+++ b/tests/db/auth/test_refresh_token.py
@@ -10,6 +10,8 @@ from diracx.db.auth.schema import RefreshTokenStatus
 async def auth_db(tmp_path):
     auth_db = AuthDB("sqlite+aiosqlite:///:memory:")
     async with auth_db.engine_context():
+        async with auth_db.engine.begin() as conn:
+            await conn.run_sync(auth_db.metadata.create_all)
         yield auth_db
 
 

--- a/tests/db/jobs/test_jobDB.py
+++ b/tests/db/jobs/test_jobDB.py
@@ -11,6 +11,8 @@ from diracx.db.jobs.db import JobDB
 async def job_db(tmp_path):
     job_db = JobDB("sqlite+aiosqlite:///:memory:")
     async with job_db.engine_context():
+        async with job_db.engine.begin() as conn:
+            await conn.run_sync(job_db.metadata.create_all)
         yield job_db
 
 

--- a/tests/db/jobs/test_jobLoggingDB.py
+++ b/tests/db/jobs/test_jobLoggingDB.py
@@ -10,6 +10,8 @@ from diracx.db import JobLoggingDB
 async def job_logging_db():
     job_logging_db = JobLoggingDB("sqlite+aiosqlite:///:memory:")
     async with job_logging_db.engine_context():
+        async with job_logging_db.engine.begin() as conn:
+            await conn.run_sync(job_logging_db.metadata.create_all)
         yield job_logging_db
 
 

--- a/tests/db/test_dummyDB.py
+++ b/tests/db/test_dummyDB.py
@@ -16,6 +16,8 @@ from diracx.db.dummy.db import DummyDB
 async def dummy_db(tmp_path) -> DummyDB:
     dummy_db = DummyDB("sqlite+aiosqlite:///:memory:")
     async with dummy_db.engine_context():
+        async with dummy_db.engine.begin() as conn:
+            await conn.run_sync(dummy_db.metadata.create_all)
         yield dummy_db
 
 

--- a/tests/db/test_sandboxMetadataDB.py
+++ b/tests/db/test_sandboxMetadataDB.py
@@ -10,6 +10,8 @@ from diracx.db.sandbox_metadata.db import SandboxMetadataDB
 async def sandbox_metadata_db(tmp_path):
     sandbox_metadata_db = SandboxMetadataDB("sqlite+aiosqlite:///:memory:")
     async with sandbox_metadata_db.engine_context():
+        async with sandbox_metadata_db.engine.begin() as conn:
+            await conn.run_sync(sandbox_metadata_db.metadata.create_all)
         yield sandbox_metadata_db
 
 


### PR DESCRIPTION
When running in production we don't want to be filling the DB schema everytime the engine is created.

This PR:

* Adds a new classmethod `available_implementations` to `BaseDB` that retrieves available implementations for a given database name.
* Adds a `__main__` module to `diracx.db` such that the databases can be initialised with something like `python -m diracx.db init-sql`