### PR TITLE
fix(db): submission datetime

### DIFF
--- a/diracx-db/src/diracx/db/sql/utils/base.py
+++ b/diracx-db/src/diracx/db/sql/utils/base.py
@@ -232,7 +232,7 @@ def find_time_resolution(value):
     if isinstance(value, datetime):
         return None, value
     if match := re.fullmatch(
-        r"\d{4}(-\d{2}(-\d{2}(([ T])\d{2}(:\d{2}(:\d{2}(\.\d{6}Z?)?)?)?)?)?)?", value
+        r"\d{4}(-\d{2}(-\d{2}(([ T])\d{2}(:\d{2}(:\d{2}(\.\d{1,6}Z?)?)?)?)?)?)?", value
     ):
         if match.group(6):
             precision, pattern = "SECOND", r"\1-\2-\3 \4:\5:\6"
@@ -249,7 +249,7 @@ def find_time_resolution(value):
         return (
             precision,
             re.sub(
-                r"^(\d{4})-?(\d{2})?-?(\d{2})?[ T]?(\d{2})?:?(\d{2})?:?(\d{2})?\.?(\d{6})?Z?$",
+                r"^(\d{4})-?(\d{2})?-?(\d{2})?[ T]?(\d{2})?:?(\d{2})?:?(\d{2})?\.?(\d{1,6})?Z?$",
                 pattern,
                 value,
             ),

--- a/diracx-db/src/diracx/db/sql/utils/functions.py
+++ b/diracx-db/src/diracx/db/sql/utils/functions.py
@@ -47,7 +47,8 @@ class date_trunc(expression.FunctionElement):  # noqa: N801
     """
 
     type = DateTime()
-    inherit_cache = True
+    # Cache does not work as intended with time resolution values, so we disable it
+    inherit_cache = False
 
     def __init__(self, *args, time_resolution, **kwargs) -> None:
         super().__init__(*args, **kwargs)

--- a/diracx-routers/pyproject.toml
+++ b/diracx-routers/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-testing = ["diracx-testing", "moto[server]", "pytest-httpx"]
+testing = ["diracx-testing", "moto[server]", "pytest-httpx", "freezegun",]
 types = [
     "boto3-stubs",
     "types-aiobotocore[essential]",


### PR DESCRIPTION
Closes https://github.com/DIRACGrid/diracx/issues/341

Note: 
- I disable `inherit_cache` in `date_trunc` because I had weird results when calling the `search` endpoint multiple times in a row. 
- The `time_resolution` does not seem to be part of the cached keys and whatever is the first `time_resolution` to be used becomes the "reference" in subsequent calls.

  Example:
  ```sql
  WHERE strftime(?, "Jobs"."SubmissionTime") = ?) AS anon_1
  ```
  Here `?` seems to be replaced with the first cached value instead of the one we want to use.  

- I haven't found an easy way to include the `time_resolution` parameter in the cache keys, but my knowledge of `sqlalchemy` is very limited, and I might have overlooked something. 
- If you want to easily reproduce the issue, you can just switch `inherit_cache` to `True` and execute the tests.



