### PR TITLE
feat: enable remote pilot logging system [MISSING AUTH]

### DIFF
--- a/diracx-core/src/diracx/core/exceptions.py
+++ b/diracx-core/src/diracx/core/exceptions.py
@@ -64,14 +64,6 @@ class JobNotFoundError(Exception):
         super().__init__(f"Job {job_id} not found" + (" ({detail})" if detail else ""))
 
 
-class PilotNotFoundError(Exception):
-    def __init__(self, pilot_stamp: str, detail: str | None = None):
-        self.pilot_stamp: str = pilot_stamp
-        super().__init__(
-            f"Pilot (stamp) {pilot_stamp} not found" + (" ({detail})" if detail else "")
-        )
-
-
 class SandboxNotFoundError(Exception):
     def __init__(self, pfn: str, se_name: str, detail: str | None = None):
         self.pfn: str = pfn

--- a/diracx-core/src/diracx/core/exceptions.py
+++ b/diracx-core/src/diracx/core/exceptions.py
@@ -64,6 +64,14 @@ class JobNotFoundError(Exception):
         super().__init__(f"Job {job_id} not found" + (" ({detail})" if detail else ""))
 
 
+class PilotNotFoundError(Exception):
+    def __init__(self, pilot_stamp: str, detail: str | None = None):
+        self.pilot_stamp: str = pilot_stamp
+        super().__init__(
+            f"Pilot (stamp) {pilot_stamp} not found" + (" ({detail})" if detail else "")
+        )
+
+
 class SandboxNotFoundError(Exception):
     def __init__(self, pfn: str, se_name: str, detail: str | None = None):
         self.pfn: str = pfn

--- a/diracx-core/src/diracx/core/models.py
+++ b/diracx-core/src/diracx/core/models.py
@@ -253,3 +253,14 @@ class VOInfo(TypedDict):
 
 class Metadata(TypedDict):
     virtual_organizations: dict[str, VOInfo]
+
+
+class LogLine(BaseModel):
+    line_no: int
+    line: str
+
+
+class LogMessage(BaseModel):
+    pilot_stamp: str
+    lines: list[LogLine]
+    vo: str

--- a/diracx-db/pyproject.toml
+++ b/diracx-db/pyproject.toml
@@ -35,6 +35,7 @@ TaskQueueDB = "diracx.db.sql:TaskQueueDB"
 
 [project.entry-points."diracx.dbs.os"]
 JobParametersDB = "diracx.db.os:JobParametersDB"
+PilotLogsDB = "diracx.db.os:PilotLogsDB"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/diracx-db/src/diracx/db/os/__init__.py
+++ b/diracx-db/src/diracx/db/os/__init__.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
-__all__ = ("JobParametersDB",)
+__all__ = (
+    "JobParametersDB",
+    "PilotLogsDB",
+)
 
 from .job_parameters import JobParametersDB
+from .pilot_logs import PilotLogsDB

--- a/diracx-db/src/diracx/db/os/pilot_logs.py
+++ b/diracx-db/src/diracx/db/os/pilot_logs.py
@@ -19,3 +19,17 @@ class PilotLogsDB(BaseOSDB):
         # TODO decide how to define the index name
         # use pilot ID
         return f"{self.index_prefix}_{doc_id // 1e6:.0f}"
+
+
+async def search_message(db: PilotLogsDB, search_params: list[dict]):
+
+    return await db.search(
+        ["Message"],
+        search_params,
+        [{"parameter": "LineNumber", "direction": "asc"}],
+    )
+
+
+async def bulk_insert(db: PilotLogsDB, docs: list[dict], pilot_id: int):
+
+    await db.bulk_insert(db.index_name(pilot_id), docs)

--- a/diracx-db/src/diracx/db/os/pilot_logs.py
+++ b/diracx-db/src/diracx/db/os/pilot_logs.py
@@ -28,8 +28,3 @@ async def search_message(db: PilotLogsDB, search_params: list[dict]):
         search_params,
         [{"parameter": "LineNumber", "direction": "asc"}],
     )
-
-
-async def bulk_insert(db: PilotLogsDB, docs: list[dict], pilot_id: int):
-
-    await db.bulk_insert(db.index_name(pilot_id), docs)

--- a/diracx-db/src/diracx/db/os/pilot_logs.py
+++ b/diracx-db/src/diracx/db/os/pilot_logs.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from diracx.db.os.utils import BaseOSDB
+
+
+class PilotLogsDB(BaseOSDB):
+    fields = {
+        "PilotStamp": {"type": "keyword"},
+        "PilotID": {"type": "long"},
+        "SubmissionTime": {"type": "date"},
+        "LineNumber": {"type": "long"},
+        "Message": {"type": "text"},
+        "VO": {"type": "keyword"},
+        "timestamp": {"type": "date"},
+    }
+    index_prefix = "pilot_logs"
+
+    def index_name(self, doc_id: int) -> str:
+        # TODO decide how to define the index name
+        # use pilot ID
+        return f"{self.index_prefix}_{doc_id // 1e6:.0f}"

--- a/diracx-db/src/diracx/db/sql/job/db.py
+++ b/diracx-db/src/diracx/db/sql/job/db.py
@@ -34,7 +34,7 @@ class JobDB(BaseSQLDB):
 
     async def summary(self, group_by, search) -> list[dict[str, str | int]]:
         """Get a summary of the jobs."""
-        columns = _get_columns(Jobs.__table__, group_by)
+        columns = get_columns(Jobs.__table__, group_by)
 
         stmt = select(*columns, func.count(Jobs.job_id).label("count"))
         stmt = apply_search_filters(Jobs.__table__.columns.__getitem__, stmt, search)

--- a/diracx-db/src/diracx/db/sql/utils/__init__.py
+++ b/diracx-db/src/diracx/db/sql/utils/__init__.py
@@ -5,6 +5,7 @@ from .base import (
     SQLDBUnavailableError,
     apply_search_filters,
     apply_sort_constraints,
+    get_columns,
 )
 from .functions import hash, substract_date, utcnow
 from .types import Column, DateNowColumn, EnumBackedBool, EnumColumn, NullColumn
@@ -19,6 +20,7 @@ __all__ = (
     "EnumColumn",
     "apply_search_filters",
     "apply_sort_constraints",
+    "get_columns",
     "substract_date",
     "hash",
     "SQLDBUnavailableError",

--- a/diracx-db/src/diracx/db/sql/utils/base.py
+++ b/diracx-db/src/diracx/db/sql/utils/base.py
@@ -258,6 +258,17 @@ def find_time_resolution(value):
     raise InvalidQueryError(f"Cannot parse {value=}")
 
 
+def get_columns(table, parameters):
+    columns = [x for x in table.columns]
+    if parameters:
+        if unrecognised_parameters := set(parameters) - set(table.columns.keys()):
+            raise InvalidQueryError(
+                f"Unrecognised parameters requested {unrecognised_parameters}"
+            )
+        columns = [c for c in columns if c.name in parameters]
+    return columns
+
+
 def apply_search_filters(column_mapping, stmt, search):
     for query in search:
         try:

--- a/diracx-logic/src/diracx/logic/jobs/status.py
+++ b/diracx-logic/src/diracx/logic/jobs/status.py
@@ -29,7 +29,7 @@ from diracx.core.models import (
     VectorSearchSpec,
 )
 from diracx.db.os.job_parameters import JobParametersDB
-from diracx.db.sql.job.db import JobDB, _get_columns
+from diracx.db.sql.job.db import JobDB, get_columns
 from diracx.db.sql.job.schema import Jobs
 from diracx.db.sql.job_logging.db import JobLoggingDB
 from diracx.db.sql.sandbox_metadata.db import SandboxMetadataDB
@@ -485,7 +485,7 @@ async def set_job_parameters_or_attributes(
 ):
     """Set job parameters or attributes for a list of jobs."""
     attribute_columns: list[str] = [
-        col.name for col in _get_columns(Jobs.__table__, None)
+        col.name for col in get_columns(Jobs.__table__, None)
     ]
     attribute_columns_lower: list[str] = [col.lower() for col in attribute_columns]
 

--- a/diracx-logic/src/diracx/logic/pilots/logging.py
+++ b/diracx-logic/src/diracx/logic/pilots/logging.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 
 from diracx.core.models import LogMessage, ScalarSearchOperator, ScalarSearchSpec
-from diracx.db.os.pilot_logs import PilotLogsDB, bulk_insert, search_message
+from diracx.db.os.pilot_logs import PilotLogsDB, search_message
 from diracx.db.sql.pilot_agents.db import PilotAgentsDB
 
 logger = logging.getLogger(__name__)
@@ -51,7 +51,8 @@ async def send_message(
             }
         )
     # bulk insert pilot logs to OpenSearch DB:
-    await bulk_insert(pilot_logs_db, docs, pilot_id)
+    await pilot_logs_db.bulk_insert(pilot_logs_db.index_name(pilot_id), docs)
+    # await bulk_insert(pilot_logs_db, docs, pilot_id)
     return pilot_id
 
 

--- a/diracx-logic/src/diracx/logic/pilots/logging.py
+++ b/diracx-logic/src/diracx/logic/pilots/logging.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import logging
+
+from diracx.core.models import LogMessage, ScalarSearchOperator, ScalarSearchSpec
+from diracx.db.os.pilot_logs import PilotLogsDB, bulk_insert, search_message
+from diracx.db.sql.pilot_agents.db import PilotAgentsDB
+
+logger = logging.getLogger(__name__)
+
+
+async def send_message(
+    data: LogMessage,
+    pilot_logs_db: PilotLogsDB,
+    pilot_agents_db: PilotAgentsDB,
+) -> int:
+
+    # get the pilot ID corresponding to a given pilot stamp, expecting exactly one row:
+    search_params = ScalarSearchSpec(
+        parameter="PilotStamp",
+        operator=ScalarSearchOperator.EQUAL,
+        value=data.pilot_stamp,
+    )
+
+    total, result = await pilot_agents_db.search(
+        ["PilotID", "VO", "SubmissionTime"], [search_params], []
+    )
+    if total != 1:
+        logger.error(
+            "Cannot determine PilotID for requested PilotStamp: %r, (%d candidates)",
+            data.pilot_stamp,
+            total,
+        )
+        raise Exception(f"Number of rows !=1 {total}")
+
+    pilot_id, vo, submission_time = (
+        result[0]["PilotID"],
+        result[0]["VO"],
+        result[0]["SubmissionTime"],
+    )
+    docs = []
+    for line in data.lines:
+        docs.append(
+            {
+                "PilotStamp": data.pilot_stamp,
+                "PilotID": pilot_id,
+                "SubmissionTime": submission_time,
+                "VO": vo,
+                "LineNumber": line.line_no,
+                "Message": line.line,
+            }
+        )
+    # bulk insert pilot logs to OpenSearch DB:
+    await bulk_insert(pilot_logs_db, docs, pilot_id)
+    return pilot_id
+
+
+async def get_logs(
+    pilot_id: int,
+    db: PilotLogsDB,
+) -> list[dict]:
+
+    search_params = [{"parameter": "PilotID", "operator": "eq", "value": pilot_id}]
+
+    result = await search_message(db, search_params)
+
+    if not result:
+        return [{"Message": f"No logs for pilot ID = {pilot_id}"}]
+    return result

--- a/diracx-logic/src/diracx/logic/pilots/logging.py
+++ b/diracx-logic/src/diracx/logic/pilots/logging.py
@@ -52,7 +52,6 @@ async def send_message(
         )
     # bulk insert pilot logs to OpenSearch DB:
     await pilot_logs_db.bulk_insert(pilot_logs_db.index_name(pilot_id), docs)
-    # await bulk_insert(pilot_logs_db, docs, pilot_id)
     return pilot_id
 
 

--- a/diracx-routers/pyproject.toml
+++ b/diracx-routers/pyproject.toml
@@ -41,6 +41,7 @@ types = [
 ]
 
 [project.entry-points."diracx.services"]
+pilots = "diracx.routers.pilots:router"
 jobs = "diracx.routers.jobs:router"
 config = "diracx.routers.configuration:router"
 auth = "diracx.routers.auth:router"
@@ -49,6 +50,7 @@ auth = "diracx.routers.auth:router"
 [project.entry-points."diracx.access_policies"]
 WMSAccessPolicy = "diracx.routers.jobs.access_policies:WMSAccessPolicy"
 SandboxAccessPolicy = "diracx.routers.jobs.access_policies:SandboxAccessPolicy"
+PilotLogsAccessPolicy = "diracx.routers.pilots.access_policies:PilotLogsAccessPolicy"
 
 # Minimum version of the client supported
 [project.entry-points."diracx.min_client_version"]

--- a/diracx-routers/src/diracx/routers/dependencies.py
+++ b/diracx-routers/src/diracx/routers/dependencies.py
@@ -8,6 +8,7 @@ __all__ = (
     "SandboxMetadataDB",
     "TaskQueueDB",
     "PilotAgentsDB",
+    "PilotLogsDB",
     "add_settings_annotation",
     "AvailableSecurityProperties",
 )
@@ -23,6 +24,7 @@ from diracx.core.settings import AuthSettings as _AuthSettings
 from diracx.core.settings import DevelopmentSettings as _DevelopmentSettings
 from diracx.core.settings import SandboxStoreSettings as _SandboxStoreSettings
 from diracx.db.os import JobParametersDB as _JobParametersDB
+from diracx.db.os import PilotLogsDB as _PilotLogsDB
 from diracx.db.sql import AuthDB as _AuthDB
 from diracx.db.sql import JobDB as _JobDB
 from diracx.db.sql import JobLoggingDB as _JobLoggingDB
@@ -38,7 +40,7 @@ def add_settings_annotation(cls: T) -> T:
     return Annotated[cls, Depends(cls.create)]  # type: ignore
 
 
-# Databases
+# SQL Databases
 AuthDB = Annotated[_AuthDB, Depends(_AuthDB.transaction)]
 JobDB = Annotated[_JobDB, Depends(_JobDB.transaction)]
 JobLoggingDB = Annotated[_JobLoggingDB, Depends(_JobLoggingDB.transaction)]
@@ -48,9 +50,9 @@ SandboxMetadataDB = Annotated[
 ]
 TaskQueueDB = Annotated[_TaskQueueDB, Depends(_TaskQueueDB.transaction)]
 
-# Opensearch databases
+# OpenSearch Databases
 JobParametersDB = Annotated[_JobParametersDB, Depends(_JobParametersDB.session)]
-
+PilotLogsDB = Annotated[_PilotLogsDB, Depends(_PilotLogsDB.session)]
 
 # Miscellaneous
 Config = Annotated[_Config, Depends(ConfigSource.create)]

--- a/diracx-routers/src/diracx/routers/pilots/__init__.py
+++ b/diracx-routers/src/diracx/routers/pilots/__init__.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from logging import getLogger
+
+from ..fastapi_classes import DiracxRouter
+from .logging import router as logging_router
+
+logger = getLogger(__name__)
+
+router = DiracxRouter()
+router.include_router(logging_router)

--- a/diracx-routers/src/diracx/routers/pilots/access_policies.py
+++ b/diracx-routers/src/diracx/routers/pilots/access_policies.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import logging
+from enum import StrEnum, auto
+from typing import Annotated, Callable
+
+from fastapi import Depends, HTTPException, status
+
+from diracx.core.models import ScalarSearchOperator, ScalarSearchSpec
+from diracx.core.properties import (
+    NORMAL_USER,
+)
+from diracx.routers.access_policies import BaseAccessPolicy
+
+from ..dependencies import PilotAgentsDB
+from ..utils.users import AuthorizedUserInfo
+
+logger = logging.getLogger(__name__)
+
+
+class ActionType(StrEnum):
+    #: Create/update pilot log records
+    CREATE = auto()
+    #: Search
+    QUERY = auto()
+
+
+class PilotLogsAccessPolicy(BaseAccessPolicy):
+    """Rules:
+    Only NORMAL_USER in a correct VO and a diracAdmin VO member can query log records.
+    All other actions and users are explicitly denied access.
+    """
+
+    @staticmethod
+    async def policy(
+        policy_name: str,
+        user_info: AuthorizedUserInfo,
+        /,
+        *,
+        action: ActionType | None = None,
+        pilot_agents_db: PilotAgentsDB | None = None,
+        pilot_id: int | None = None,
+    ):
+        assert pilot_agents_db
+        if action is None:
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST, detail="Action is a mandatory argument"
+            )
+        elif action == ActionType.QUERY:
+            if pilot_id is None:
+                logger.error("Pilot ID value is not provided (None)")
+                raise HTTPException(
+                    status.HTTP_400_BAD_REQUEST,
+                    detail=f"PilotID not provided: {pilot_id}",
+                )
+            search_params = ScalarSearchSpec(
+                parameter="PilotID",
+                operator=ScalarSearchOperator.EQUAL,
+                value=pilot_id,
+            )
+
+            total, result = await pilot_agents_db.search(["VO"], [search_params], [])
+            # we expect exactly one row.
+            if total != 1:
+                logger.error(
+                    "Cannot determine VO for requested PilotID: %d, found %d candidates.",
+                    pilot_id,
+                    total,
+                )
+                raise HTTPException(
+                    status.HTTP_400_BAD_REQUEST, detail=f"PilotID not found: {pilot_id}"
+                )
+            vo = result[0]["VO"]
+
+            if user_info.vo == "diracAdmin":
+                return
+
+            if NORMAL_USER in user_info.properties and user_info.vo == vo:
+                return
+
+            raise HTTPException(
+                status.HTTP_403_FORBIDDEN,
+                detail="You don't have permission to access this pilot's log.",
+            )
+        else:
+            raise NotImplementedError(action)
+
+
+CheckPilotLogsPolicyCallable = Annotated[Callable, Depends(PilotLogsAccessPolicy.check)]

--- a/diracx-routers/src/diracx/routers/pilots/logging.py
+++ b/diracx-routers/src/diracx/routers/pilots/logging.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import logging
 
 from fastapi import HTTPException, status
-from pydantic import BaseModel
 
-from diracx.core.models import ScalarSearchOperator, ScalarSearchSpec
+from diracx.core.models import LogMessage
+from diracx.logic.pilots.logging import get_logs as get_logs_bl
+from diracx.logic.pilots.logging import send_message as send_message_bl
 
 from ..access_policies import open_access
 from ..dependencies import PilotAgentsDB, PilotLogsDB
@@ -14,22 +15,6 @@ from .access_policies import ActionType, CheckPilotLogsPolicyCallable
 
 logger = logging.getLogger(__name__)
 router = DiracxRouter()
-
-
-class LogLine(BaseModel):
-    line_no: int
-    line: str
-
-
-class LogMessage(BaseModel):
-    pilot_stamp: str
-    lines: list[LogLine]
-    vo: str
-
-
-class DateRange(BaseModel):
-    min: str | None = None  # expects a string in ISO 8601 ("%Y-%m-%dT%H:%M:%S.%f%z")
-    max: str | None = None  # expects a string in ISO 8601 ("%Y-%m-%dT%H:%M:%S.%f%z")
 
 
 @open_access
@@ -41,55 +26,11 @@ async def send_message(
     # user_info: Annotated[AuthorizedUserInfo, Depends(verify_dirac_access_token)],
 ) -> int:
 
-    # expecting exactly one row:
-    search_params = ScalarSearchSpec(
-        parameter="PilotStamp",
-        operator=ScalarSearchOperator.EQUAL,
-        value=data.pilot_stamp,
-    )
-
-    total, result = await pilot_agents_db.search(
-        ["PilotID", "VO", "SubmissionTime"], [search_params], []
-    )
-    if total != 1:
-        logger.error(
-            "Cannot determine PilotID for requested PilotStamp: %r, (%d candidates)",
-            data.pilot_stamp,
-            total,
-        )
-        raise HTTPException(
-            status.HTTP_400_BAD_REQUEST, detail=f"Number of rows !=1: {total}"
-        )
-    pilot_id, vo, submission_time = (
-        result[0]["PilotID"],
-        result[0]["VO"],
-        result[0]["SubmissionTime"],
-    )
-
-    # await check_permissions(action=ActionType.CREATE, pilot_agent_db, pilot_id),
-
-    docs = []
-    for line in data.lines:
-        docs.append(
-            {
-                "PilotStamp": data.pilot_stamp,
-                "PilotID": pilot_id,
-                "SubmissionTime": submission_time,
-                "VO": vo,
-                "LineNumber": line.line_no,
-                "Message": line.line,
-            }
-        )
-    await pilot_logs_db.bulk_insert(pilot_logs_db.index_name(pilot_id), docs)
-    """
-    search_params = [{"parameter": "PilotID", "operator": "eq", "value": pilot_id}]
-
-    result = await pilot_logs_db.search(
-        ["Message"],
-        search_params,
-        [{"parameter": "LineNumber", "direction": "asc"}],
-    )
-    """
+    # await check_permissions(action=ActionType.CREATE, pilot_agent_db, pilot_id)
+    try:
+        pilot_id = await send_message_bl(data, pilot_logs_db, pilot_agents_db)
+    except Exception as exc:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     return pilot_id
 
 
@@ -107,13 +48,4 @@ async def get_logs(
         action=ActionType.QUERY, pilot_agents_db=pilot_agents_db, pilot_id=pilot_id
     )
 
-    search_params = [{"parameter": "PilotID", "operator": "eq", "value": pilot_id}]
-
-    result = await db.search(
-        ["Message"],
-        search_params,
-        [{"parameter": "LineNumber", "direction": "asc"}],
-    )
-    if not result:
-        return [{"Message": f"No logs for pilot ID = {pilot_id}"}]
-    return result
+    return await get_logs_bl(pilot_id, db)

--- a/diracx-routers/src/diracx/routers/pilots/logging.py
+++ b/diracx-routers/src/diracx/routers/pilots/logging.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import logging
+
+from fastapi import HTTPException, status
+from pydantic import BaseModel
+
+from diracx.core.models import ScalarSearchOperator, ScalarSearchSpec
+
+from ..access_policies import open_access
+from ..dependencies import PilotAgentsDB, PilotLogsDB
+from ..fastapi_classes import DiracxRouter
+from .access_policies import ActionType, CheckPilotLogsPolicyCallable
+
+logger = logging.getLogger(__name__)
+router = DiracxRouter()
+
+
+class LogLine(BaseModel):
+    line_no: int
+    line: str
+
+
+class LogMessage(BaseModel):
+    pilot_stamp: str
+    lines: list[LogLine]
+    vo: str
+
+
+class DateRange(BaseModel):
+    min: str | None = None  # expects a string in ISO 8601 ("%Y-%m-%dT%H:%M:%S.%f%z")
+    max: str | None = None  # expects a string in ISO 8601 ("%Y-%m-%dT%H:%M:%S.%f%z")
+
+
+@open_access
+@router.post("/")
+async def send_message(
+    data: LogMessage,
+    pilot_logs_db: PilotLogsDB,
+    pilot_agents_db: PilotAgentsDB,
+    # user_info: Annotated[AuthorizedUserInfo, Depends(verify_dirac_access_token)],
+) -> int:
+
+    # expecting exactly one row:
+    search_params = ScalarSearchSpec(
+        parameter="PilotStamp",
+        operator=ScalarSearchOperator.EQUAL,
+        value=data.pilot_stamp,
+    )
+
+    total, result = await pilot_agents_db.search(
+        ["PilotID", "VO", "SubmissionTime"], [search_params], []
+    )
+    if total != 1:
+        logger.error(
+            "Cannot determine PilotID for requested PilotStamp: %r, (%d candidates)",
+            data.pilot_stamp,
+            total,
+        )
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST, detail=f"Number of rows !=1: {total}"
+        )
+    pilot_id, vo, submission_time = (
+        result[0]["PilotID"],
+        result[0]["VO"],
+        result[0]["SubmissionTime"],
+    )
+
+    # await check_permissions(action=ActionType.CREATE, pilot_agent_db, pilot_id),
+
+    docs = []
+    for line in data.lines:
+        docs.append(
+            {
+                "PilotStamp": data.pilot_stamp,
+                "PilotID": pilot_id,
+                "SubmissionTime": submission_time,
+                "VO": vo,
+                "LineNumber": line.line_no,
+                "Message": line.line,
+            }
+        )
+    await pilot_logs_db.bulk_insert(pilot_logs_db.index_name(pilot_id), docs)
+    """
+    search_params = [{"parameter": "PilotID", "operator": "eq", "value": pilot_id}]
+
+    result = await pilot_logs_db.search(
+        ["Message"],
+        search_params,
+        [{"parameter": "LineNumber", "direction": "asc"}],
+    )
+    """
+    return pilot_id
+
+
+@router.get("/logs")
+async def get_logs(
+    pilot_id: int,
+    db: PilotLogsDB,
+    pilot_agents_db: PilotAgentsDB,
+    check_permissions: CheckPilotLogsPolicyCallable,
+) -> list[dict]:
+
+    logger.debug("Retrieving logs for pilot ID %d", pilot_id)
+    # users will only see logs from their own VO if enforced by a policy:
+    await check_permissions(
+        action=ActionType.QUERY, pilot_agents_db=pilot_agents_db, pilot_id=pilot_id
+    )
+
+    search_params = [{"parameter": "PilotID", "operator": "eq", "value": pilot_id}]
+
+    result = await db.search(
+        ["Message"],
+        search_params,
+        [{"parameter": "LineNumber", "direction": "asc"}],
+    )
+    if not result:
+        return [{"Message": f"No logs for pilot ID = {pilot_id}"}]
+    return result

--- a/diracx-routers/tests/pilots/test_pilot_logger.py
+++ b/diracx-routers/tests/pilots/test_pilot_logger.py
@@ -6,7 +6,13 @@ from fastapi.testclient import TestClient
 from diracx.routers.utils.users import AuthSettings
 
 pytestmark = pytest.mark.enabled_dependencies(
-    ["AuthSettings", "PilotAgentsDB", "PilotLogsDB"]
+    [
+        "AuthSettings",
+        "PilotAgentsDB",
+        "PilotLogsDB",
+        "PilotLogsAccessPolicy",
+        "DevelopmentSettings",
+    ]
 )
 
 
@@ -49,3 +55,9 @@ async def test_send_and_retrieve_logs(
     r = normal_user_client.post("/api/pilots/", json=msg_dict)
 
     assert r.status_code == 200, r.text
+    # it just returns the pilot id corresponding for pilot stamp.
+    assert r.json() == 1
+    # get the message back:
+    r = normal_user_client.get("/api/pilots/logs?pilot_id=1")
+    assert r.status_code == 200, r.text
+    assert [next(iter(d.values())) for d in r.json()] == msg.split("\n")

--- a/diracx-routers/tests/pilots/test_pilot_logger.py
+++ b/diracx-routers/tests/pilots/test_pilot_logger.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from diracx.routers.utils.users import AuthSettings
+
+pytestmark = pytest.mark.enabled_dependencies(
+    ["AuthSettings", "PilotAgentsDB", "PilotLogsDB"]
+)
+
+
+@pytest.fixture
+def normal_user_client(client_factory):
+    with client_factory.normal_user() as client:
+        yield client
+
+
+async def test_send_and_retrieve_logs(
+    normal_user_client: TestClient, test_auth_settings: AuthSettings
+):
+
+    from diracx.db.sql import PilotAgentsDB
+
+    # Add a pilot reference
+    upper_limit = 6
+    refs = [f"ref_{i}" for i in range(1, upper_limit)]
+    stamps = [f"stamp_{i}" for i in range(1, upper_limit)]
+    stamp_dict = dict(zip(refs, stamps))
+
+    db = normal_user_client.app.dependency_overrides[PilotAgentsDB.transaction].args[0]
+
+    async with db:
+        await db.add_pilot_references(
+            refs, "test_vo", grid_type="DIRAC", pilot_stamps=stamp_dict
+        )
+
+    msg = (
+        "2022-02-26 13:48:35.123456 UTC DEBUG [PilotParams] JSON file loaded: pilot.json\n"
+        "2022-02-26 13:48:36.123456 UTC DEBUG [PilotParams] JSON file analysed: pilot.json"
+    )
+    # message dict
+    lines = []
+    for i, line in enumerate(msg.split("\n")):
+        lines.append({"line_no": i, "line": line})
+    msg_dict = {"lines": lines, "pilot_stamp": "stamp_1", "vo": "diracAdmin"}
+
+    # send message
+    r = normal_user_client.post("/api/pilots/", json=msg_dict)
+
+    assert r.status_code == 200, r.text


### PR DESCRIPTION
Enable remote logging system with open search. This PR only shows a router in its preliminary form.
The router defines following operations:

1. `@router.post("/")`  - bulk insert log record sent by a pilot. The method returns a` pilotID`, so it can use it next time to insert messaged w/o consulting `PilotAgentsDB` to get PilotID from `PilotStamp`. 
2. `@router.get("/logs")` - to retrieve logs for a given pilot_id

Policies allow pilots to store VO-aware logs. Normal users can only retrieve log for their own VOs. diracAdmin can retrieve logs for any VO.