### PR TITLE
Support running enchanced tests against the demo instance

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,49 @@ jobs:
       - name: Upload coverage report
         uses: codecov/codecov-action@v3.1.4
 
+  pytest-integration:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: environment.yml
+          init-shell: bash
+          post-cleanup: 'all'
+      - name: Set up environment
+        run: |
+          pip install pytest-github-actions-annotate-failures
+          pip install git+https://github.com/DIRACGrid/DIRAC.git@integration
+          pip install .
+      - name: Start demo
+        run: |
+          git clone https://github.com/DIRACGrid/diracx-charts.git ../diracx-charts
+          ../diracx-charts/run_demo.sh --exit-when-done $PWD
+      - name: Debugging information
+        run: |
+          DIRACX_DEMO_DIR=$PWD/../diracx-charts/.demo
+          export KUBECONFIG=${DIRACX_DEMO_DIR}/kube.conf
+          export PATH=${DIRACX_DEMO_DIR}:$PATH
+          kubectl get pods
+          for pod_name in $(kubectl get pods -o json | jq -r '.items[] | .metadata.name' | grep -vE '(dex|minio|mysql|rabbitmq|opensearch)'); do
+            echo "${pod_name}"
+            kubectl describe pod/"${pod_name}" || true
+            for container_name in $(kubectl get pods $pod_name -o jsonpath='{.spec.initContainers[*].name} {.spec.containers[*].name}'); do
+              echo $pod_name $container_name
+              kubectl logs "${pod_name}" -c "${container_name}" || true
+            done
+          done
+          if [ ! -f "${DIRACX_DEMO_DIR}/.success" ]; then
+            cat "${DIRACX_DEMO_DIR}/.failed"
+            exit 1
+          fi
+      - name: Run pytest
+        run: |
+          pytest . --demo-dir ../diracx-charts/ --cov-report=xml:coverage.xml --junitxml=report.xml
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v3.1.4
+
   mypy:
     runs-on: ubuntu-latest
     steps:

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,4 +10,8 @@ coverage:
         target: 100%
         informational: true
 
+codecov:
+  notify:
+    after_n_builds: 2
+
 comment: false

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,13 +58,20 @@ pre-commit install
 
 ### Run the test
 
-Run the unit tests
+Run the unit tests:
 
 ```bash
 # In the `diracx` folder
 pytest
 mypy .
 pre-commit run --all-files
+```
+
+Some tests require the DiracX demo instance to be running (see above) and are skipped by default.
+To enable these tests pass `--demo-dir` like so:
+
+```bash
+pytest . --demo-dir ../diracx-charts/
 ```
 
 ### Run a local instance of diracx

--- a/tests/db/opensearch/test_connection.py
+++ b/tests/db/opensearch/test_connection.py
@@ -78,3 +78,17 @@ async def test_connection_error_bad_password(opensearch_conn_kwargs):
         }
     )
     await _ensure_db_unavailable(db)
+
+
+async def test_sanity_checks(opensearch_conn_kwargs):
+    """Check that the sanity checks are working as expected."""
+    db = DummyOSDB(opensearch_conn_kwargs)
+    # Check that the client is not available before entering the context manager
+    with pytest.raises(RuntimeError):
+        db.client.ping()
+
+    # It shouldn't be possible to enter the context manager twice
+    async with db.client_context():
+        assert db.client.ping()
+        with pytest.raises(AssertionError):
+            await db.__aenter__()


### PR DESCRIPTION
This PR makes it possible to pass `--demo-dir ../diracx-charts/` to pytest to run enhanced tests. For now this is just used to test against OpenSearch however it should soon be expanded to include MySQL and the DiracX services themselves. Doing that might result in the fixtures being refactored but the I think the interface for running the tests will be stable.

In general these tests should focus on being independent, fast and easy to rerun without leaving any messy state on the server. In the case of testing against OpenSearch I create a random index prefix each time and try to clean up again afterwards (but even if the cleanup fails future test runs should be unaffected).

Whil the standard `pytest` job is a strict subset, I keep it as I think we should keep the CI for the sake of making sure the tests still work in the minimal mode.