### PR TITLE
Use StrEnum instead of subclassing both str and Enum

### DIFF
--- a/src/diracx/core/models.py
+++ b/src/diracx/core/models.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Literal, TypedDict
 
 from pydantic import BaseModel, Field
 
 
-class ScalarSearchOperator(str, Enum):
+class ScalarSearchOperator(StrEnum):
     EQUAL = "eq"
     NOT_EQUAL = "neq"
     GREATER_THAN = "gt"
@@ -15,7 +15,7 @@ class ScalarSearchOperator(str, Enum):
     LIKE = "like"
 
 
-class VectorSearchOperator(str, Enum):
+class VectorSearchOperator(StrEnum):
     IN = "in"
     NOT_IN = "not in"
 
@@ -49,7 +49,7 @@ class TokenResponse(BaseModel):
     refresh_token: str | None
 
 
-class JobStatus(str, Enum):
+class JobStatus(StrEnum):
     SUBMITTING = "Submitting"
     RECEIVED = "Received"
     CHECKING = "Checking"

--- a/src/diracx/routers/auth.py
+++ b/src/diracx/routers/auth.py
@@ -6,7 +6,7 @@ import json
 import re
 import secrets
 from datetime import timedelta
-from enum import Enum
+from enum import StrEnum
 from typing import Annotated, Literal, TypedDict
 from uuid import UUID, uuid4
 
@@ -90,7 +90,7 @@ def has_properties(expression: UnevaluatedProperty | SecurityProperty):
     return Depends(require_property)
 
 
-class GrantType(str, Enum):
+class GrantType(StrEnum):
     authorization_code = "authorization_code"
     device_code = "urn:ietf:params:oauth:grant-type:device_code"
     refresh_token = "refresh_token"


### PR DESCRIPTION
In Python 3.11 a `StrEnum` class was added to avoid some of the issues with inheriting from `str`. See https://github.com/python/cpython/issues/85982 for details.