### PR TITLE
feat: lock file while read, write and refresh token

### DIFF
--- a/diracx-cli/src/diracx/cli/__init__.py
+++ b/diracx-cli/src/diracx/cli/__init__.py
@@ -10,7 +10,7 @@ from diracx.client.aio import DiracClient
 from diracx.client.models import DeviceFlowErrorResponse
 from diracx.core.extensions import select_from_extension
 from diracx.core.preferences import get_diracx_preferences
-from diracx.core.utils import write_credentials
+from diracx.core.utils import read_credentials, write_credentials
 
 from .utils import AsyncTyper
 
@@ -116,11 +116,11 @@ async def logout():
     async with DiracClient() as api:
         credentials_path = get_diracx_preferences().credentials_path
         if credentials_path.exists():
-            credentials = json.loads(credentials_path.read_text())
+            credentials = read_credentials(credentials_path)
 
             # Revoke refresh token
             try:
-                await api.auth.revoke_refresh_token(credentials["refresh_token"])
+                await api.auth.revoke_refresh_token(credentials.refresh_token)
             except Exception as e:
                 print(f"Error revoking the refresh token {e!r}")
                 pass

--- a/diracx-client/src/diracx/client/patches/aio/utils.py
+++ b/diracx-client/src/diracx/client/patches/aio/utils.py
@@ -9,7 +9,6 @@ Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python
 from __future__ import annotations
 
 import abc
-import json
 from importlib.metadata import PackageNotFoundError, distribution
 from types import TracebackType
 from pathlib import Path
@@ -89,6 +88,9 @@ class DiracBearerTokenCredentialPolicy(AsyncBearerTokenCredentialPolicy):
     * It does not ensure that an access token is available.
     """
 
+    # Make mypy happy
+    _token: Optional[AccessToken] = None
+
     def __init__(
         self, credential: DiracTokenCredential, *scopes: str, **kwargs: Any
     ) -> None:
@@ -102,8 +104,12 @@ class DiracBearerTokenCredentialPolicy(AsyncBearerTokenCredentialPolicy):
         :type request: ~azure.core.pipeline.PipelineRequest
         :raises: :class:`~azure.core.exceptions.ServiceRequestError`
         """
+        # Make mypy happy
+        if not isinstance(self._credential, AsyncTokenCredential):
+            return
+
         self._token = await self._credential.get_token("", token=self._token)
-        if not self._token:
+        if not self._token.token:
             # If we are here, it means the token is not available
             # we suppose it is not needed to perform the request
             return

--- a/diracx-client/src/diracx/client/patches/aio/utils.py
+++ b/diracx-client/src/diracx/client/patches/aio/utils.py
@@ -13,7 +13,9 @@ import json
 from importlib.metadata import PackageNotFoundError, distribution
 from types import TracebackType
 from pathlib import Path
-from typing import Any, List, Optional, Self
+
+from typing import Any, List, Optional, cast
+
 from azure.core.credentials import AccessToken
 from azure.core.credentials_async import AsyncTokenCredential
 from azure.core.pipeline import PipelineRequest
@@ -24,8 +26,6 @@ from diracx.core.preferences import get_diracx_preferences, DiracxPreferences
 from ..utils import (
     get_openid_configuration,
     get_token,
-    refresh_token,
-    is_refresh_token_valid,
 )
 
 __all__: List[str] = [
@@ -56,20 +56,12 @@ class DiracTokenCredential(AsyncTokenCredential):
         tenant_id: Optional[str] = None,
         **kwargs: Any,
     ) -> AccessToken:
-        """Refresh the access token using the refresh_token flow.
-        :param str scopes: The type of access needed.
-        :keyword str claims: Additional claims required in the token, such as those returned in a resource
-            provider's claims challenge following an authorization failure.
-        :keyword str tenant_id: Optional tenant to include in the token request.
-        :rtype: AccessToken
-        :return: An AccessToken instance containing the token string and its expiration time in Unix time.
-        """
-        return refresh_token(
+        return get_token(
             self.location,
+            kwargs.get("token"),
             self.token_endpoint,
             self.client_id,
-            kwargs["refresh_token"],
-            verify=self.verify,
+            self.verify,
         )
 
     async def close(self) -> None:
@@ -110,28 +102,15 @@ class DiracBearerTokenCredentialPolicy(AsyncBearerTokenCredentialPolicy):
         :type request: ~azure.core.pipeline.PipelineRequest
         :raises: :class:`~azure.core.exceptions.ServiceRequestError`
         """
-        self._token: AccessToken | None
-        self._credential: DiracTokenCredential
-        credentials: dict[str, Any]
-        try:
-            self._token = get_token(self._credential.location, self._token)
-        except RuntimeError:
-            # If we are here, it means the credentials path does not exist
+        self._token = await self._credential.get_token("", token=self._token)
+        if not self._token:
+            # If we are here, it means the token is not available
             # we suppose it is not needed to perform the request
             return
 
-        if not self._token:
-            credentials = json.loads(self._credential.location.read_text())
-            refresh_token = credentials["refresh_token"]
-            if not is_refresh_token_valid(refresh_token):
-                # If we are here, it means the refresh token is not valid anymore
-                # we suppose it is not needed to perform the request
-                return
-            self._token = await self._credential.get_token(
-                "", refresh_token=refresh_token
-            )
-
-        request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"
+        request.http_request.headers["Authorization"] = (
+            "Bearer " + cast(AccessToken, self._token).token
+        )
 
 
 class DiracClientMixin(metaclass=abc.ABCMeta):

--- a/diracx-client/src/diracx/client/patches/utils.py
+++ b/diracx-client/src/diracx/client/patches/utils.py
@@ -38,6 +38,7 @@ class TokenResult:
     access_token: Optional[AccessToken] = None
     refresh_token: Optional[str] = None
 
+
 def get_openid_configuration(
     endpoint: str, *, verify: bool | str = True
 ) -> Dict[str, str]:

--- a/diracx-client/src/diracx/client/patches/utils.py
+++ b/diracx-client/src/diracx/client/patches/utils.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
-
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+import fcntl
 import json
+import os
+from diracx.core.utils import EXPIRES_GRACE_SECONDS, serialize_credentials
 import jwt
 import requests
 
@@ -9,31 +14,109 @@ from datetime import datetime, timezone
 from importlib.metadata import PackageNotFoundError, distribution
 
 from pathlib import Path
-from typing import Any, Dict, List, Optional, cast, Self
+
+from typing import Any, Dict, List, Optional, TextIO
 from urllib import parse
 from azure.core.credentials import AccessToken
 from azure.core.credentials import TokenCredential
 from azure.core.pipeline import PipelineRequest
 from azure.core.pipeline.policies import BearerTokenCredentialPolicy
 
-from ..generated.models import TokenResponse
-from diracx.core.models import TokenResponse as CoreTokenResponse
+from diracx.core.models import TokenResponse
 from diracx.core.preferences import DiracxPreferences, get_diracx_preferences
 
-import sys
+
+class TokenStatus(Enum):
+    VALID = "valid"
+    REFRESH = "refresh"
+    INVALID = "invalid"
+
+
+@dataclass
+class TokenResult:
+    status: TokenStatus
+    access_token: Optional[AccessToken] = None
+    refresh_token: Optional[str] = None
+
+def get_openid_configuration(
+    endpoint: str, *, verify: bool | str = True
+) -> Dict[str, str]:
+    """Get the openid configuration from the .well-known endpoint"""
+    response = requests.get(
+        url=parse.urljoin(endpoint, ".well-known/openid-configuration"),
+        verify=verify,
+    )
+    if not response.ok:
+        raise RuntimeError("Cannot fetch any information from the .well-known endpoint")
+    return response.json()
+
+
+def get_token(
+    location: Path,
+    token: AccessToken | None,
+    token_endpoint: str,
+    client_id: str,
+    verify: bool,
+) -> AccessToken | None:
+    """Get the access token if available and still valid."""
+    # Immediately return the token if it is available and still valid
+    if token and is_token_valid(token):
+        return token
+
+    if not location.exists():
+        # If we are here, it means the credentials path does not exist
+        # we suppose access token is not needed to perform the request
+        return None
+
+    with open(location, "r+") as f:
+        # Acquire exclusive lock
+        fcntl.flock(f, fcntl.LOCK_EX)
+        try:
+            response = extract_token_from_credentials(f, token)
+            if response.status == TokenStatus.VALID:
+                # Release the lock
+                fcntl.flock(f, fcntl.LOCK_UN)
+                return response.access_token
+
+            if response.status == TokenStatus.INVALID:
+                # Release the lock
+                fcntl.flock(f, fcntl.LOCK_UN)
+                return None
+
+            # If we are here, it means the token needs to be refreshed
+            token_response = refresh_token(
+                token_endpoint,
+                client_id,
+                response.refresh_token,
+                verify=verify,
+            )
+
+            # Write the new credentials to the file
+            f.seek(0)
+            f.truncate()
+            f.write(serialize_credentials(token_response))
+            f.flush()
+            os.fsync(f.fileno())
+
+            # Get an AccessToken instance
+            return AccessToken(
+                token=token_response.access_token,
+                expires_on=datetime.now(tz=timezone.utc)
+                + timedelta(seconds=token_response.expires_in - EXPIRES_GRACE_SECONDS),
+            )
+        finally:
+            # Release the lock
+            fcntl.flock(f, fcntl.LOCK_UN)
 
 
 def refresh_token(
-    location: Path,
     token_endpoint: str,
     client_id: str,
     refresh_token: str,
     *,
     verify: bool | str = True,
-) -> AccessToken:
+) -> TokenResponse:
     """Refresh the access token using the refresh_token flow."""
-    from diracx.core.utils import write_credentials
-
     response = requests.post(
         url=token_endpoint,
         data={
@@ -50,56 +133,49 @@ def refresh_token(
         )
 
     res = response.json()
-    token_response = TokenResponse(
+    return TokenResponse(
         access_token=res["access_token"],
         expires_in=res["expires_in"],
         token_type=res.get("token_type"),
         refresh_token=res.get("refresh_token"),
     )
 
-    write_credentials(cast(CoreTokenResponse, token_response), location=location)
-    credentials = json.loads(location.read_text())
-    return AccessToken(credentials.get("access_token"), credentials.get("expires_on"))
 
-
-def get_openid_configuration(
-    endpoint: str, *, verify: bool | str = True
-) -> Dict[str, str]:
-    """Get the openid configuration from the .well-known endpoint"""
-    response = requests.get(
-        url=parse.urljoin(endpoint, ".well-known/openid-configuration"),
-        verify=verify,
-    )
-    if not response.ok:
-        raise RuntimeError("Cannot fetch any information from the .well-known endpoint")
-    return response.json()
-
-
-def get_token(location: Path, token: AccessToken | None) -> AccessToken | None:
+def extract_token_from_credentials(
+    token_file_descriptor: TextIO, token: AccessToken | None
+) -> TokenResult:
     """Get token if available and still valid."""
-    # If the credentials path does not exist, raise an error
-    if not location.exists():
-        raise RuntimeError("credentials are not set")
+    # If we are here, it means the token is not available or not valid anymore
+    # We try to get it from the file
+    try:
+        credentials = json.load(token_file_descriptor)
+    except json.JSONDecodeError:
+        return TokenResult(TokenStatus.INVALID)
 
-    # Load the existing credentials
-    if not token:
-        credentials = json.loads(location.read_text())
+    try:
         token = AccessToken(
-            cast(str, credentials.get("access_token")),
-            cast(int, credentials.get("expires_on")),
+            token=credentials["access_token"],
+            expires_on=credentials["expires_on"],
         )
+        refresh_token = credentials["refresh_token"]
+    except KeyError:
+        return TokenResult(TokenStatus.INVALID)
 
-    # We check the validity of the token
-    # If not valid, then return None to inform the caller that a new token
-    # is needed
-    if not is_token_valid(token):
-        return None
+    # We check the validity of the tokens
+    if is_token_valid(token):
+        return TokenResult(TokenStatus.VALID, access_token=token)
 
-    return token
+    if is_refresh_token_valid(refresh_token):
+        return TokenResult(TokenStatus.REFRESH, refresh_token=credentials.refresh_token)
+
+    # If we are here, it means the refresh token is not valid anymore
+    return TokenResult(TokenStatus.INVALID)
 
 
-def is_refresh_token_valid(refresh_token: str) -> bool:
+def is_refresh_token_valid(refresh_token: str | None) -> bool:
     """Check if the refresh token is still valid."""
+    if not refresh_token:
+        return False
     # Decode the refresh token
     refresh_payload = jwt.decode(refresh_token, options={"verify_signature": False})
     if not refresh_payload or "exp" not in refresh_payload:
@@ -140,20 +216,12 @@ class DiracTokenCredential(TokenCredential):
         tenant_id: Optional[str] = None,
         **kwargs: Any,
     ) -> AccessToken:
-        """Refresh the access token using the refresh_token flow.
-        :param str scopes: The type of access needed.
-        :keyword str claims: Additional claims required in the token, such as those returned in a resource
-            provider's claims challenge following an authorization failure.
-        :keyword str tenant_id: Optional tenant to include in the token request.
-        :rtype: AccessToken
-        :return: An AccessToken instance containing the token string and its expiration time in Unix time.
-        """
-        return refresh_token(
+        return get_token(
             self.location,
+            kwargs.get("token"),
             self.token_endpoint,
             self.client_id,
-            kwargs["refresh_token"],
-            verify=self.verify,
+            self.verify,
         )
 
 
@@ -169,35 +237,19 @@ class DiracBearerTokenCredentialPolicy(BearerTokenCredentialPolicy):
     ) -> None:
         super().__init__(credential, *scopes, **kwargs)
 
-    def on_request(
-        self, request: PipelineRequest
-    ) -> None:  # pylint:disable=invalid-overridden-method
+    def on_request(self, request: PipelineRequest) -> None:
         """Authorization Bearer is optional here.
         :param request: The pipeline request object to be modified.
         :type request: ~azure.core.pipeline.PipelineRequest
         :raises: :class:`~azure.core.exceptions.ServiceRequestError`
         """
-        self._token: AccessToken | None
-        self._credential: DiracTokenCredential
-        credentials: dict[str, Any]
-
-        try:
-            self._token = get_token(self._credential.location, self._token)
-        except RuntimeError:
-            # If we are here, it means the credentials path does not exist
+        self._token = self._credential.get_token("", token=self._token)
+        if not self._token:
+            # If we are here, it means the token is not available
             # we suppose it is not needed to perform the request
             return
 
-        if not self._token:
-            credentials = json.loads(self._credential.location.read_text())
-            refresh_token = credentials["refresh_token"]
-            if not is_refresh_token_valid(refresh_token):
-                # If we are here, it means the refresh token is not valid anymore
-                # we suppose it is not needed to perform the request
-                return
-            self._token = self._credential.get_token("", refresh_token=refresh_token)
-
-        request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"
+        self._update_headers(request.http_request.headers, self._token.token)
 
 
 class DiracClientMixin:

--- a/diracx-client/tests/test_auth.py
+++ b/diracx-client/tests/test_auth.py
@@ -1,0 +1,263 @@
+import fcntl
+import json
+from datetime import datetime, time, timedelta, timezone
+from multiprocessing import Pool
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from unittest.mock import patch
+
+import pytest
+from azure.core.credentials import AccessToken
+
+from diracx.client.patches.utils import get_token
+from diracx.core.models import TokenResponse
+from diracx.core.utils import serialize_credentials
+
+TOKEN_RESPONSE_DICT = {
+    "access_token": "test_token",
+    "expires_in": int((datetime.now(tz=timezone.utc) + timedelta(days=1)).timestamp()),
+    "token_type": "Bearer",
+    "refresh_token": "test_refresh",
+}
+CREDENTIALS_CONTENT: str = serialize_credentials(TokenResponse(**TOKEN_RESPONSE_DICT))
+
+
+def lock_and_read_file(file_path):
+    """Lock and read file."""
+    with open(file_path, "r") as f:
+        fcntl.flock(f, fcntl.LOCK_SH)
+        f.read()
+        time.sleep(2)
+        fcntl.flock(f, fcntl.LOCK_UN)
+
+
+def lock_and_write_file(file_path: Path):
+    """Lock and write file."""
+    with open(file_path, "a") as f:
+        fcntl.flock(f, fcntl.LOCK_EX)
+        f.write(CREDENTIALS_CONTENT)
+        time.sleep(2)
+        fcntl.flock(f, fcntl.LOCK_UN)
+
+
+@pytest.fixture
+def concurrent_access_to_lock_file():
+
+    def run_processes(proc_to_test, *, read=True):
+        """Run the process to be tested and attempt to read or write concurrently."""
+        location = proc_to_test[1]["location"]
+        error_dict = dict()
+        with Pool(2) as pool:
+            if read:
+                # Creating the file before reading it
+                with open(location, "w") as f:
+                    f.write(CREDENTIALS_CONTENT)
+                pool.apply_async(
+                    lock_and_read_file,
+                    args=(location,),
+                    error_callback=lambda e: error_callback(
+                        e, error_dict, "lock_and_read_file"
+                    ),
+                )
+            else:
+                pool.apply_async(
+                    lock_and_write_file,
+                    args=(location,),
+                    error_callback=lambda e: error_callback(
+                        e, error_dict, "lock_and_write_file"
+                    ),
+                )
+            time.sleep(1)
+            result = pool.apply_async(
+                proc_to_test[0],
+                kwds=proc_to_test[1],
+                error_callback=lambda e: error_callback(
+                    e, error_dict, f"{proc_to_test[0].__name__}"
+                ),
+            )
+            pool.close()
+            pool.join()
+            res = result.get(timeout=1)
+        return res, error_dict
+
+    return run_processes
+
+
+def error_callback(error, error_dict, process_name):
+    """Called if the process fails."""
+    error_dict[process_name] = error
+
+
+@pytest.fixture
+def token_setup() -> tuple[TokenResponse, Path, AccessToken]:
+    """Setup token response and location."""
+    with NamedTemporaryFile(delete=False) as tmp:
+        token_location = Path(tmp.name)
+    token_response = TokenResponse(**TOKEN_RESPONSE_DICT)
+    access_token = AccessToken(token_response.access_token, token_response.expires_in)
+
+    yield token_response, token_location, access_token
+
+    if token_location.exists():
+        token_location.unlink()
+
+
+def test_get_token_accessing_lock_file(token_setup, concurrent_access_to_lock_file):
+    """Test get_token is waiting to read token from locked file."""
+    token_response, token_location, _ = token_setup
+    process_to_test = (
+        get_token,
+        {
+            "location": token_location,
+            "token": None,
+            "token_endpoint": "/endpoint",
+            "client_id": "ID",
+            "verify": False,
+        },
+    )
+    result, error_dict = concurrent_access_to_lock_file(process_to_test, read=False)
+    assert not error_dict
+    assert isinstance(result, AccessToken)
+    assert result.token == token_response.access_token
+
+
+def test_get_token_valid_input_token(token_setup):
+    """Test that get_token return the valid token."""
+    _, token_location, access_token = token_setup
+    result = get_token(
+        location=token_location,
+        token=access_token,
+        token_endpoint="",
+        client_id="ID",
+        verify=False,
+    )
+
+    assert result == access_token
+
+
+def test_get_token_valid_input_credential():
+    """Test that get_token return the valid token given in the credential file."""
+    with NamedTemporaryFile(delete=False) as tmp:
+        tmp.write(CREDENTIALS_CONTENT.encode())
+        temp_file = Path(tmp.name)
+    result = get_token(
+        location=temp_file, token=None, token_endpoint="", client_id="ID", verify=False
+    )
+    temp_file.unlink()
+    assert isinstance(result, AccessToken)
+
+
+def test_get_token_input_token_not_exists(token_setup):
+    _, token_location, _ = token_setup
+    result = get_token(
+        location=token_location,
+        token=None,
+        token_endpoint="",
+        client_id="ID",
+        verify=False,
+    )
+    assert result is None
+
+
+def test_get_token_invalid_input():
+    """Test that get_token manage invalid input token."""
+    # Test wrong key in credential
+    wrong_credential_content = "'{\"wrong_key\": False}'"
+    with NamedTemporaryFile(delete=False) as tmp:
+        tmp.write(json.dumps(wrong_credential_content).encode())
+        temp_file = Path(tmp.name)
+    result = get_token(
+        location=temp_file, token=None, token_endpoint="", client_id="ID", verify=False
+    )
+    temp_file.unlink()
+    assert result is None
+
+    # Test with invalid token date
+    token_response = TOKEN_RESPONSE_DICT.copy()
+    token_response["expires_in"] = int(datetime.now(tz=timezone.utc).timestamp())
+    with NamedTemporaryFile(delete=False) as tmp:
+        tmp.write(json.dumps(token_response).encode())
+        temp_file = Path(tmp.name)
+
+    result = get_token(
+        location=temp_file, token=None, token_endpoint="", client_id="ID", verify=False
+    )
+    temp_file.unlink()
+    assert result is None
+
+
+def test_get_token_refresh_valid():
+    """Test that get_token refresh a valid outdated token."""
+    token_response = TOKEN_RESPONSE_DICT.copy()
+    # the future content of the refreshed token
+    refresh_token = TokenResponse(**token_response)
+    # Create expired credential file
+    token_response["expires_on"] = int(
+        (datetime.now(tz=timezone.utc) - timedelta(seconds=10)).timestamp()
+    )
+    token_response.pop("expires_in")
+    with NamedTemporaryFile(delete=False) as tmp:
+        tmp.write(json.dumps(token_response).encode())
+        temp_file = Path(tmp.name)
+
+    with (
+        patch(
+            "diracx.client.patches.utils.is_refresh_token_valid", return_value=True
+        ) as mock_is_refresh_valid,
+        patch(
+            "diracx.client.patches.utils.refresh_token", return_value=refresh_token
+        ) as mock_refresh_token,
+    ):
+        result = get_token(
+            location=temp_file,
+            token=None,
+            token_endpoint="",
+            client_id="ID",
+            verify=False,
+        )
+
+    # Verify that the credential fil has been refreshed:
+    with open(temp_file, "r") as f:
+        content = f.read()
+        assert content == serialize_credentials(refresh_token)
+
+    temp_file.unlink()
+
+    assert result is not None
+    assert isinstance(result, AccessToken)
+    assert result.token == refresh_token.access_token
+    assert result.expires_on > refresh_token.expires_in
+    mock_is_refresh_valid.assert_called_once_with(refresh_token.refresh_token)
+    mock_refresh_token.assert_called_once_with(
+        "", "ID", refresh_token.refresh_token, verify=False
+    )
+
+
+def test_get_token_refresh_invalid():
+    """Test that get_token manages an invalid refresh token."""
+    token_response = TOKEN_RESPONSE_DICT.copy()
+    refresh_token = TokenResponse(**token_response)
+    token_response["expires_on"] = int(
+        (datetime.now(tz=timezone.utc) - timedelta(seconds=10)).timestamp()
+    )
+    token_response.pop("expires_in")
+    with NamedTemporaryFile(delete=False) as tmp:
+        tmp.write(json.dumps(token_response).encode())
+        temp_file = Path(tmp.name)
+
+    with (
+        patch(
+            "diracx.client.patches.utils.is_refresh_token_valid", return_value=False
+        ) as mock_is_refresh_valid,
+    ):
+        result = get_token(
+            location=temp_file,
+            token=None,
+            token_endpoint="",
+            client_id="ID",
+            verify=False,
+        )
+
+    temp_file.unlink()
+    assert result is None
+    mock_is_refresh_valid.assert_called_once_with(refresh_token.refresh_token)

--- a/diracx-client/tests/test_auth.py
+++ b/diracx-client/tests/test_auth.py
@@ -1,11 +1,8 @@
 import fcntl
 import json
-from datetime import datetime, time, timedelta, timezone
-from multiprocessing import Pool
-from pathlib import Path
-from tempfile import NamedTemporaryFile
-from unittest.mock import patch
+from datetime import datetime, timedelta, timezone
 
+import jwt
 import pytest
 from azure.core.credentials import AccessToken
 
@@ -13,117 +10,72 @@ from diracx.client.patches.utils import get_token
 from diracx.core.models import TokenResponse
 from diracx.core.utils import serialize_credentials
 
+# Create a fake jwt dictionary
+REFRESH_CONTENT = {
+    "jti": "f0706e0a-af1e-4538-9f1f-7b9620783cba",
+    "exp": int((datetime.now(tz=timezone.utc) + timedelta(days=1)).timestamp()),
+    "legacy_exchange": False,
+    "dirac_policies": {},
+}
+
 TOKEN_RESPONSE_DICT = {
     "access_token": "test_token",
-    "expires_in": int((datetime.now(tz=timezone.utc) + timedelta(days=1)).timestamp()),
+    "expires_in": 3600,
     "token_type": "Bearer",
-    "refresh_token": "test_refresh",
+    "refresh_token": jwt.encode(REFRESH_CONTENT, "secret_key"),
 }
 CREDENTIALS_CONTENT: str = serialize_credentials(TokenResponse(**TOKEN_RESPONSE_DICT))
 
 
-def lock_and_read_file(file_path):
-    """Lock and read file."""
-    with open(file_path, "r") as f:
-        fcntl.flock(f, fcntl.LOCK_SH)
-        f.read()
-        time.sleep(2)
-        fcntl.flock(f, fcntl.LOCK_UN)
-
-
-def lock_and_write_file(file_path: Path):
-    """Lock and write file."""
-    with open(file_path, "a") as f:
-        fcntl.flock(f, fcntl.LOCK_EX)
-        f.write(CREDENTIALS_CONTENT)
-        time.sleep(2)
-        fcntl.flock(f, fcntl.LOCK_UN)
-
-
-@pytest.fixture
-def concurrent_access_to_lock_file():
-
-    def run_processes(proc_to_test, *, read=True):
-        """Run the process to be tested and attempt to read or write concurrently."""
-        location = proc_to_test[1]["location"]
-        error_dict = dict()
-        with Pool(2) as pool:
-            if read:
-                # Creating the file before reading it
-                with open(location, "w") as f:
-                    f.write(CREDENTIALS_CONTENT)
-                pool.apply_async(
-                    lock_and_read_file,
-                    args=(location,),
-                    error_callback=lambda e: error_callback(
-                        e, error_dict, "lock_and_read_file"
-                    ),
-                )
-            else:
-                pool.apply_async(
-                    lock_and_write_file,
-                    args=(location,),
-                    error_callback=lambda e: error_callback(
-                        e, error_dict, "lock_and_write_file"
-                    ),
-                )
-            time.sleep(1)
-            result = pool.apply_async(
-                proc_to_test[0],
-                kwds=proc_to_test[1],
-                error_callback=lambda e: error_callback(
-                    e, error_dict, f"{proc_to_test[0].__name__}"
-                ),
-            )
-            pool.close()
-            pool.join()
-            res = result.get(timeout=1)
-        return res, error_dict
-
-    return run_processes
-
-
-def error_callback(error, error_dict, process_name):
-    """Called if the process fails."""
-    error_dict[process_name] = error
-
-
-@pytest.fixture
-def token_setup() -> tuple[TokenResponse, Path, AccessToken]:
-    """Setup token response and location."""
-    with NamedTemporaryFile(delete=False) as tmp:
-        token_location = Path(tmp.name)
-    token_response = TokenResponse(**TOKEN_RESPONSE_DICT)
-    access_token = AccessToken(token_response.access_token, token_response.expires_in)
-
-    yield token_response, token_location, access_token
-
-    if token_location.exists():
-        token_location.unlink()
-
-
-def test_get_token_accessing_lock_file(token_setup, concurrent_access_to_lock_file):
+def test_get_token_accessing_lock_file(monkeypatch, tmp_path):
     """Test get_token is waiting to read token from locked file."""
-    token_response, token_location, _ = token_setup
-    process_to_test = (
-        get_token,
-        {
-            "location": token_location,
-            "token": None,
-            "token_endpoint": "/endpoint",
-            "client_id": "ID",
-            "verify": False,
-        },
+    token_location = tmp_path / "credentials.json"
+    token_location.write_text(CREDENTIALS_CONTENT)
+
+    # Patch 'fcntl.flock' within the 'diracx.client.patches.utils' module
+    flock_calls = []
+
+    def mock_flock(file, operation):
+        flock_calls.append((file, operation))
+        if operation == fcntl.LOCK_EX:
+            raise BlockingIOError("File is locked")
+
+    monkeypatch.setattr("diracx.client.patches.utils.fcntl.flock", mock_flock)
+
+    # Attempt to get a token, expecting a BlockingIOError due to the lock
+    with pytest.raises(BlockingIOError) as exc_info:
+        get_token(
+            location=token_location,
+            token=None,
+            token_endpoint="/endpoint",
+            client_id="ID",
+            verify=False,
+        )
+
+    # Verify that flock was called with LOCK_EX
+    assert len(flock_calls) == 1, "fcntl.flock was not called"
+    assert (
+        flock_calls[-1][1] == fcntl.LOCK_EX
+    ), f"Expected LOCK_SH, got {flock_calls[-1][1]}"
+    assert "File is locked" in str(exc_info.value)
+
+
+def test_get_token_valid_input_token(tmp_path):
+    """Test that get_token return the valid provided token."""
+    token_location = tmp_path / "credentials.json"
+    # Create a valid access token
+    token_response = TokenResponse(**TOKEN_RESPONSE_DICT)
+    access_token = AccessToken(
+        token_response.access_token,
+        int(
+            (
+                datetime.now(tz=timezone.utc)
+                + timedelta(seconds=token_response.expires_in)
+            ).timestamp()
+        ),
     )
-    result, error_dict = concurrent_access_to_lock_file(process_to_test, read=False)
-    assert not error_dict
-    assert isinstance(result, AccessToken)
-    assert result.token == token_response.access_token
 
-
-def test_get_token_valid_input_token(token_setup):
-    """Test that get_token return the valid token."""
-    _, token_location, access_token = token_setup
+    # Call get_token
     result = get_token(
         location=token_location,
         token=access_token,
@@ -135,20 +87,12 @@ def test_get_token_valid_input_token(token_setup):
     assert result == access_token
 
 
-def test_get_token_valid_input_credential():
+def test_get_token_valid_input_credential(tmp_path):
     """Test that get_token return the valid token given in the credential file."""
-    with NamedTemporaryFile(delete=False) as tmp:
-        tmp.write(CREDENTIALS_CONTENT.encode())
-        temp_file = Path(tmp.name)
-    result = get_token(
-        location=temp_file, token=None, token_endpoint="", client_id="ID", verify=False
-    )
-    temp_file.unlink()
-    assert isinstance(result, AccessToken)
+    token_location = tmp_path / "credentials.json"
+    token_location.write_text(CREDENTIALS_CONTENT)
 
-
-def test_get_token_input_token_not_exists(token_setup):
-    _, token_location, _ = token_setup
+    # Call get_token
     result = get_token(
         location=token_location,
         token=None,
@@ -156,108 +100,130 @@ def test_get_token_input_token_not_exists(token_setup):
         client_id="ID",
         verify=False,
     )
-    assert result is None
+
+    # Verify that the returned token is the expected token
+    assert isinstance(result, AccessToken)
+    assert result.token == TOKEN_RESPONSE_DICT["access_token"]
+    assert result.expires_on > datetime.now(tz=timezone.utc).timestamp()
 
 
-def test_get_token_invalid_input():
-    """Test that get_token manage invalid input token."""
+def test_get_token_input_token_not_exists(tmp_path):
+    """Test that get_token return an empty token when the provided token does not exist."""
+    token_location = tmp_path / "credentials.json"
+
+    # Call get_token
+    result = get_token(
+        location=token_location,
+        token=None,
+        token_endpoint="",
+        client_id="ID",
+        verify=False,
+    )
+    assert isinstance(result, AccessToken)
+    assert result.token == ""
+    assert result.expires_on == 0
+
+
+def test_get_token_invalid_input(tmp_path):
+    """Test that get_token manages invalid input token."""
     # Test wrong key in credential
-    wrong_credential_content = "'{\"wrong_key\": False}'"
-    with NamedTemporaryFile(delete=False) as tmp:
-        tmp.write(json.dumps(wrong_credential_content).encode())
-        temp_file = Path(tmp.name)
+    wrong_credential_content = {"wrong_key": False}
+
+    token_location = tmp_path / "credentials.json"
+    token_location.write_text(json.dumps(wrong_credential_content))
+
+    # Call get_token
     result = get_token(
-        location=temp_file, token=None, token_endpoint="", client_id="ID", verify=False
+        location=token_location,
+        token=None,
+        token_endpoint="",
+        client_id="ID",
+        verify=False,
     )
-    temp_file.unlink()
-    assert result is None
-
-    # Test with invalid token date
-    token_response = TOKEN_RESPONSE_DICT.copy()
-    token_response["expires_in"] = int(datetime.now(tz=timezone.utc).timestamp())
-    with NamedTemporaryFile(delete=False) as tmp:
-        tmp.write(json.dumps(token_response).encode())
-        temp_file = Path(tmp.name)
-
-    result = get_token(
-        location=temp_file, token=None, token_endpoint="", client_id="ID", verify=False
-    )
-    temp_file.unlink()
-    assert result is None
+    # Verify that the returned token is empty
+    assert isinstance(result, AccessToken)
+    assert result.token == ""
+    assert result.expires_on == 0
 
 
-def test_get_token_refresh_valid():
+def test_get_token_refresh_valid(monkeypatch, tmp_path):
     """Test that get_token refresh a valid outdated token."""
     token_response = TOKEN_RESPONSE_DICT.copy()
-    # the future content of the refreshed token
-    refresh_token = TokenResponse(**token_response)
-    # Create expired credential file
+    # Expected future content of the refreshed token
+    expected_token_response = TokenResponse(**token_response)
+
+    # Create expired access token
     token_response["expires_on"] = int(
         (datetime.now(tz=timezone.utc) - timedelta(seconds=10)).timestamp()
     )
     token_response.pop("expires_in")
-    with NamedTemporaryFile(delete=False) as tmp:
-        tmp.write(json.dumps(token_response).encode())
-        temp_file = Path(tmp.name)
 
-    with (
-        patch(
-            "diracx.client.patches.utils.is_refresh_token_valid", return_value=True
-        ) as mock_is_refresh_valid,
-        patch(
-            "diracx.client.patches.utils.refresh_token", return_value=refresh_token
-        ) as mock_refresh_token,
-    ):
-        result = get_token(
-            location=temp_file,
-            token=None,
-            token_endpoint="",
-            client_id="ID",
-            verify=False,
-        )
+    # Write expired credentials to a file
+    token_location = tmp_path / "credentials.json"
+    token_location.write_text(json.dumps(token_response))
 
-    # Verify that the credential fil has been refreshed:
-    with open(temp_file, "r") as f:
+    # Mock the refresh_token function
+    was_refresh_called = False
+
+    def mock_refresh(token_endpoint, client_id, refresh_token, verify):
+        nonlocal was_refresh_called
+        was_refresh_called = True
+        return TokenResponse(**TOKEN_RESPONSE_DICT)
+
+    monkeypatch.setattr("diracx.client.patches.utils.refresh_token", mock_refresh)
+
+    # Call get_token
+    result = get_token(
+        location=token_location,
+        token=None,
+        token_endpoint="",
+        client_id="ID",
+        verify=False,
+    )
+
+    # Verify that the credential file has been refreshed:
+    with open(token_location, "r") as f:
         content = f.read()
-        assert content == serialize_credentials(refresh_token)
+        assert content == serialize_credentials(expected_token_response)
 
-    temp_file.unlink()
-
+    # Verify that the returned token is the expected refreshed token
     assert result is not None
     assert isinstance(result, AccessToken)
-    assert result.token == refresh_token.access_token
-    assert result.expires_on > refresh_token.expires_in
-    mock_is_refresh_valid.assert_called_once_with(refresh_token.refresh_token)
-    mock_refresh_token.assert_called_once_with(
-        "", "ID", refresh_token.refresh_token, verify=False
+    assert result.token == expected_token_response.access_token
+    assert result.expires_on > token_response["expires_on"]
+    assert was_refresh_called
+
+
+def test_get_token_refresh_expired(tmp_path):
+    """Test that get_token manages an expired refresh token: should return an empty token."""
+    # Create expired access token and refresh token
+    token_response = TOKEN_RESPONSE_DICT.copy()
+    refresh_token = REFRESH_CONTENT.copy()
+
+    refresh_token["exp"] = int(
+        (datetime.now(tz=timezone.utc) - timedelta(seconds=10)).timestamp()
     )
 
-
-def test_get_token_refresh_invalid():
-    """Test that get_token manages an invalid refresh token."""
-    token_response = TOKEN_RESPONSE_DICT.copy()
-    refresh_token = TokenResponse(**token_response)
     token_response["expires_on"] = int(
         (datetime.now(tz=timezone.utc) - timedelta(seconds=10)).timestamp()
     )
     token_response.pop("expires_in")
-    with NamedTemporaryFile(delete=False) as tmp:
-        tmp.write(json.dumps(token_response).encode())
-        temp_file = Path(tmp.name)
+    token_response["refresh_token"] = jwt.encode(refresh_token, "secret_key")
 
-    with (
-        patch(
-            "diracx.client.patches.utils.is_refresh_token_valid", return_value=False
-        ) as mock_is_refresh_valid,
-    ):
-        result = get_token(
-            location=temp_file,
-            token=None,
-            token_endpoint="",
-            client_id="ID",
-            verify=False,
-        )
+    # Write expired credentials to a file
+    token_location = tmp_path / "credentials.json"
+    token_location.write_text(json.dumps(token_response))
 
-    temp_file.unlink()
-    assert result is None
-    mock_is_refresh_valid.assert_called_once_with(refresh_token.refresh_token)
+    # Call get_token
+    result = get_token(
+        location=token_location,
+        token=None,
+        token_endpoint="",
+        client_id="ID",
+        verify=False,
+    )
+
+    # Verify that the returned token is empty
+    assert isinstance(result, AccessToken)
+    assert result.token == ""
+    assert result.expires_on == 0

--- a/diracx-core/src/diracx/core/utils.py
+++ b/diracx-core/src/diracx/core/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import fcntl
 import json
 import os
 import re
@@ -37,10 +38,48 @@ def serialize_credentials(token_response: TokenResponse) -> str:
     return json.dumps(credential_data)
 
 
+def read_credentials(location: Path) -> TokenResponse:
+    """Read credentials from a file."""
+    from diracx.core.preferences import get_diracx_preferences
+
+    credentials_path = location or get_diracx_preferences().credentials_path
+    try:
+        with open(credentials_path, "r") as f:
+            # Lock the file to prevent other processes from writing to it at the same time
+            fcntl.flock(f, fcntl.LOCK_SH | fcntl.LOCK_NB)
+            # Read the credentials from the file
+            try:
+                credentials = json.load(f)
+            finally:
+                # Release the lock
+                fcntl.flock(f, fcntl.LOCK_UN)
+    except (BlockingIOError, FileNotFoundError, json.JSONDecodeError) as e:
+        raise RuntimeError(f"Error reading credentials: {e}") from e
+
+    return TokenResponse(
+        access_token=credentials["access_token"],
+        expires_in=credentials["expires_on"]
+        - int(datetime.now(tz=timezone.utc).timestamp()),
+        token_type="Bearer",  # noqa: S106
+        refresh_token=credentials.get("refresh_token"),
+    )
+
+
 def write_credentials(token_response: TokenResponse, *, location: Path | None = None):
     """Write credentials received in dirax_preferences.credentials_path."""
     from diracx.core.preferences import get_diracx_preferences
 
     credentials_path = location or get_diracx_preferences().credentials_path
     credentials_path.parent.mkdir(parents=True, exist_ok=True)
-    credentials_path.write_text(serialize_credentials(token_response))
+
+    with open(credentials_path, "w") as f:
+        # Lock the file to prevent other processes from writing to it at the same time
+        fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        try:
+            # Write the credentials to the file
+            f.write(serialize_credentials(token_response))
+            f.flush()
+            os.fsync(f.fileno())
+        finally:
+            # Release the lock
+            fcntl.flock(f, fcntl.LOCK_UN)

--- a/diracx-core/src/diracx/core/utils.py
+++ b/diracx-core/src/diracx/core/utils.py
@@ -46,14 +46,14 @@ def read_credentials(location: Path) -> TokenResponse:
     try:
         with open(credentials_path, "r") as f:
             # Lock the file to prevent other processes from writing to it at the same time
-            fcntl.flock(f, fcntl.LOCK_SH | fcntl.LOCK_NB)
+            fcntl.flock(f, fcntl.LOCK_SH)
             # Read the credentials from the file
             try:
                 credentials = json.load(f)
             finally:
                 # Release the lock
                 fcntl.flock(f, fcntl.LOCK_UN)
-    except (BlockingIOError, FileNotFoundError, json.JSONDecodeError) as e:
+    except (FileNotFoundError, json.JSONDecodeError) as e:
         raise RuntimeError(f"Error reading credentials: {e}") from e
 
     return TokenResponse(
@@ -74,7 +74,7 @@ def write_credentials(token_response: TokenResponse, *, location: Path | None = 
 
     with open(credentials_path, "w") as f:
         # Lock the file to prevent other processes from writing to it at the same time
-        fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fcntl.flock(f, fcntl.LOCK_EX)
         try:
             # Write the credentials to the file
             f.write(serialize_credentials(token_response))

--- a/diracx-core/tests/test_utils.py
+++ b/diracx-core/tests/test_utils.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
 import fcntl
+import json
 import time
 from datetime import datetime, timedelta, timezone
 from multiprocessing import Pool
 from pathlib import Path
 from tempfile import NamedTemporaryFile
+from unittest.mock import patch
 
 import pytest
+from azure.core.credentials import AccessToken
 
+from diracx.client.patches.utils import get_token
 from diracx.core.models import TokenResponse
 from diracx.core.utils import (
     dotenv_files_from_environment,
@@ -47,13 +51,13 @@ TOKEN_RESPONSE_DICT = {
     "token_type": "Bearer",
     "refresh_token": "test_refresh",
 }
-CREDENTIALS_CONTENT = serialize_credentials(TokenResponse(**TOKEN_RESPONSE_DICT))
+CREDENTIALS_CONTENT: str = serialize_credentials(TokenResponse(**TOKEN_RESPONSE_DICT))
 
 
 def lock_and_read_file(file_path):
     """Lock and read file."""
     with open(file_path, "r") as f:
-        fcntl.flock(f, fcntl.LOCK_SH | fcntl.LOCK_NB)
+        fcntl.flock(f, fcntl.LOCK_SH)
         f.read()
         time.sleep(2)
         fcntl.flock(f, fcntl.LOCK_UN)
@@ -62,18 +66,20 @@ def lock_and_read_file(file_path):
 def lock_and_write_file(file_path: Path):
     """Lock and write file."""
     with open(file_path, "a") as f:
-        fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fcntl.flock(f, fcntl.LOCK_EX)
         f.write(CREDENTIALS_CONTENT)
         time.sleep(2)
         fcntl.flock(f, fcntl.LOCK_UN)
 
 
 @pytest.fixture
-def token_setup() -> tuple[TokenResponse, Path]:
+def token_setup() -> tuple[TokenResponse, Path, AccessToken]:
     """Setup token response and location."""
     token_location = Path(NamedTemporaryFile().name)
     token_response = TokenResponse(**TOKEN_RESPONSE_DICT)
-    return token_response, token_location
+    access_token = AccessToken(token_response.access_token, token_response.expires_in)
+
+    return token_response, token_location, access_token
 
 
 @pytest.fixture
@@ -104,7 +110,7 @@ def concurrent_access_to_lock_file():
                     ),
                 )
             time.sleep(1)
-            pool.apply_async(
+            result = pool.apply_async(
                 proc_to_test[0],
                 kwds=proc_to_test[1],
                 error_callback=lambda e: error_callback(
@@ -113,7 +119,8 @@ def concurrent_access_to_lock_file():
             )
             pool.close()
             pool.join()
-        return error_dict
+            res = result.get(timeout=1)
+        return res, error_dict
 
     return run_processes
 
@@ -127,41 +134,6 @@ def assert_read_credentials_error_message(exc_info):
     assert "Error reading credentials:" in exc_info.value.args[0]
 
 
-def test_read_credentials_reading_locked_file(
-    token_setup, concurrent_access_to_lock_file
-):
-    """Test that read_credentials reading a locked file end in error."""
-    _, token_location = token_setup
-    process_to_test = (read_credentials, {"location": token_location})
-    error_dict = concurrent_access_to_lock_file(process_to_test, read=False)
-    process_name = process_to_test[0].__name__
-    if process_name in error_dict.keys():
-        assert isinstance(error_dict[process_name], RuntimeError)
-    else:
-        raise AssertionError(
-            "Expected a RuntimeError while reading locked credentials."
-        )
-
-
-def test_write_credentials_writing_locked_file(
-    token_setup, concurrent_access_to_lock_file
-):
-    """Test that write_credentials writing a locked file end in error."""
-    token_response, token_location = token_setup
-    process_to_test = (
-        write_credentials,
-        {"token_response": token_response, "location": token_location},
-    )
-    error_dict = concurrent_access_to_lock_file(process_to_test)
-    process_name = process_to_test[0].__name__
-    if process_name in error_dict.keys():
-        assert isinstance(error_dict[process_name], BlockingIOError)
-    else:
-        raise AssertionError(
-            "Expected a BlockingIOError while writing locked credentials."
-        )
-
-
 def create_temp_file(content=None) -> Path:
     """Helper function to create a temporary file with optional content."""
     temp_file = NamedTemporaryFile(delete=False)
@@ -170,6 +142,29 @@ def create_temp_file(content=None) -> Path:
     if content is not None:
         temp_path.write_text(content)
     return temp_path
+
+
+def test_read_credentials_reading_locked_file(
+    token_setup, concurrent_access_to_lock_file
+):
+    """Test that read_credentials is waiting to read a locked file end in error."""
+    _, token_location, _ = token_setup
+    process_to_test = (read_credentials, {"location": token_location})
+    _, error_dict = concurrent_access_to_lock_file(process_to_test, read=False)
+    assert not error_dict
+
+
+def test_write_credentials_writing_locked_file(
+    token_setup, concurrent_access_to_lock_file
+):
+    """Test that write_credentials is waiting to write a locked file end in error."""
+    token_response, token_location, _ = token_setup
+    process_to_test = (
+        write_credentials,
+        {"token_response": token_response, "location": token_location},
+    )
+    _, error_dict = concurrent_access_to_lock_file(process_to_test)
+    assert not error_dict
 
 
 def test_read_credentials_empty_file():
@@ -186,7 +181,7 @@ def test_read_credentials_empty_file():
 def test_write_credentials_empty_file(token_setup):
     """Test that write_credentials raises an appropriate error for an empty file."""
     temp_file = create_temp_file("")
-    token_response, _ = token_setup
+    token_response, _, _ = token_setup
     write_credentials(token_response, location=temp_file)
     temp_file.unlink()
 
@@ -202,7 +197,7 @@ def test_read_credentials_missing_file():
 def test_write_credentials_unavailable_path(token_setup):
     """Test that write_credentials raises error when it can't create path."""
     wrong_path = Path("/wrong/path/file.txt")
-    token_response, _ = token_setup
+    token_response, _, _ = token_setup
     with pytest.raises(PermissionError):
         write_credentials(token_response, location=wrong_path)
 
@@ -220,7 +215,7 @@ def test_read_credentials_invalid_content():
 
 def test_read_credentials_valid_file(token_setup):
     """Test that read_credentials works correctly with a valid file."""
-    token_response, _ = token_setup
+    token_response, _, _ = token_setup
     temp_file = create_temp_file(content=CREDENTIALS_CONTENT)
 
     credentials = read_credentials(location=temp_file)
@@ -229,3 +224,159 @@ def test_read_credentials_valid_file(token_setup):
     assert credentials.expires_in < token_response.expires_in
     assert credentials.token_type == token_response.token_type
     assert credentials.refresh_token == token_response.refresh_token
+
+
+# Testing get_token:
+
+
+def test_get_token_accessing_lock_file(token_setup, concurrent_access_to_lock_file):
+    """Test get_token is waiting to read token from locked file."""
+    token_response, token_location, _ = token_setup
+    process_to_test = (
+        get_token,
+        {
+            "location": token_location,
+            "token": None,
+            "token_endpoint": "/endpoint",
+            "client_id": "ID",
+            "verify": False,
+        },
+    )
+    result, error_dict = concurrent_access_to_lock_file(process_to_test, read=False)
+    assert not error_dict
+    assert isinstance(result, AccessToken)
+    assert result.token == token_response.access_token
+
+
+def test_get_token_valid_input_token(token_setup):
+    """Test that get_token return the valid token."""
+    _, token_location, access_token = token_setup
+    result = get_token(
+        location=token_location,
+        token=access_token,
+        token_endpoint="",
+        client_id="ID",
+        verify=False,
+    )
+    assert result == access_token
+
+
+def test_get_token_valid_input_credential():
+    """Test that get_token return the valid token given in the credential file."""
+    temp_file = create_temp_file(content=CREDENTIALS_CONTENT)
+    result = get_token(
+        location=temp_file, token=None, token_endpoint="", client_id="ID", verify=False
+    )
+    temp_file.unlink()
+    assert isinstance(result, AccessToken)
+
+
+def test_get_token_input_token_not_exists(token_setup):
+    _, token_location, access_token = token_setup
+    result = get_token(
+        location=token_location,
+        token=access_token,
+        token_endpoint="",
+        client_id="ID",
+        verify=False,
+    )
+    assert result is None
+
+
+def test_get_token_invalid_input(token_setup):
+    """Test that get_token manage invalid input token."""
+    # Test wrong key in credential
+    token_response, _, _ = token_setup
+    wrong_credential_content = "'{\"wrong_key\": False}'"
+    temp_file = create_temp_file(content=wrong_credential_content)
+    result = get_token(
+        location=temp_file, token=None, token_endpoint="", client_id="ID", verify=False
+    )
+    temp_file.unlink()
+    assert result is None
+
+    # Test with invalid token date
+    token_response = TOKEN_RESPONSE_DICT.copy()
+    token_response["expires_in"] = int(datetime.now(tz=timezone.utc).timestamp())
+    credential_content = json.dumps(token_response)
+    temp_file = create_temp_file(content=credential_content)
+    result = get_token(
+        location=temp_file, token=None, token_endpoint="", client_id="ID", verify=False
+    )
+    temp_file.unlink()
+    assert result is None
+
+
+def test_get_token_refresh_valid():
+    """Test that get_token refresh a valid outdated token."""
+    token_response = TOKEN_RESPONSE_DICT.copy()
+    # the future content of the refreshed token
+    refresh_token = TokenResponse(**token_response)
+    # Create expired credential file
+    token_response["expires_on"] = int(
+        (datetime.now(tz=timezone.utc) - timedelta(seconds=10)).timestamp()
+    )
+    token_response.pop("expires_in")
+    credentials = json.dumps(token_response)
+    temp_file = create_temp_file(content=credentials)
+
+    with (
+        patch(
+            "diracx.client.patches.utils.is_refresh_token_valid", return_value=True
+        ) as mock_is_refresh_valid,
+        patch(
+            "diracx.client.patches.utils.refresh_token", return_value=refresh_token
+        ) as mock_refresh_token,
+    ):
+        result = get_token(
+            location=temp_file,
+            token=None,
+            token_endpoint="",
+            client_id="ID",
+            verify=False,
+        )
+
+    # Verify that the credential fil has been refreshed:
+    with open(temp_file, "r") as f:
+        content = f.read()
+        assert content == serialize_credentials(refresh_token)
+
+    temp_file.unlink()
+
+    assert result is not None
+    assert isinstance(result, AccessToken)
+    assert result.token == refresh_token.access_token
+    assert result.expires_on > refresh_token.expires_in
+    mock_is_refresh_valid.assert_called_once_with(refresh_token.refresh_token)
+    mock_refresh_token.assert_called_once_with(
+        "", "ID", refresh_token.refresh_token, verify=False
+    )
+
+
+def test_get_token_refresh_invalid():
+    """Test that get_token manages an invalid refresh token."""
+    token_response = TOKEN_RESPONSE_DICT.copy()
+    refresh_token = TokenResponse(**token_response)
+    token_response["expires_on"] = int(
+        (datetime.now(tz=timezone.utc) - timedelta(seconds=10)).timestamp()
+    )
+    token_response.pop("expires_in")
+    credentials = json.dumps(token_response)
+    temp_file = create_temp_file(content=credentials)
+
+    with (
+        patch(
+            "diracx.client.patches.utils.is_refresh_token_valid", return_value=False
+        ) as mock_is_refresh_valid,
+    ):
+        result = get_token(
+            location=temp_file,
+            token=None,
+            token_endpoint="",
+            client_id="ID",
+            verify=False,
+        )
+
+    temp_file.unlink()
+    assert result is None
+    mock_is_refresh_valid.assert_called_once_with(refresh_token.refresh_token)

--- a/diracx-core/tests/test_utils.py
+++ b/diracx-core/tests/test_utils.py
@@ -272,10 +272,10 @@ def test_get_token_valid_input_credential():
 
 
 def test_get_token_input_token_not_exists(token_setup):
-    _, token_location, access_token = token_setup
+    _, token_location, _ = token_setup
     result = get_token(
         location=token_location,
-        token=access_token,
+        token=None,
         token_endpoint="",
         client_id="ID",
         verify=False,

--- a/diracx-core/tests/test_utils.py
+++ b/diracx-core/tests/test_utils.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import fcntl
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from tempfile import NamedTemporaryFile
 
 import pytest
 
@@ -48,27 +47,19 @@ TOKEN_RESPONSE_DICT = {
 CREDENTIALS_CONTENT: str = serialize_credentials(TokenResponse(**TOKEN_RESPONSE_DICT))
 
 
-@pytest.fixture
-def token_setup() -> tuple[TokenResponse, Path]:
-    """Setup token response and location."""
-    with NamedTemporaryFile(delete=False) as tmp:
-        token_location = Path(tmp.name)
-    token_response = TokenResponse(**TOKEN_RESPONSE_DICT)
+def test_read_credentials_reading_locked_file(monkeypatch, tmp_path):
+    """Test that read_credentials waits to read a locked file.
 
-    yield token_response, token_location
-
-    if token_location.exists():
-        token_location.unlink()
-
-
-def test_read_credentials_reading_locked_file(monkeypatch, token_setup):
-    """Test that read_credentials is waiting to read a locked file end in error."""
-    _, token_location = token_setup
+    To keep the test simple and deterministic, we patch 'fcntl.flock' within the 'diracx.core.utils' module.
+    This will raise a BlockingIOError when attempting to read the file.
+    """
+    token_location = tmp_path / "credentials.json"
 
     # Write valid credentials to the file to ensure read_credentials attempts to lock
     token_location.write_text(CREDENTIALS_CONTENT)
 
     # Patch 'fcntl.flock' within the 'diracx.core.utils' module
+    # This will raise a BlockingIOError when attempting to read the file
     flock_calls = []
 
     def mock_flock(file, operation):
@@ -90,9 +81,13 @@ def test_read_credentials_reading_locked_file(monkeypatch, token_setup):
     assert "File is locked" in str(exc_info.value)
 
 
-def test_write_credentials_writing_locked_file(monkeypatch, token_setup):
-    """Test that write_credentials is waiting to write a locked file end in error."""
-    token_response, token_location = token_setup
+def test_write_credentials_writing_locked_file(monkeypatch, tmp_path):
+    """Test that write_credentials waits to write into a locked file.
+
+    To keep the test simple and deterministic, we patch 'fcntl.flock' within the 'diracx.core.utils' module.
+    This will raise a BlockingIOError when attempting to write to the file.
+    """
+    token_location = tmp_path / "credentials.json"
 
     # Write valid credentials to the file to ensure write_credentials attempts to lock
     token_location.write_text(CREDENTIALS_CONTENT)
@@ -109,7 +104,7 @@ def test_write_credentials_writing_locked_file(monkeypatch, token_setup):
 
     # Attempt to write credentials, expecting a BlockingIOError due to the lock
     with pytest.raises(BlockingIOError) as exc_info:
-        write_credentials(token_response, location=token_location)
+        write_credentials(TokenResponse(**TOKEN_RESPONSE_DICT), location=token_location)
 
     # Verify that flock was called (for LOCK_EX)
     assert len(flock_calls) == 1, "fcntl.flock was not called"
@@ -119,22 +114,21 @@ def test_write_credentials_writing_locked_file(monkeypatch, token_setup):
     assert "File is locked" in str(exc_info.value)
 
 
-def test_read_credentials_empty_file():
+def test_read_credentials_empty_file(tmp_path):
     """Test that read_credentials raises an appropriate error for an empty file."""
-    with NamedTemporaryFile(delete=False) as empty_file:
-        token_location = Path(empty_file.name)
+    empty_location = tmp_path / "credentials.json"
+    empty_location.touch()
 
     with pytest.raises(RuntimeError) as exc_info:
-        read_credentials(location=token_location)
+        read_credentials(location=empty_location)
 
-    token_location.unlink()
     assert "Error reading credentials:" in str(exc_info.value)
     assert "Expecting value" in str(exc_info.value)
 
 
-def test_read_credentials_missing_file():
+def test_read_credentials_missing_file(tmp_path):
     """Test that read_credentials raises an appropriate error for a missing file."""
-    missing_file = Path("/path/to/nonexistent/file.txt")
+    missing_file = tmp_path / "missing.json"
     with pytest.raises(RuntimeError) as exc_info:
         read_credentials(location=missing_file)
 
@@ -142,36 +136,34 @@ def test_read_credentials_missing_file():
     assert "No such file or directory" in str(exc_info.value)
 
 
-def test_write_credentials_unavailable_path(token_setup):
+def test_write_credentials_unavailable_path():
     """Test that write_credentials raises error when it can't create path."""
     wrong_path = Path("/wrong/path/file.txt")
-    token_response, _ = token_setup
     with pytest.raises(PermissionError):
-        write_credentials(token_response, location=wrong_path)
+        write_credentials(TokenResponse(**TOKEN_RESPONSE_DICT), location=wrong_path)
 
 
-def test_read_credentials_invalid_content():
+def test_read_credentials_invalid_content(tmp_path):
     """Test that read_credentials raises an appropriate error for a file with invalid content."""
-    with NamedTemporaryFile(delete=False) as invalid_file:
-        invalid_file.write(b"invalid content")
-        token_location = Path(invalid_file.name)
+    malformed_token_location = tmp_path / "credentials.json"
+    malformed_token_location.write_text("invalid content")
 
     with pytest.raises(RuntimeError) as exc_info:
-        read_credentials(location=token_location)
+        read_credentials(location=malformed_token_location)
 
-    token_location.unlink()
     assert "Error reading credentials:" in str(exc_info.value)
     assert "Expecting value" in str(exc_info.value)
 
 
-def test_read_credentials_valid_file(token_setup):
+def test_read_credentials_valid_file(tmp_path):
     """Test that read_credentials works correctly with a valid file."""
-    token_response, token_location = token_setup
+    token_location = tmp_path / "credentials.json"
     token_location.write_text(CREDENTIALS_CONTENT)
 
     credentials = read_credentials(location=token_location)
 
-    token_location.unlink()
+    token_response = TokenResponse(**TOKEN_RESPONSE_DICT)
+
     assert credentials.access_token == token_response.access_token
     assert credentials.expires_in < token_response.expires_in
     assert credentials.token_type == token_response.token_type

--- a/diracx-core/tests/test_utils.py
+++ b/diracx-core/tests/test_utils.py
@@ -1,6 +1,21 @@
 from __future__ import annotations
 
-from diracx.core.utils import dotenv_files_from_environment
+import fcntl
+import time
+from datetime import datetime, timedelta, timezone
+from multiprocessing import Pool
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+import pytest
+
+from diracx.core.models import TokenResponse
+from diracx.core.utils import (
+    dotenv_files_from_environment,
+    read_credentials,
+    serialize_credentials,
+    write_credentials,
+)
 
 
 def test_dotenv_files_from_environment(monkeypatch):
@@ -24,3 +39,193 @@ def test_dotenv_files_from_environment(monkeypatch):
         {"TEST_PREFIX_2a": "/c", "TEST_PREFIX": "/a", "TEST_PREFIX_1": "/b"},
     )
     assert dotenv_files_from_environment("TEST_PREFIX") == ["/a", "/b"]
+
+
+TOKEN_RESPONSE_DICT = {
+    "access_token": "test_token",
+    "expires_in": int((datetime.now(tz=timezone.utc) + timedelta(days=1)).timestamp()),
+    "token_type": "Bearer",
+    "refresh_token": "test_refresh",
+}
+CREDENTIALS_CONTENT = serialize_credentials(TokenResponse(**TOKEN_RESPONSE_DICT))
+
+
+def lock_and_read_file(file_path):
+    """Lock and read file."""
+    with open(file_path, "r") as f:
+        fcntl.flock(f, fcntl.LOCK_SH | fcntl.LOCK_NB)
+        f.read()
+        time.sleep(2)
+        fcntl.flock(f, fcntl.LOCK_UN)
+
+
+def lock_and_write_file(file_path: Path):
+    """Lock and write file."""
+    with open(file_path, "a") as f:
+        fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        f.write(CREDENTIALS_CONTENT)
+        time.sleep(2)
+        fcntl.flock(f, fcntl.LOCK_UN)
+
+
+@pytest.fixture
+def token_setup() -> tuple[TokenResponse, Path]:
+    """Setup token response and location."""
+    token_location = Path(NamedTemporaryFile().name)
+    token_response = TokenResponse(**TOKEN_RESPONSE_DICT)
+    return token_response, token_location
+
+
+@pytest.fixture
+def concurrent_access_to_lock_file():
+
+    def run_processes(proc_to_test, *, read=True):
+        """Run the process to be tested and attempt to read or write concurrently."""
+        location = proc_to_test[1]["location"]
+        error_dict = dict()
+        with Pool(2) as pool:
+            if read:
+                # Creating the file before reading it
+                with open(location, "w") as f:
+                    f.write(CREDENTIALS_CONTENT)
+                pool.apply_async(
+                    lock_and_read_file,
+                    args=(location,),
+                    error_callback=lambda e: error_callback(
+                        e, error_dict, "lock_and_read_file"
+                    ),
+                )
+            else:
+                pool.apply_async(
+                    lock_and_write_file,
+                    args=(location,),
+                    error_callback=lambda e: error_callback(
+                        e, error_dict, "lock_and_write_file"
+                    ),
+                )
+            time.sleep(1)
+            pool.apply_async(
+                proc_to_test[0],
+                kwds=proc_to_test[1],
+                error_callback=lambda e: error_callback(
+                    e, error_dict, f"{proc_to_test[0].__name__}"
+                ),
+            )
+            pool.close()
+            pool.join()
+        return error_dict
+
+    return run_processes
+
+
+def error_callback(error, error_dict, process_name):
+    """Called if the process fails."""
+    error_dict[process_name] = error
+
+
+def assert_read_credentials_error_message(exc_info):
+    assert "Error reading credentials:" in exc_info.value.args[0]
+
+
+def test_read_credentials_reading_locked_file(
+    token_setup, concurrent_access_to_lock_file
+):
+    """Test that read_credentials reading a locked file end in error."""
+    _, token_location = token_setup
+    process_to_test = (read_credentials, {"location": token_location})
+    error_dict = concurrent_access_to_lock_file(process_to_test, read=False)
+    process_name = process_to_test[0].__name__
+    if process_name in error_dict.keys():
+        assert isinstance(error_dict[process_name], RuntimeError)
+    else:
+        raise AssertionError(
+            "Expected a RuntimeError while reading locked credentials."
+        )
+
+
+def test_write_credentials_writing_locked_file(
+    token_setup, concurrent_access_to_lock_file
+):
+    """Test that write_credentials writing a locked file end in error."""
+    token_response, token_location = token_setup
+    process_to_test = (
+        write_credentials,
+        {"token_response": token_response, "location": token_location},
+    )
+    error_dict = concurrent_access_to_lock_file(process_to_test)
+    process_name = process_to_test[0].__name__
+    if process_name in error_dict.keys():
+        assert isinstance(error_dict[process_name], BlockingIOError)
+    else:
+        raise AssertionError(
+            "Expected a BlockingIOError while writing locked credentials."
+        )
+
+
+def create_temp_file(content=None) -> Path:
+    """Helper function to create a temporary file with optional content."""
+    temp_file = NamedTemporaryFile(delete=False)
+    temp_path = Path(temp_file.name)
+    temp_file.close()
+    if content is not None:
+        temp_path.write_text(content)
+    return temp_path
+
+
+def test_read_credentials_empty_file():
+    """Test that read_credentials raises an appropriate error for an empty file."""
+    temp_file = create_temp_file("")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        read_credentials(location=temp_file)
+
+    temp_file.unlink()
+    assert_read_credentials_error_message(exc_info)
+
+
+def test_write_credentials_empty_file(token_setup):
+    """Test that write_credentials raises an appropriate error for an empty file."""
+    temp_file = create_temp_file("")
+    token_response, _ = token_setup
+    write_credentials(token_response, location=temp_file)
+    temp_file.unlink()
+
+
+def test_read_credentials_missing_file():
+    """Test that read_credentials raises an appropriate error for a missing file."""
+    missing_file = Path("/path/to/nonexistent/file.txt")
+    with pytest.raises(RuntimeError) as exc_info:
+        read_credentials(location=missing_file)
+    assert_read_credentials_error_message(exc_info)
+
+
+def test_write_credentials_unavailable_path(token_setup):
+    """Test that write_credentials raises error when it can't create path."""
+    wrong_path = Path("/wrong/path/file.txt")
+    token_response, _ = token_setup
+    with pytest.raises(PermissionError):
+        write_credentials(token_response, location=wrong_path)
+
+
+def test_read_credentials_invalid_content():
+    """Test that read_credentials raises an appropriate error for a file with invalid content."""
+    temp_file = create_temp_file("invalid content")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        read_credentials(location=temp_file)
+
+    temp_file.unlink()
+    assert_read_credentials_error_message(exc_info)
+
+
+def test_read_credentials_valid_file(token_setup):
+    """Test that read_credentials works correctly with a valid file."""
+    token_response, _ = token_setup
+    temp_file = create_temp_file(content=CREDENTIALS_CONTENT)
+
+    credentials = read_credentials(location=temp_file)
+    temp_file.unlink()
+    assert credentials.access_token == token_response.access_token
+    assert credentials.expires_in < token_response.expires_in
+    assert credentials.token_type == token_response.token_type
+    assert credentials.refresh_token == token_response.refresh_token

--- a/diracx-core/tests/test_utils.py
+++ b/diracx-core/tests/test_utils.py
@@ -1,18 +1,12 @@
 from __future__ import annotations
 
 import fcntl
-import json
-import time
 from datetime import datetime, timedelta, timezone
-from multiprocessing import Pool
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from unittest.mock import patch
 
 import pytest
-from azure.core.credentials import AccessToken
 
-from diracx.client.patches.utils import get_token
 from diracx.core.models import TokenResponse
 from diracx.core.utils import (
     dotenv_files_from_environment,
@@ -54,136 +48,88 @@ TOKEN_RESPONSE_DICT = {
 CREDENTIALS_CONTENT: str = serialize_credentials(TokenResponse(**TOKEN_RESPONSE_DICT))
 
 
-def lock_and_read_file(file_path):
-    """Lock and read file."""
-    with open(file_path, "r") as f:
-        fcntl.flock(f, fcntl.LOCK_SH)
-        f.read()
-        time.sleep(2)
-        fcntl.flock(f, fcntl.LOCK_UN)
-
-
-def lock_and_write_file(file_path: Path):
-    """Lock and write file."""
-    with open(file_path, "a") as f:
-        fcntl.flock(f, fcntl.LOCK_EX)
-        f.write(CREDENTIALS_CONTENT)
-        time.sleep(2)
-        fcntl.flock(f, fcntl.LOCK_UN)
-
-
 @pytest.fixture
-def token_setup() -> tuple[TokenResponse, Path, AccessToken]:
+def token_setup() -> tuple[TokenResponse, Path]:
     """Setup token response and location."""
-    token_location = Path(NamedTemporaryFile().name)
+    with NamedTemporaryFile(delete=False) as tmp:
+        token_location = Path(tmp.name)
     token_response = TokenResponse(**TOKEN_RESPONSE_DICT)
-    access_token = AccessToken(token_response.access_token, token_response.expires_in)
 
-    return token_response, token_location, access_token
+    yield token_response, token_location
 
-
-@pytest.fixture
-def concurrent_access_to_lock_file():
-
-    def run_processes(proc_to_test, *, read=True):
-        """Run the process to be tested and attempt to read or write concurrently."""
-        location = proc_to_test[1]["location"]
-        error_dict = dict()
-        with Pool(2) as pool:
-            if read:
-                # Creating the file before reading it
-                with open(location, "w") as f:
-                    f.write(CREDENTIALS_CONTENT)
-                pool.apply_async(
-                    lock_and_read_file,
-                    args=(location,),
-                    error_callback=lambda e: error_callback(
-                        e, error_dict, "lock_and_read_file"
-                    ),
-                )
-            else:
-                pool.apply_async(
-                    lock_and_write_file,
-                    args=(location,),
-                    error_callback=lambda e: error_callback(
-                        e, error_dict, "lock_and_write_file"
-                    ),
-                )
-            time.sleep(1)
-            result = pool.apply_async(
-                proc_to_test[0],
-                kwds=proc_to_test[1],
-                error_callback=lambda e: error_callback(
-                    e, error_dict, f"{proc_to_test[0].__name__}"
-                ),
-            )
-            pool.close()
-            pool.join()
-            res = result.get(timeout=1)
-        return res, error_dict
-
-    return run_processes
+    if token_location.exists():
+        token_location.unlink()
 
 
-def error_callback(error, error_dict, process_name):
-    """Called if the process fails."""
-    error_dict[process_name] = error
-
-
-def assert_read_credentials_error_message(exc_info):
-    assert "Error reading credentials:" in exc_info.value.args[0]
-
-
-def create_temp_file(content=None) -> Path:
-    """Helper function to create a temporary file with optional content."""
-    temp_file = NamedTemporaryFile(delete=False)
-    temp_path = Path(temp_file.name)
-    temp_file.close()
-    if content is not None:
-        temp_path.write_text(content)
-    return temp_path
-
-
-def test_read_credentials_reading_locked_file(
-    token_setup, concurrent_access_to_lock_file
-):
+def test_read_credentials_reading_locked_file(monkeypatch, token_setup):
     """Test that read_credentials is waiting to read a locked file end in error."""
-    _, token_location, _ = token_setup
-    process_to_test = (read_credentials, {"location": token_location})
-    _, error_dict = concurrent_access_to_lock_file(process_to_test, read=False)
-    assert not error_dict
+    _, token_location = token_setup
+
+    # Write valid credentials to the file to ensure read_credentials attempts to lock
+    token_location.write_text(CREDENTIALS_CONTENT)
+
+    # Patch 'fcntl.flock' within the 'diracx.core.utils' module
+    flock_calls = []
+
+    def mock_flock(file, operation):
+        flock_calls.append((file, operation))
+        if operation == fcntl.LOCK_SH:
+            raise BlockingIOError("File is locked")
+
+    monkeypatch.setattr("diracx.core.utils.fcntl.flock", mock_flock)
+
+    # Attempt to read credentials, expecting a BlockingIOError due to the lock
+    with pytest.raises(BlockingIOError) as exc_info:
+        read_credentials(location=token_location)
+
+    # Verify that flock was called with LOCK_SH
+    assert len(flock_calls) == 1, "fcntl.flock was not called"
+    assert (
+        flock_calls[-1][1] == fcntl.LOCK_SH
+    ), f"Expected LOCK_SH, got {flock_calls[-1][1]}"
+    assert "File is locked" in str(exc_info.value)
 
 
-def test_write_credentials_writing_locked_file(
-    token_setup, concurrent_access_to_lock_file
-):
+def test_write_credentials_writing_locked_file(monkeypatch, token_setup):
     """Test that write_credentials is waiting to write a locked file end in error."""
-    token_response, token_location, _ = token_setup
-    process_to_test = (
-        write_credentials,
-        {"token_response": token_response, "location": token_location},
-    )
-    _, error_dict = concurrent_access_to_lock_file(process_to_test)
-    assert not error_dict
+    token_response, token_location = token_setup
+
+    # Write valid credentials to the file to ensure write_credentials attempts to lock
+    token_location.write_text(CREDENTIALS_CONTENT)
+
+    # Patch 'fcntl.flock' within the 'diracx.core.utils' module
+    flock_calls = []
+
+    def mock_flock(file, operation):
+        flock_calls.append((file, operation))
+        if operation == fcntl.LOCK_EX:
+            raise BlockingIOError("File is locked")
+
+    monkeypatch.setattr("diracx.core.utils.fcntl.flock", mock_flock)
+
+    # Attempt to write credentials, expecting a BlockingIOError due to the lock
+    with pytest.raises(BlockingIOError) as exc_info:
+        write_credentials(token_response, location=token_location)
+
+    # Verify that flock was called (for LOCK_EX)
+    assert len(flock_calls) == 1, "fcntl.flock was not called"
+    assert (
+        flock_calls[-1][1] == fcntl.LOCK_EX
+    ), f"Expected LOCK_EX, got {flock_calls[-1][1]}"
+    assert "File is locked" in str(exc_info.value)
 
 
 def test_read_credentials_empty_file():
     """Test that read_credentials raises an appropriate error for an empty file."""
-    temp_file = create_temp_file("")
+    with NamedTemporaryFile(delete=False) as empty_file:
+        token_location = Path(empty_file.name)
 
     with pytest.raises(RuntimeError) as exc_info:
-        read_credentials(location=temp_file)
+        read_credentials(location=token_location)
 
-    temp_file.unlink()
-    assert_read_credentials_error_message(exc_info)
-
-
-def test_write_credentials_empty_file(token_setup):
-    """Test that write_credentials raises an appropriate error for an empty file."""
-    temp_file = create_temp_file("")
-    token_response, _, _ = token_setup
-    write_credentials(token_response, location=temp_file)
-    temp_file.unlink()
+    token_location.unlink()
+    assert "Error reading credentials:" in str(exc_info.value)
+    assert "Expecting value" in str(exc_info.value)
 
 
 def test_read_credentials_missing_file():
@@ -191,192 +137,42 @@ def test_read_credentials_missing_file():
     missing_file = Path("/path/to/nonexistent/file.txt")
     with pytest.raises(RuntimeError) as exc_info:
         read_credentials(location=missing_file)
-    assert_read_credentials_error_message(exc_info)
+
+    assert "Error reading credentials:" in str(exc_info.value)
+    assert "No such file or directory" in str(exc_info.value)
 
 
 def test_write_credentials_unavailable_path(token_setup):
     """Test that write_credentials raises error when it can't create path."""
     wrong_path = Path("/wrong/path/file.txt")
-    token_response, _, _ = token_setup
+    token_response, _ = token_setup
     with pytest.raises(PermissionError):
         write_credentials(token_response, location=wrong_path)
 
 
 def test_read_credentials_invalid_content():
     """Test that read_credentials raises an appropriate error for a file with invalid content."""
-    temp_file = create_temp_file("invalid content")
+    with NamedTemporaryFile(delete=False) as invalid_file:
+        invalid_file.write(b"invalid content")
+        token_location = Path(invalid_file.name)
 
     with pytest.raises(RuntimeError) as exc_info:
-        read_credentials(location=temp_file)
+        read_credentials(location=token_location)
 
-    temp_file.unlink()
-    assert_read_credentials_error_message(exc_info)
+    token_location.unlink()
+    assert "Error reading credentials:" in str(exc_info.value)
+    assert "Expecting value" in str(exc_info.value)
 
 
 def test_read_credentials_valid_file(token_setup):
     """Test that read_credentials works correctly with a valid file."""
-    token_response, _, _ = token_setup
-    temp_file = create_temp_file(content=CREDENTIALS_CONTENT)
+    token_response, token_location = token_setup
+    token_location.write_text(CREDENTIALS_CONTENT)
 
-    credentials = read_credentials(location=temp_file)
-    temp_file.unlink()
+    credentials = read_credentials(location=token_location)
+
+    token_location.unlink()
     assert credentials.access_token == token_response.access_token
     assert credentials.expires_in < token_response.expires_in
     assert credentials.token_type == token_response.token_type
     assert credentials.refresh_token == token_response.refresh_token
-
-
-# Testing get_token:
-
-
-def test_get_token_accessing_lock_file(token_setup, concurrent_access_to_lock_file):
-    """Test get_token is waiting to read token from locked file."""
-    token_response, token_location, _ = token_setup
-    process_to_test = (
-        get_token,
-        {
-            "location": token_location,
-            "token": None,
-            "token_endpoint": "/endpoint",
-            "client_id": "ID",
-            "verify": False,
-        },
-    )
-    result, error_dict = concurrent_access_to_lock_file(process_to_test, read=False)
-    assert not error_dict
-    assert isinstance(result, AccessToken)
-    assert result.token == token_response.access_token
-
-
-def test_get_token_valid_input_token(token_setup):
-    """Test that get_token return the valid token."""
-    _, token_location, access_token = token_setup
-    result = get_token(
-        location=token_location,
-        token=access_token,
-        token_endpoint="",
-        client_id="ID",
-        verify=False,
-    )
-    assert result == access_token
-
-
-def test_get_token_valid_input_credential():
-    """Test that get_token return the valid token given in the credential file."""
-    temp_file = create_temp_file(content=CREDENTIALS_CONTENT)
-    result = get_token(
-        location=temp_file, token=None, token_endpoint="", client_id="ID", verify=False
-    )
-    temp_file.unlink()
-    assert isinstance(result, AccessToken)
-
-
-def test_get_token_input_token_not_exists(token_setup):
-    _, token_location, _ = token_setup
-    result = get_token(
-        location=token_location,
-        token=None,
-        token_endpoint="",
-        client_id="ID",
-        verify=False,
-    )
-    assert result is None
-
-
-def test_get_token_invalid_input(token_setup):
-    """Test that get_token manage invalid input token."""
-    # Test wrong key in credential
-    token_response, _, _ = token_setup
-    wrong_credential_content = "'{\"wrong_key\": False}'"
-    temp_file = create_temp_file(content=wrong_credential_content)
-    result = get_token(
-        location=temp_file, token=None, token_endpoint="", client_id="ID", verify=False
-    )
-    temp_file.unlink()
-    assert result is None
-
-    # Test with invalid token date
-    token_response = TOKEN_RESPONSE_DICT.copy()
-    token_response["expires_in"] = int(datetime.now(tz=timezone.utc).timestamp())
-    credential_content = json.dumps(token_response)
-    temp_file = create_temp_file(content=credential_content)
-    result = get_token(
-        location=temp_file, token=None, token_endpoint="", client_id="ID", verify=False
-    )
-    temp_file.unlink()
-    assert result is None
-
-
-def test_get_token_refresh_valid():
-    """Test that get_token refresh a valid outdated token."""
-    token_response = TOKEN_RESPONSE_DICT.copy()
-    # the future content of the refreshed token
-    refresh_token = TokenResponse(**token_response)
-    # Create expired credential file
-    token_response["expires_on"] = int(
-        (datetime.now(tz=timezone.utc) - timedelta(seconds=10)).timestamp()
-    )
-    token_response.pop("expires_in")
-    credentials = json.dumps(token_response)
-    temp_file = create_temp_file(content=credentials)
-
-    with (
-        patch(
-            "diracx.client.patches.utils.is_refresh_token_valid", return_value=True
-        ) as mock_is_refresh_valid,
-        patch(
-            "diracx.client.patches.utils.refresh_token", return_value=refresh_token
-        ) as mock_refresh_token,
-    ):
-        result = get_token(
-            location=temp_file,
-            token=None,
-            token_endpoint="",
-            client_id="ID",
-            verify=False,
-        )
-
-    # Verify that the credential fil has been refreshed:
-    with open(temp_file, "r") as f:
-        content = f.read()
-        assert content == serialize_credentials(refresh_token)
-
-    temp_file.unlink()
-
-    assert result is not None
-    assert isinstance(result, AccessToken)
-    assert result.token == refresh_token.access_token
-    assert result.expires_on > refresh_token.expires_in
-    mock_is_refresh_valid.assert_called_once_with(refresh_token.refresh_token)
-    mock_refresh_token.assert_called_once_with(
-        "", "ID", refresh_token.refresh_token, verify=False
-    )
-
-
-def test_get_token_refresh_invalid():
-    """Test that get_token manages an invalid refresh token."""
-    token_response = TOKEN_RESPONSE_DICT.copy()
-    refresh_token = TokenResponse(**token_response)
-    token_response["expires_on"] = int(
-        (datetime.now(tz=timezone.utc) - timedelta(seconds=10)).timestamp()
-    )
-    token_response.pop("expires_in")
-    credentials = json.dumps(token_response)
-    temp_file = create_temp_file(content=credentials)
-
-    with (
-        patch(
-            "diracx.client.patches.utils.is_refresh_token_valid", return_value=False
-        ) as mock_is_refresh_valid,
-    ):
-        result = get_token(
-            location=temp_file,
-            token=None,
-            token_endpoint="",
-            client_id="ID",
-            verify=False,
-        )
-
-    temp_file.unlink()
-    assert result is None
-    mock_is_refresh_valid.assert_called_once_with(refresh_token.refresh_token)


### PR DESCRIPTION
closes #133

Tests can be performed on `read/write_credentials`, and the client (probably simpler if we do it through `get_token` directly). Test cases:
- [x] (`read/write_credentials` and `get_token`) multiple processes attempting to read or write to the credentials file simultaneously.
- [x] (`read/write_credentials`) credentials file is missing, empty, invalid.
- [x] (`get_token`) token exists and is valid, credentials file is missing, empty, invalid, token needs to be refreshed, refresh token valid/invalid.
