### PR TITLE
Do not close the connection to OS DB when finishing a request

### DIFF
--- a/diracx-db/src/diracx/db/os/utils.py
+++ b/diracx-db/src/diracx/db/os/utils.py
@@ -165,7 +165,6 @@ class BaseOSDB(metaclass=ABCMeta):
 
     async def __aexit__(self, exc_type, exc, tb):
         assert self._conn.get()
-        self._client = None
         self._conn.set(False)
         return
 


### PR DESCRIPTION
This was a stupid bug which just prevented 2 calls in a row on an OS DB :man_shrugging: 