### PR TITLE
use urljoin instead of string manipulation

### DIFF
--- a/diracx-client/src/diracx/client/_patch.py
+++ b/diracx-client/src/diracx/client/_patch.py
@@ -15,6 +15,7 @@ import requests
 
 from pathlib import Path
 from typing import Any, Dict, List, Optional, cast
+from urllib import parse
 from azure.core.credentials import AccessToken
 from azure.core.credentials import TokenCredential
 from azure.core.pipeline import PipelineRequest
@@ -215,7 +216,7 @@ def get_openid_configuration(
 ) -> Dict[str, str]:
     """Get the openid configuration from the .well-known endpoint"""
     response = requests.get(
-        url=f"{endpoint}/.well-known/openid-configuration",
+        url=parse.urljoin(endpoint, ".well-known/openid-configuration"),
         verify=verify,
     )
     if not response.ok:


### PR DESCRIPTION
Without this, if defining the server URL like `export DIRACX_URL=https://diracx-cert.app.cern.ch/` (note the trailing `/`), we get an exception when doing `dirac login`