### PR TITLE
feat: allow to request specific properties when logging in

### DIFF
--- a/diracx-routers/src/diracx/routers/auth/token.py
+++ b/diracx-routers/src/diracx/routers/auth/token.py
@@ -384,7 +384,7 @@ async def exchange_token(
             f"User is not a member of the requested group ({preferred_username}, {dirac_group})"
         )
 
-    allowed_user_properties = get_allowed_user_properties(config, user_info, vo)
+    allowed_user_properties = get_allowed_user_properties(config, sub, vo)
     if not set(properties).issubset(allowed_user_properties):
         raise ValueError(
             f"{set(properties) - allowed_user_properties} are not valid properties for user {preferred_username}, "

--- a/diracx-routers/src/diracx/routers/auth/utils.py
+++ b/diracx-routers/src/diracx/routers/auth/utils.py
@@ -226,12 +226,6 @@ def parse_and_validate_scope(
             f"{set(properties)-set(available_properties)} are not valid properties"
         )
 
-    if not set(properties).issubset(allowed_properties):
-        raise PermissionError(
-            f"Attempted to access properties {set(properties)-set(allowed_properties)} which are not allowed."
-            f" Allowed properties are: {allowed_properties}"
-        )
-
     return {
         "group": group,
         "properties": sorted(properties),

--- a/diracx-routers/src/diracx/routers/auth/utils.py
+++ b/diracx-routers/src/diracx/routers/auth/utils.py
@@ -36,7 +36,7 @@ class GrantType(StrEnum):
 
 class ScopeInfoDict(TypedDict):
     group: str
-    properties: list[str]
+    properties: set[str]
     vo: str
 
 
@@ -217,9 +217,7 @@ def parse_and_validate_scope(
             raise ValueError(f"{group} not in {vo} groups")
 
     allowed_properties = config.Registry[vo].Groups[group].Properties
-    if not properties:
-        # If there are no properties set get the defaults from the CS
-        properties = [str(p) for p in allowed_properties]
+    properties.extend([str(p) for p in allowed_properties])
 
     if not set(properties).issubset(available_properties):
         raise ValueError(
@@ -228,7 +226,7 @@ def parse_and_validate_scope(
 
     return {
         "group": group,
-        "properties": sorted(properties),
+        "properties": set(sorted(properties)),
         "vo": vo,
     }
 

--- a/diracx-routers/src/diracx/routers/utils/users.py
+++ b/diracx-routers/src/diracx/routers/utils/users.py
@@ -8,7 +8,6 @@ from fastapi.security import OpenIdConnect
 from pydantic import BaseModel, Field
 from pydantic_settings import SettingsConfigDict
 
-from diracx.core.config.schema import UserConfig
 from diracx.core.models import UserInfo
 from diracx.core.properties import SecurityProperty
 from diracx.core.settings import FernetKey, ServiceSettingsBase, TokenSigningKey
@@ -120,12 +119,10 @@ async def verify_dirac_access_token(
     )
 
 
-def get_allowed_user_properties(
-    config: Config, user_info: UserConfig, vo: str
-) -> set[SecurityProperty]:
+def get_allowed_user_properties(config: Config, sub, vo: str) -> set[SecurityProperty]:
     """Retrieve all properties of groups a user is registered in."""
     allowed_user_properties = set()
     for group in config.Registry[vo].Groups:
-        if user_info.PreferedUsername in config.Registry[vo].Groups[group].Users:
+        if sub in config.Registry[vo].Groups[group].Users:
             allowed_user_properties.update(config.Registry[vo].Groups[group].Properties)
     return allowed_user_properties

--- a/diracx-routers/tests/auth/test_legacy_exchange.py
+++ b/diracx-routers/tests/auth/test_legacy_exchange.py
@@ -79,7 +79,9 @@ async def test_valid(test_client, legacy_credentials, expires_seconds):
     assert user_info["sub"] == "lhcb:b824d4dc-1f9d-4ee8-8df5-c0ae55d46041"
     assert user_info["vo"] == "lhcb"
     assert user_info["dirac_group"] == "lhcb_user"
-    assert user_info["properties"] == ["NormalUser", "PrivateLimitedDelegation"]
+    assert sorted(user_info["properties"]) == sorted(
+        ["PrivateLimitedDelegation", "NormalUser"]
+    )
 
 
 async def test_refresh_token(test_client, legacy_credentials):

--- a/diracx-testing/src/diracx/testing/__init__.py
+++ b/diracx-testing/src/diracx/testing/__init__.py
@@ -444,6 +444,10 @@ def with_config_repo(tmp_path_factory):
                                 "c935e5ed-2g0e-5ff9-9eg6-d1bf66e57152",
                             ],
                         },
+                        "lhcb_prmgr": {
+                            "Properties": ["NormalUser", "ProductionManagement"],
+                            "Users": ["b824d4dc-1f9d-4ee8-8df5-c0ae55d46041"],
+                        },
                         "lhcb_tokenmgr": {
                             "Properties": ["NormalUser", "ProxyManagement"],
                             "Users": ["c935e5ed-2g0e-5ff9-9eg6-d1bf66e57152"],


### PR DESCRIPTION
Closes https://github.com/DIRACGrid/diracx/issues/148

Use cases (scope we provide to the `auth` endpoints :arrow_right: claims we should obtain from the token)
- `<vo>` :arrow_right: `<vo> <default group> <properties of default group>`
- `<vo> <group>` :arrow_right: `<vo> <group> <properties of group>`
- `<vo> <properties>` :arrow_right: `<vo> <default group> <properties of default group + properties>`
- `<vo> <group> <properties>` :arrow_right: `<vo> <group> <properties of group + properties>`
 

 