### PR TITLE
Set minimal version of aiobotocore to speedup pip resolution

### DIFF
--- a/diracx-core/pyproject.toml
+++ b/diracx-core/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Topic :: System :: Distributed Computing",
 ]
 dependencies = [
-    "aiobotocore",
+    "aiobotocore>=2.12",
     "authlib",
     "botocore",
     "cachetools",

--- a/diracx-routers/pyproject.toml
+++ b/diracx-routers/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Topic :: System :: Distributed Computing",
 ]
 dependencies = [
-    "aiobotocore",
+    "aiobotocore>=2.12",
     "authlib",
     "botocore",
     "cachetools",


### PR DESCRIPTION
DIRAC integration tests are timing out because each `pip install` takes 10 mn because of that