### PR TITLE
Add a default 30mn timeout for the container build

### DIFF
--- a/.github/workflows/containerised.yml
+++ b/.github/workflows/containerised.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   docker:
+    timeout-minutes:  30
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
It should get better when we have a base image cached, but it anyway doesn't hurt