### PR TITLE
Requests → httpx

### DIFF
--- a/diracx-cli/src/diracx/cli/auth.py
+++ b/diracx-cli/src/diracx/cli/auth.py
@@ -5,6 +5,7 @@ __all__ = ("app",)
 import asyncio
 import json
 import os
+from asyncio import sleep
 from datetime import datetime, timedelta, timezone
 from typing import Annotated, Optional
 
@@ -92,7 +93,7 @@ async def login(
                 if response.error == "authorization_pending":
                     # TODO: Setting more than 5 seconds results in an error
                     # Related to keep-alive disconnects from uvicon (--timeout-keep-alive)
-                    await asyncio.sleep(2)
+                    await sleep(2)
                     continue
                 raise RuntimeError(f"Device flow failed with {response}")
             break

--- a/diracx-client/pyproject.toml
+++ b/diracx-client/pyproject.toml
@@ -12,12 +12,12 @@ classifiers = [
     "Topic :: Scientific/Engineering",
     "Topic :: System :: Distributed Computing",
 ]
-dependencies = ["azure-core", "diracx-core", "isodate", "requests"]
+dependencies = ["azure-core", "diracx-core", "isodate", "httpx"]
 dynamic = ["version"]
 
 [project.optional-dependencies]
 testing = ["diracx-testing"]
-types = ["types-requests"]
+types = []
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/diracx-client/src/diracx/client/generated/_patch.py
+++ b/diracx-client/src/diracx/client/generated/_patch.py
@@ -13,7 +13,7 @@ from datetime import datetime, timezone
 import importlib.util
 import json
 import jwt
-import requests
+import httpx
 
 from pathlib import Path
 from typing import Any, Dict, List, Optional, cast

--- a/diracx-client/src/diracx/client/patches/utils.py
+++ b/diracx-client/src/diracx/client/patches/utils.py
@@ -7,8 +7,8 @@ import fcntl
 import json
 import os
 from diracx.core.utils import EXPIRES_GRACE_SECONDS, serialize_credentials
+import httpx
 import jwt
-import requests
 
 from datetime import datetime, timezone
 from importlib.metadata import PackageNotFoundError, distribution
@@ -43,11 +43,11 @@ def get_openid_configuration(
     endpoint: str, *, verify: bool | str = True
 ) -> Dict[str, str]:
     """Get the openid configuration from the .well-known endpoint"""
-    response = requests.get(
+    response = httpx.get(
         url=parse.urljoin(endpoint, ".well-known/openid-configuration"),
         verify=verify,
     )
-    if not response.ok:
+    if not response.is_success:
         raise RuntimeError("Cannot fetch any information from the .well-known endpoint")
     return response.json()
 
@@ -123,7 +123,7 @@ def refresh_token(
     verify: bool | str = True,
 ) -> TokenResponse:
     """Refresh the access token using the refresh_token flow."""
-    response = requests.post(
+    response = httpx.post(
         url=token_endpoint,
         data={
             "client_id": client_id,

--- a/diracx-core/tests/test_s3.py
+++ b/diracx-core/tests/test_s3.py
@@ -124,12 +124,18 @@ async def test_bucket(minio_client):
     "content,checksum,size,expected_error",
     [
         # Make sure a valid request works
-        [*_random_file(128), 128, None],
+        pytest.param(*_random_file(128), 128, None, id="valid"),
         # Check with invalid sizes
-        [*_random_file(128), 127, "exceeds the maximum"],
-        [*_random_file(128), 129, "smaller than the minimum"],
+        pytest.param(*_random_file(128), 127, "exceeds the maximum", id="maximum"),
+        pytest.param(*_random_file(128), 129, "smaller than the minimum", id="minimum"),
         # Check with invalid checksum
-        [_random_file(128)[0], _random_file(128)[1], 128, "ContentChecksumMismatch"],
+        pytest.param(
+            _random_file(128)[0],
+            _random_file(128)[1],
+            128,
+            "ContentChecksumMismatch",
+            id="checksum",
+        ),
     ],
 )
 async def test_presigned_upload_minio(

--- a/diracx-routers/pyproject.toml
+++ b/diracx-routers/pyproject.toml
@@ -43,7 +43,6 @@ types = [
     "types-cachetools",
     "types-python-dateutil",
     "types-PyYAML",
-    "types-requests",
 ]
 
 [project.entry-points."diracx.services"]

--- a/diracx-routers/tests/jobs/test_sandboxes.py
+++ b/diracx-routers/tests/jobs/test_sandboxes.py
@@ -5,8 +5,8 @@ import secrets
 from copy import deepcopy
 from io import BytesIO
 
+import httpx
 import pytest
-import requests
 from fastapi.testclient import TestClient
 
 from diracx.routers.auth.token import create_token
@@ -57,7 +57,7 @@ def test_upload_then_download(
 
     # Actually upload the file
     files = {"file": ("file", BytesIO(data))}
-    r = requests.post(upload_info["url"], data=upload_info["fields"], files=files)
+    r = httpx.post(upload_info["url"], data=upload_info["fields"], files=files)
     assert r.status_code == 204, r.text
 
     # Make sure we can download it and get the same data back
@@ -65,7 +65,7 @@ def test_upload_then_download(
     assert r.status_code == 200, r.text
     download_info = r.json()
     assert download_info["expires_in"] > 5
-    r = requests.get(download_info["url"])
+    r = httpx.get(download_info["url"])
     assert r.status_code == 200, r.text
     assert r.content == data
 

--- a/diracx-testing/pyproject.toml
+++ b/diracx-testing/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "pytest-asyncio",
     "pytest-cov",
     "pytest-xdist",
+    "httpx",
 ]
 dynamic = ["version"]
 

--- a/diracx-testing/src/diracx/testing/utils.py
+++ b/diracx-testing/src/diracx/testing/utils.py
@@ -635,7 +635,7 @@ async def test_login(monkeypatch, capfd, cli_env):
         assert poll_attempts <= 100
 
         # Reduce the sleep duration to zero to speed up the test
-        await unpatched_sleep(0)
+        await unpatched_sleep(0.1)
 
     # We monkeypatch asyncio.sleep to provide a hook to run the actions that
     # would normally be done by a user. This includes capturing the login URL

--- a/diracx-testing/src/diracx/testing/utils.py
+++ b/diracx-testing/src/diracx/testing/utils.py
@@ -635,7 +635,7 @@ async def test_login(monkeypatch, capfd, cli_env):
         assert poll_attempts <= 100
 
         # Reduce the sleep duration to zero to speed up the test
-        await unpatched_sleep(0.1)
+        await unpatched_sleep(0.0)
 
     # We monkeypatch asyncio.sleep to provide a hook to run the actions that
     # would normally be done by a user. This includes capturing the login URL
@@ -650,7 +650,7 @@ async def test_login(monkeypatch, capfd, cli_env):
 
     # Run the login command
     with monkeypatch.context() as m:
-        m.setattr("asyncio.sleep", fake_sleep)
+        m.setattr("diracx.cli.auth.sleep", fake_sleep)
         await cli.auth.login(vo="diracAdmin", group=None, property=None)
     captured = capfd.readouterr()
     assert "Login successful!" in captured.out

--- a/extensions/gubbins/gubbins-client/pyproject.toml
+++ b/extensions/gubbins/gubbins-client/pyproject.toml
@@ -17,7 +17,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 testing = ["diracx-client[testing]", "diracx-testing"]
-types = ["types-requests"]
+types = []
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/extensions/gubbins/gubbins-routers/pyproject.toml
+++ b/extensions/gubbins/gubbins-routers/pyproject.toml
@@ -30,7 +30,6 @@ types = [
     "types-cachetools",
     "types-python-dateutil",
     "types-PyYAML",
-    "types-requests",
 ]
 
 [project.entry-points."diracx.services"]


### PR DESCRIPTION
Notes for reviewers:

* The `get_openid_config` seems to be not covered by tests, see 55522d5
* requests was imported in the patch file for the autogenerated client code, but marked as not used. See [7de3db1](https://github.com/DIRACGrid/diracx/pull/374/commits/7de3db13b7f01ca86b8eba9de038f9e7849f1cfc)
* The async client uses the sync `get_openid_config`, should probably be using its own async version


Fixes #338 