### PR TITLE
fix(diracx-routers): search endpoint does not display jobs in GlobalMonitoring is set to False

### DIFF
--- a/diracx-routers/src/diracx/routers/jobs/query.py
+++ b/diracx-routers/src/diracx/routers/jobs/query.py
@@ -178,7 +178,11 @@ async def search(
             {
                 "parameter": "Owner",
                 "operator": ScalarSearchOperator.EQUAL,
-                "value": user_info.sub,
+                # TODO-385: https://github.com/DIRACGrid/diracx/issues/385
+                # The value shoud be user_info.sub,
+                # but since we historically rely on the preferred_username
+                # we will keep using the preferred_username for now.
+                "value": user_info.preferred_username,
             }
         )
 


### PR DESCRIPTION
- The current code currently reflects the behavior we want to have once the migration will be over, but it cannot work as of now.
- We still have to deal with the `preferred_username` field, so this PR temporarily solves the issue. 

More details are explained in https://github.com/DIRACGrid/diracx/issues/385