### PR TITLE
feat: internals `add_vo()` and `add_group()`

### DIFF
--- a/diracx-cli/src/diracx/cli/internal/__init__.py
+++ b/diracx-cli/src/diracx/cli/internal/__init__.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Annotated, Optional
 
 import git
 import typer
@@ -26,11 +27,6 @@ app.add_typer(legacy.app, name="legacy")
 @app.command()
 def generate_cs(
     config_repo: str,
-    *,
-    vo: str = "testvo",
-    user_group: str = "user",
-    idp_url: str = "https://idp.invalid",
-    idp_client_id: str = "idp-client-id",
 ):
     """Generate a minimal DiracX configuration repository"""
     # TODO: The use of parse_obj_as should be moved in to typer itself
@@ -42,37 +38,103 @@ def generate_cs(
         typer.echo(f"ERROR: Directory {repo_path} already exists", err=True)
         raise typer.Exit(1)
 
-    registry = RegistryConfig(
-        IdP=IdpConfig(URL=idp_url, ClientID=idp_client_id),
-        DefaultGroup=user_group,
-        Users={},
-        Groups={
-            user_group: GroupConfig(Properties={"NormalUser"}, Quota=None, Users=set())
-        },
-    )
     config = Config(
-        Registry={vo: registry},
+        Registry={},
         DIRAC=DIRACConfig(),
         Operations={"Defaults": OperationsConfig()},
     )
 
-    repo = git.Repo.init(repo_path, initial_branch="master")
-    yaml_path = repo_path / "default.yml"
-    typer.echo(f"Writing configuration to {yaml_path}", err=True)
-    yaml_path.write_text(yaml.safe_dump(config.dict(exclude_unset=True)))
-    repo.index.add([yaml_path.relative_to(repo_path)])
-    repo.index.commit("Initial commit")
+    update_config_and_commit(
+        repo_path=repo_path, config=config, message="Initial commit"
+    )
     typer.echo(f"Successfully created repo in {config_repo}", err=True)
+
+
+@app.command()
+def add_vo(
+    config_repo: str,
+    *,
+    vo: Annotated[str, typer.Option()],
+    default_group: Optional[str] = "user",
+    idp_url: Annotated[str, typer.Option()],
+    idp_client_id: Annotated[str, typer.Option()],
+):
+    """Add a registry entry (vo) to an existing configuration repository"""
+
+    # TODO: The use of parse_obj_as should be moved in to typer itself
+    config_repo = parse_obj_as(ConfigSourceUrl, config_repo)
+    repo_path = Path(config_repo.path)
+
+    # A VO should at least contain a default group
+    new_registry = RegistryConfig(
+        IdP=IdpConfig(URL=idp_url, ClientID=idp_client_id),
+        DefaultGroup=default_group,
+        Users={},
+        Groups={
+            default_group: GroupConfig(
+                Properties={"NormalUser"}, Quota=None, Users=set()
+            )
+        },
+    )
+
+    config = ConfigSource.create_from_url(backend_url=repo_path).read_config()
+
+    if vo in config.Registry:
+        typer.echo(f"ERROR: VO {vo} already exists", err=True)
+        raise typer.Exit(1)
+
+    config.Registry[vo] = new_registry
+
+    update_config_and_commit(
+        repo_path=repo_path,
+        config=config,
+        message=f"Added vo {vo} registry (default group {default_group} and idp {idp_url})",
+    )
+    typer.echo(f"Successfully added vo to {config_repo}", err=True)
+
+
+@app.command()
+def add_group(
+    config_repo: str,
+    *,
+    vo: Annotated[str, typer.Option()],
+    group: Annotated[str, typer.Option()],
+    properties: list[str] = ["NormalUser"],
+):
+    """Add a group to an existing vo in the configuration repository"""
+
+    # TODO: The use of parse_obj_as should be moved in to typer itself
+    config_repo = parse_obj_as(ConfigSourceUrl, config_repo)
+    repo_path = Path(config_repo.path)
+
+    new_group = GroupConfig(Properties=set(properties), Quota=None, Users=set())
+
+    config = ConfigSource.create_from_url(backend_url=repo_path).read_config()
+
+    if vo not in config.Registry:
+        typer.echo(f"ERROR: Virtual Organization {vo} does not exist", err=True)
+        raise typer.Exit(1)
+
+    if group in config.Registry[vo].Groups.keys():
+        typer.echo(f"ERROR: Group {group} already exists in {vo}", err=True)
+        raise typer.Exit(1)
+
+    config.Registry[vo].Groups[group] = new_group
+
+    update_config_and_commit(
+        repo_path=repo_path, config=config, message=f"Added group {group} in {vo}"
+    )
+    typer.echo(f"Successfully added group to {config_repo}", err=True)
 
 
 @app.command()
 def add_user(
     config_repo: str,
     *,
-    vo: str = "testvo",
-    user_group: str = "user",
-    sub: str = "usersub",
-    preferred_username: str = "preferred_username",
+    vo: Annotated[str, typer.Option()],
+    groups: Annotated[Optional[list[str]], typer.Option("--group")] = None,
+    sub: Annotated[str, typer.Option()],
+    preferred_username: Annotated[str, typer.Option()],
 ):
     """Add a user to an existing vo and group"""
 
@@ -85,20 +147,42 @@ def add_user(
 
     config = ConfigSource.create_from_url(backend_url=repo_path).read_config()
 
+    if vo not in config.Registry:
+        typer.echo(f"ERROR: Virtual Organization {vo} does not exist", err=True)
+        raise typer.Exit(1)
+
     if sub in config.Registry[vo].Users:
         typer.echo(f"ERROR: User {sub} already exists", err=True)
         raise typer.Exit(1)
 
     config.Registry[vo].Users[sub] = new_user
 
-    config.Registry[vo].Groups[user_group].Users.add(sub)
+    if not groups:
+        groups = [config.Registry[vo].DefaultGroup]
 
+    for group in set(groups):
+        if group not in config.Registry[vo].Groups:
+            typer.echo(f"ERROR: Group {group} does not exist in {vo}", err=True)
+            raise typer.Exit(1)
+        if sub in config.Registry[vo].Groups[group].Users:
+            typer.echo(f"ERROR: User {sub} already exists in group {group}", err=True)
+            raise typer.Exit(1)
+
+        config.Registry[vo].Groups[group].Users.add(sub)
+
+    update_config_and_commit(
+        repo_path=repo_path,
+        config=config,
+        message=f"Added user {sub} ({preferred_username}) to vo {vo} and groups {groups}",
+    )
+    typer.echo(f"Successfully added user to {config_repo}", err=True)
+
+
+def update_config_and_commit(repo_path: Path, config: Config, message: str):
+    """Update the yaml file in the repo and commit it"""
     repo = git.Repo.init(repo_path)
     yaml_path = repo_path / "default.yml"
     typer.echo(f"Writing back configuration to {yaml_path}", err=True)
     yaml_path.write_text(yaml.safe_dump(config.dict(exclude_unset=True)))
     repo.index.add([yaml_path.relative_to(repo_path)])
-    repo.index.commit(
-        f"Added user {sub} ({preferred_username}) to vo {vo} and user_group {user_group}"
-    )
-    typer.echo(f"Successfully added user to {config_repo}", err=True)
+    repo.index.commit(message)

--- a/diracx-cli/tests/test_internal.py
+++ b/diracx-cli/tests/test_internal.py
@@ -25,8 +25,147 @@ def test_generate_cs(tmp_path, protocol):
     assert result.exit_code != 0
 
 
+def test_add_vo(tmp_path):
+    cs_repo = f"git+file://{tmp_path}"
+
+    # Create the CS
+    runner.invoke(app, ["internal", "generate-cs", cs_repo])
+
+    # Add a VO to it
+    vo1 = "testvo"
+    result = runner.invoke(
+        app,
+        [
+            "internal",
+            "add-vo",
+            cs_repo,
+            f"--vo={vo1}",
+            "--idp-url=https://idp.invalid",
+            "--idp-client-id=idp-client-id",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    config = ConfigSource.create_from_url(backend_url=cs_repo).read_config()
+
+    assert vo1 in config.Registry
+    assert config.Registry[vo1].DefaultGroup == "user"
+    assert config.Registry[vo1].IdP.URL == "https://idp.invalid"
+    assert config.Registry[vo1].IdP.ClientID == "idp-client-id"
+
+    # Add a second VO to it
+    vo2 = "lhcb"
+    result = runner.invoke(
+        app,
+        [
+            "internal",
+            "add-vo",
+            cs_repo,
+            f"--vo={vo2}",
+            "--idp-url=https://idp.example.invalid",
+            "--idp-client-id=idp-client-id2",
+            "--default-group",
+            "admin",
+        ],
+    )
+
+    config = ConfigSource.create_from_url(backend_url=cs_repo).read_config()
+    assert result.exit_code == 0, result.output
+
+    assert vo2 in config.Registry
+    assert config.Registry[vo2].DefaultGroup == "admin"
+    assert config.Registry[vo2].IdP.URL == "https://idp.example.invalid"
+    assert config.Registry[vo2].IdP.ClientID == "idp-client-id2"
+
+    # Try to insert a VO that already exists
+    result = runner.invoke(
+        app,
+        [
+            "internal",
+            "add-vo",
+            cs_repo,
+            f"--vo={vo1}",
+            "--idp-url=https://idp.invalid",
+            "--idp-client-id=idp-client-id",
+        ],
+    )
+    assert result.exit_code != 0, result.output
+
+
+def test_add_group(tmp_path):
+    cs_repo = f"git+file://{tmp_path}"
+    vo = "testvo"
+    group1 = "testgroup1"
+    group2 = "testgroup2"
+
+    # Create the CS
+    runner.invoke(app, ["internal", "generate-cs", cs_repo])
+    runner.invoke(
+        app,
+        [
+            "internal",
+            "add-vo",
+            cs_repo,
+            f"--vo={vo}",
+            "--idp-url=https://idp.invalid",
+            "--idp-client-id=idp-client-id",
+        ],
+    )
+
+    # Add a group to it
+    result = runner.invoke(
+        app, ["internal", "add-group", cs_repo, f"--vo={vo}", f"--group={group1}"]
+    )
+    assert result.exit_code == 0, result.output
+
+    config = ConfigSource.create_from_url(backend_url=cs_repo).read_config()
+
+    assert group1 in config.Registry[vo].Groups
+    assert config.Registry[vo].Groups[group1].JobShare == 1000
+    assert config.Registry[vo].Groups[group1].Properties == {"NormalUser"}
+    assert config.Registry[vo].Groups[group1].Users == set()
+
+    # Add a second group to it
+    result = runner.invoke(
+        app,
+        [
+            "internal",
+            "add-group",
+            cs_repo,
+            f"--vo={vo}",
+            f"--group={group2}",
+            "--properties",
+            "NormalUser",
+            "--properties",
+            "AdminUser",
+        ],
+    )
+    config = ConfigSource.create_from_url(backend_url=cs_repo).read_config()
+    assert result.exit_code == 0, result.output
+
+    assert group2 in config.Registry[vo].Groups
+    assert config.Registry[vo].Groups[group2].JobShare == 1000
+    assert config.Registry[vo].Groups[group2].Properties == {"AdminUser", "NormalUser"}
+    assert config.Registry[vo].Groups[group2].Users == set()
+
+    # Try to insert a group that already exists
+    result = runner.invoke(
+        app, ["internal", "add-group", cs_repo, f"--vo={vo}", f"--group={group1}"]
+    )
+    assert result.exit_code != 0, result.output
+
+    # Try to insert a group with a non-existing VO
+    result = runner.invoke(
+        app,
+        ["internal", "add-group", cs_repo, "--vo=nonexistingvo", f"--group={group1}"],
+    )
+    assert result.exit_code != 0, result.output
+
+
 @pytest.mark.parametrize("vo", ["nonexistingvo", "testvo"])
-@pytest.mark.parametrize("user_group", ["nonexisting_group", "user"])
+@pytest.mark.parametrize(
+    "user_group", [["nonexisting_group"], ["user"], ["user", "admin"], []]
+)
 def test_add_user(tmp_path, vo, user_group):
     cs_repo = f"git+file://{tmp_path}"
 
@@ -35,6 +174,23 @@ def test_add_user(tmp_path, vo, user_group):
 
     # Create the CS
     runner.invoke(app, ["internal", "generate-cs", cs_repo])
+    runner.invoke(
+        app,
+        [
+            "internal",
+            "add-vo",
+            cs_repo,
+            "--vo=testvo",
+            "--idp-url=https://idp.invalid",
+            "--idp-client-id=idp-client-id",
+        ],
+    )
+    runner.invoke(
+        app, ["internal", "add-group", cs_repo, "--vo=testvo", "--group=user"]
+    )
+    runner.invoke(
+        app, ["internal", "add-group", cs_repo, "--vo=testvo", "--group=admin"]
+    )
 
     config = ConfigSource.create_from_url(backend_url=cs_repo).read_config()
 
@@ -49,18 +205,14 @@ def test_add_user(tmp_path, vo, user_group):
             "internal",
             "add-user",
             cs_repo,
-            "--vo",
-            vo,
-            "--user-group",
-            user_group,
-            "--sub",
-            sub,
-            "--preferred-username",
-            preferred_username,
-        ],
+            f"--vo={vo}",
+            f"--sub={sub}",
+            f"--preferred-username={preferred_username}",
+        ]
+        + [f"--group={x}" for x in user_group],
     )
 
-    if "nonexisting" in vo or "nonexisting" in user_group:
+    if "nonexistingvo" in vo or "nonexisting_group" in user_group:
         assert result.exit_code != 0
         return
 
@@ -70,3 +222,5 @@ def test_add_user(tmp_path, vo, user_group):
     # check the user is defined
     assert vo in config.Registry
     assert sub in config.Registry[vo].Users
+    for group in user_group or ["user"]:
+        assert config.Registry[vo].Groups[group].Users == {sub}

--- a/run_local.sh
+++ b/run_local.sh
@@ -11,8 +11,18 @@ signing_key="${tmp_dir}/signing-key/rsa256.key"
 ssh-keygen -P "" -t rsa -b 4096 -m PEM -f "${signing_key}"
 
 # Make a fake CS
-dirac internal generate-cs "${tmp_dir}/cs_store/initialRepo" \
-  --vo=diracAdmin --user-group=admin --idp-url=runlocal.diracx.invalid
+dirac internal generate-cs "${tmp_dir}/cs_store/initialRepo"
+
+dirac internal add-vo "${tmp_dir}/cs_store/initialRepo" \
+    --vo=diracAdmin \
+    --idp-url=runlocal.diracx.invalid \
+    --idp-client-id="idp-client-id" \
+    --default-group=admin
+
+dirac internal add-group "${tmp_dir}/cs_store/initialRepo" \
+    --vo=diracAdmin \
+    --group=admin
+
 dirac internal add-user "${tmp_dir}/cs_store/initialRepo" \
   --vo=diracAdmin --user-group=admin \
   --sub=75212b23-14c2-47be-9374-eb0113b0575e \


### PR DESCRIPTION
Would this make sense?

It would allow setting up multiple VOs and groups when launching `diracx` with `run_demo` (of course we would need another PR in `diracx-charts`).
- The alternative is to manually change the config (`default.yml`) and commit it from a running pod (which is probably fine too).
