### PR TITLE
Make run_local.sh usable

### DIFF
--- a/run_local.sh
+++ b/run_local.sh
@@ -1,32 +1,77 @@
 #!/usr/bin/env bash
-
-### Runs a local uvicorn server with the default configuration
-
-
+# Run a local uvicorn server with the default configuration
 set -euo pipefail
 IFS=$'\n\t'
 
 tmp_dir=$(mktemp -d)
+echo "Using temp dir: ${tmp_dir}"
 mkdir -p "${tmp_dir}/signing-key" "${tmp_dir}/cs_store/"
 
-ssh-keygen -P "" -t rsa -b 4096 -m PEM -f "${tmp_dir}/signing-key/rs256.key"
+signing_key="${tmp_dir}/signing-key/rsa256.key"
+ssh-keygen -P "" -t rsa -b 4096 -m PEM -f "${signing_key}"
 
-dirac internal generate-cs "${tmp_dir}/cs_store/initialRepo" --vo=diracAdmin --user-group=admin --idp-url=runlocal.diracx.invalid
+# Make a fake CS
+dirac internal generate-cs "${tmp_dir}/cs_store/initialRepo" \
+  --vo=diracAdmin --user-group=admin --idp-url=runlocal.diracx.invalid
+dirac internal add-user "${tmp_dir}/cs_store/initialRepo" \
+  --vo=diracAdmin --user-group=admin \
+  --sub=75212b23-14c2-47be-9374-eb0113b0575e \
+  --preferred-username=localuser
 
 export DIRACX_CONFIG_BACKEND_URL="git+file://${tmp_dir}/cs_store/initialRepo"
 export DIRACX_DB_URL_AUTHDB="sqlite+aiosqlite:///:memory:"
 export DIRACX_DB_URL_JOBDB="sqlite+aiosqlite:///:memory:"
 export DIRACX_DB_URL_JOBLOGGINGDB="sqlite+aiosqlite:///:memory:"
-export DIRACX_SERVICE_AUTH_TOKEN_KEY="file://${tmp_dir}/signing-key/rs256.key"
+export DIRACX_DB_URL_SANDBOXMETADATADB="sqlite+aiosqlite:///:memory:"
+export DIRACX_SERVICE_AUTH_TOKEN_KEY="file://${signing_key}"
 export DIRACX_SERVICE_AUTH_ALLOWED_REDIRECTS='["http://'$(hostname| tr -s '[:upper:]' '[:lower:]')':8000/docs/oauth2-redirect"]'
+export DIRACX_SANDBOX_STORE_BUCKET_NAME=sandboxes
+export DIRACX_SANDBOX_STORE_AUTO_CREATE_BUCKET=true
+export DIRACX_SANDBOX_STORE_S3_CLIENT_KWARGS='{"endpoint_url": "http://localhost:3000", "aws_access_key_id": "console", "aws_secret_access_key": "console123"}'
 
+moto_server -p3000 &
+moto_pid=$!
+uvicorn --factory diracx.routers:create_app --reload &
+diracx_pid=$!
 
-uvicorn --factory diracx.routers:create_app --reload
+success=0
+for i in {1..10}; do
+  if curl --silent --head http://localhost:8000 > /dev/null; then
+    success=1
+    break
+  fi
+  sleep 1
+done
+
+echo ""
+echo ""
+echo ""
+if [ $success -eq 0 ]; then
+  echo "Failed to start DiracX"
+else
+  echo "DiracX is running on http://localhost:8000"
+fi
+echo "To interact with DiracX you can:"
+echo ""
+echo "1. Use the CLI:"
+echo ""
+echo "    export DIRACX_URL=http://localhost:8000"
+echo "    tests/make-token-local.py ${signing_key}"
+echo ""
+echo "2. Using swagger: http://localhost:8000/api/docs"
 
 function cleanup(){
-  trap - SIGTERM;
-  echo "Cleaning up";
+  trap - SIGTERM
+  kill $moto_pid
+  kill $diracx_pid
+  echo "Waiting for proccesses to exit"
+  wait $moto_pid $diracx_pid
+  echo "Cleaning up"
   rm -rf "${tmp_dir}"
 }
 
 trap "cleanup" EXIT
+
+while true; do
+  sleep 1
+done

--- a/tests/make-token-local.py
+++ b/tests/make-token-local.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+import argparse
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from diracx.core.models import TokenResponse
+from diracx.core.properties import NORMAL_USER
+from diracx.core.utils import write_credentials
+from diracx.routers.auth import AuthSettings, create_token
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("token_key", type=Path, help="The key to sign the token with")
+    args = parser.parse_args()
+    main(args.token_key.read_text())
+
+
+def main(token_key):
+    vo = "diracAdmin"
+    dirac_group = "admin"
+    sub = "75212b23-14c2-47be-9374-eb0113b0575e"
+    preferred_username = "localuser"
+    dirac_properties = [NORMAL_USER]
+    settings = AuthSettings(token_key=token_key)
+    creation_time = datetime.now(tz=timezone.utc)
+    expires_in = 7 * 24 * 60 * 60
+
+    access_payload = {
+        "sub": f"{vo}:{sub}",
+        "vo": vo,
+        "aud": settings.token_audience,
+        "iss": settings.token_issuer,
+        "dirac_properties": dirac_properties,
+        "jti": str(uuid.uuid4()),
+        "preferred_username": preferred_username,
+        "dirac_group": dirac_group,
+        "exp": creation_time + timedelta(seconds=expires_in),
+    }
+    token = TokenResponse(
+        access_token=create_token(access_payload, settings),
+        expires_in=expires_in,
+        refresh_token=None,
+    )
+    write_credentials(token)
+
+
+if __name__ == "__main__":
+    parse_args()


### PR DESCRIPTION
This makes it so that when you execute `./run_local.sh` you get:

```
DiracX is running on http://localhost:8000
To interact with DiracX you can:

1. Use the CLI:

    export DIRACX_URL=http://localhost:8000
    tests/make-token-local.py /var/folders/1g/q2y74s696ng0v_cmb9sv7qgr0000gn/T/tmp.CJ4d9L9H/signing-key/rsa256.key

2. Using swagger: http://localhost:8000/api/docs
```

Using `tests/make-token-local.py` gives you a token which is valid for a week.