### PR TITLE
Starting point for "dirac internal legacy generate-helm-values"

### DIFF
--- a/src/diracx/__init__.py
+++ b/src/diracx/__init__.py
@@ -2,7 +2,7 @@ import logging
 from importlib.metadata import PackageNotFoundError, version
 
 logging.basicConfig(
-    level=logging.DEBUG, format="%(asctime)s | %(name)s | %(levelname)s | %(message)s"
+    level=logging.WARNING, format="%(asctime)s | %(name)s | %(levelname)s | %(message)s"
 )
 
 try:

--- a/tests/cli/legacy/cs_sync/integration_test.cfg
+++ b/tests/cli/legacy/cs_sync/integration_test.cfg
@@ -26,6 +26,11 @@ DIRAC
     }
   }
 }
+DiracX
+{
+  URL = https://dirac-integration-tests.invalid:1234
+  LegacyExchangeApiKey = diracx:legacy:ChangeME
+}
 Systems
 {
   Configuration

--- a/tests/cli/legacy/cs_sync/integration_test_secret.cfg
+++ b/tests/cli/legacy/cs_sync/integration_test_secret.cfg
@@ -1,0 +1,136 @@
+#This section determines which DIRAC components will be installed and where
+LocalInstallation
+{
+  Release = rel-v8r0
+  InstallType = server
+  TargetPath = /home/dirac/ServerInstallDIR
+  SiteName = DIRAC.Jenkins.ch
+  Setup = dirac-JenkinsSetup
+  InstanceName = Production
+  VirtualOrganization = vo
+  SkipCADownload = True
+  UseServerCertificate = True
+  #ConfigurationServer = https://myprimaryserver.name:8443/Configuration/Server
+  ConfigurationName = Production
+  #LogLevel of the installed components
+  LogLevel = DEBUG
+  AdminUserName = adminusername
+  #DN of the Admin user certificate (default: None )
+  #In order the find out the DN that needs to be included in the Configuration for a given
+  #host or user certificate the following command can be used::
+  #openssl x509 -noout -subject -enddate -in <certfile.pem>
+  AdminUserDN = /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser
+  AdminUserEmail = lhcb-dirac-ci@cern.ch
+  AdminGroupName = dirac_admin
+  #DN of the host certificate (*) (default: None )
+  HostDN = /C=ch/O=DIRAC/OU=DIRAC CI/CN=server
+  ConfigurationMaster = yes
+  Host = server
+  #List of Systems to be installed - by default all services are added
+  Systems = Accounting
+  Systems += Configuration
+  Systems += DataManagement
+  Systems += Framework
+  Systems += Monitoring
+  Systems += RequestManagement
+  Systems += ResourceStatus
+  Systems += StorageManagement
+  Systems += Production
+  Systems += Transformation
+  Systems += WorkloadManagement
+  Systems += Tornado
+  #List of DataBases to be installed - minimal list for a running base server
+  Databases = InstalledComponentsDB
+  Databases += ResourceStatusDB
+  #List of Services to be installed - minimal list for a running base server
+  Services = Configuration/Server
+  Services += Framework/ComponentMonitoring
+  Services += Framework/SystemAdministrator
+  Services += ResourceStatus/ResourceStatus
+  Database
+  {
+    User = Dirac
+    Password = Dirac
+    RootUser = root
+    RootPwd = password
+    Host = mysql
+    Port = 3306
+  }
+  NoSQLDatabase
+  {
+    User = elastic
+    Password = changeme
+    Host = elasticsearch
+    Port = 9200
+    SSL = No
+  }
+}
+DIRAC
+{
+  Setup = dirac-JenkinsSetup
+  VirtualOrganization = vo
+  Hostname = server
+  Security
+  {
+  }
+  Setups
+  {
+    dirac-JenkinsSetup
+    {
+      Configuration = Production
+      Accounting = Production
+      DataManagement = Production
+      Framework = Production
+      Monitoring = Production
+      RequestManagement = Production
+      ResourceStatus = Production
+      StorageManagement = Production
+      Production = Production
+      Transformation = Production
+      WorkloadManagement = Production
+      Tornado = Production
+    }
+  }
+  Configuration
+  {
+    Master = yes
+    Name = Production
+    Servers = dips://server:9135/Configuration/Server
+  }
+}
+LocalSite
+{
+  Site = DIRAC.Jenkins.ch
+}
+Systems
+{
+  Databases
+  {
+    User = Dirac
+    Password = Dirac
+    Host = mysql
+    Port = 3306
+  }
+  NoSQLDatabases
+  {
+    Host = elasticsearch
+    Port = 9200
+    User = elastic
+    Password = changeme
+    SSL = No
+  }
+}
+Resources
+{
+  StorageElements
+  {
+    S3-INDIRECT
+    {
+      S3
+      {
+        Aws_access_key_id = fakeId
+        Aws_secret_access_key = fakeKey
+      }
+    }
+  }
+}

--- a/tests/cli/legacy/test_legacy.py
+++ b/tests/cli/legacy/test_legacy.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+import yaml
+from typer.testing import CliRunner
+
+from diracx.cli import app
+
+runner = CliRunner()
+
+file_path = Path(__file__).parent
+
+
+def test_generate_helm_values(tmp_path, monkeypatch):
+    output_file = tmp_path / "values.yaml"
+
+    result = runner.invoke(
+        app,
+        [
+            "internal",
+            "legacy",
+            "generate-helm-values",
+            "--public-cfg",
+            str(file_path / "cs_sync" / "integration_test.cfg"),
+            "--secret-cfg",
+            str(file_path / "cs_sync" / "integration_test_secret.cfg"),
+            "--output-file",
+            str(output_file),
+        ],
+    )
+    assert result.exit_code == 0
+    assert output_file.is_file()
+
+    assert isinstance(yaml.safe_load(output_file.read_text()), dict)


### PR DESCRIPTION
For #125 

It gives the initial values.yaml alright for the dirac setup running on openshift, but we will have to polish the ingress and SNI for running everything on k3s or other before being able to generate a fully correct initial values.yaml

