### PR TITLE
fix(jobs): malformed checksum error when uploading a sandbox

### DIFF
--- a/diracx-core/src/diracx/core/models.py
+++ b/diracx-core/src/diracx/core/models.py
@@ -122,7 +122,7 @@ class SandboxFormat(StrEnum):
 
 class SandboxInfo(BaseModel):
     checksum_algorithm: ChecksumAlgorithm
-    checksum: str = Field(pattern=r"^[0-f]{64}$")
+    checksum: str = Field(pattern=r"^[0-9a-fA-F]{64}$")
     size: int = Field(ge=1)
     format: SandboxFormat
 


### PR DESCRIPTION
The OpenAPI document contains an incorrect example for the `checksum` field in the `POST /sandbox` route. 
It was generated from the `SandboxInfo` pydantic model, where the pattern was not correct.

As the default `checksum_algorithm` is `sha256`, the `checksum` should be a 64-character hexadecimal string composed only of the characters 0-9, a-f, or A-F. 
