### PR TITLE
fix(client): better error when refresh token is expired

### DIFF
--- a/diracx-cli/src/diracx/cli/utils.py
+++ b/diracx-cli/src/diracx/cli/utils.py
@@ -6,6 +6,8 @@ from asyncio import run
 from functools import wraps
 
 import typer
+from azure.core.exceptions import ClientAuthenticationError
+from rich import print
 
 
 class AsyncTyper(typer.Typer):
@@ -13,7 +15,13 @@ class AsyncTyper(typer.Typer):
         def decorator(async_func):
             @wraps(async_func)
             def sync_func(*_args, **_kwargs):
-                return run(async_func(*_args, **_kwargs))
+                try:
+                    return run(async_func(*_args, **_kwargs))
+                except ClientAuthenticationError:
+                    print(
+                        ":x: [bold red]You are not authenticated. Log in with:[/bold red] "
+                        "[bold] dirac login [OPTIONS] [VO] [/bold]"
+                    )
 
             self.command(*args, **kwargs)(sync_func)
             return async_func

--- a/diracx-routers/src/diracx/routers/auth/management.py
+++ b/diracx-routers/src/diracx/routers/auth/management.py
@@ -67,7 +67,7 @@ async def revoke_refresh_token(
 
     if PROXY_MANAGEMENT not in user_info.properties and user_info.sub != res["sub"]:
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,
             detail="Cannot revoke a refresh token owned by someone else",
         )
     await auth_db.revoke_refresh_token(jti)

--- a/diracx-routers/src/diracx/routers/auth/token.py
+++ b/diracx-routers/src/diracx/routers/auth/token.py
@@ -125,7 +125,7 @@ async def get_oidc_token_info_from_device_flow(
         ) from e
     except ExpiredFlowError as e:
         raise DiracHttpResponse(
-            status.HTTP_400_BAD_REQUEST, {"error": "expired_token"}
+            status.HTTP_401_UNAUTHORIZED, {"error": "expired_token"}
         ) from e
     # raise DiracHttpResponse(status.HTTP_400_BAD_REQUEST, {"error": "slow_down"})
     # raise DiracHttpResponse(status.HTTP_400_BAD_REQUEST, {"error": "expired_token"})
@@ -233,7 +233,7 @@ async def get_oidc_token_info_from_refresh_flow(
             await auth_db.conn.commit()
 
             raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
+                status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Revoked refresh token reused: potential attack detected. You must authenticate again",
             )
 
@@ -307,8 +307,9 @@ async def legacy_exchange(
 
     if hashlib.sha256(raw_token).hexdigest() != expected_api_key:
         raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
+            status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid credentials",
+            headers={"WWW-Authenticate": "Bearer"},
         )
 
     try:

--- a/diracx-routers/tests/auth/test_legacy_exchange.py
+++ b/diracx-routers/tests/auth/test_legacy_exchange.py
@@ -151,7 +151,7 @@ async def test_wrong_credentials(test_client, legacy_credentials):
         params={"preferred_username": "chaen", "scope": "vo:lhcb group:lhcb_user"},
         headers={"Authorization": "Bearer diracx:legacy:ChangeME"},
     )
-    assert r.status_code == 403
+    assert r.status_code == 401
     assert r.json()["detail"] == "Invalid credentials"
 
 

--- a/diracx-routers/tests/auth/test_standard.py
+++ b/diracx-routers/tests/auth/test_standard.py
@@ -453,7 +453,7 @@ async def test_refresh_token_rotation(test_client, auth_httpx_mock: HTTPXMock):
     # The server should detect the breach and revoke every token bound to User
     r = test_client.post("/api/auth/token", data=request_data)
     data = r.json()
-    assert r.status_code == 400, data
+    assert r.status_code == 401, data
     assert (
         data["detail"]
         == "Revoked refresh token reused: potential attack detected. You must authenticate again"
@@ -465,7 +465,7 @@ async def test_refresh_token_rotation(test_client, auth_httpx_mock: HTTPXMock):
     request_data["refresh_token"] = new_refresh_token
     r = test_client.post("/api/auth/token", data=request_data)
     data = r.json()
-    assert r.status_code == 400, data
+    assert r.status_code == 401, data
     assert (
         data["detail"]
         == "Revoked refresh token reused: potential attack detected. You must authenticate again"
@@ -666,7 +666,7 @@ async def test_revoke_refresh_tokens_normal_user(
         headers={"Authorization": f"Bearer {normal_user_access_token}"},
     )
     data = r.json()
-    assert r.status_code == 401, data
+    assert r.status_code == 403, data
 
     # Normal user tries to delete his/her RT: should work
     r = test_client.delete(

--- a/diracx-routers/tests/test_config_manager.py
+++ b/diracx-routers/tests/test_config_manager.py
@@ -13,7 +13,7 @@ def normal_user_client(client_factory):
 def test_unauthenticated(client_factory):
     with client_factory.unauthenticated() as client:
         response = client.get("/api/config/")
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
 def test_get_config(normal_user_client):


### PR DESCRIPTION
Aims at fixing the following error:

```bash
$ dirac login diracAdmin
# do some stuff, then stop using it for a few days, the refresh token expired
$ dirac jobs submit job.jdl
RuntimeError: An issue occured while refreshing your access token: Invalid JWT: bad_signature:
$ dirac login diracAdmin
RuntimeError: An issue occured while refreshing your access token: Invalid JWT: bad_signature:
$ dirac logout
$ dirac login diracAdmin
# Login successful!
```

In this PR, we check the validity of the refresh token before refreshing the access token. We should have:

```bash
$ dirac login diracAdmin
# do some stuff, then stop using it for a few days, the refresh token expired
$ dirac jobs submit job.jdl
HttpResponseError: Operation returned an invalid status 'Forbidden'
Content: {"detail":"Not authenticated"}
$ dirac login diracAdmin
# Login successful!
```