### PR TITLE
chore: remove __all__ from non- __init__ files

### DIFF
--- a/diracx-api/src/diracx/api/jobs.py
+++ b/diracx-api/src/diracx/api/jobs.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-__all__ = ("create_sandbox", "download_sandbox")
-
 import hashlib
 import logging
 import os

--- a/diracx-api/src/diracx/api/utils.py
+++ b/diracx-api/src/diracx/api/utils.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-__all__ = ("with_client",)
-
 from functools import wraps
 
 from diracx.client.aio import DiracClient

--- a/diracx-cli/src/diracx/cli/auth.py
+++ b/diracx-cli/src/diracx/cli/auth.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-__all__ = ("app",)
-
 import asyncio
 import json
 import os

--- a/diracx-cli/src/diracx/cli/config.py
+++ b/diracx-cli/src/diracx/cli/config.py
@@ -2,8 +2,6 @@
 # from __future__ import annotations
 from __future__ import annotations
 
-__all__ = ("dump",)
-
 import json
 
 from rich import print_json

--- a/diracx-cli/src/diracx/cli/jobs.py
+++ b/diracx-cli/src/diracx/cli/jobs.py
@@ -2,8 +2,6 @@
 # from __future__ import annotations
 from __future__ import annotations
 
-__all__ = ("app",)
-
 import json
 import re
 from typing import Annotated, cast

--- a/diracx-cli/src/diracx/cli/utils.py
+++ b/diracx-cli/src/diracx/cli/utils.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-__all__ = ("AsyncTyper",)
-
 from asyncio import run
 from functools import wraps
 

--- a/diracx-core/src/diracx/core/extensions.py
+++ b/diracx-core/src/diracx/core/extensions.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-__all__ = ("select_from_extension",)
-
 import os
 from collections import defaultdict
 from importlib.metadata import EntryPoint, entry_points

--- a/diracx-core/src/diracx/core/preferences.py
+++ b/diracx-core/src/diracx/core/preferences.py
@@ -1,18 +1,13 @@
 from __future__ import annotations
 
-from pydantic import field_validator
-from pydantic_settings import SettingsConfigDict
-
-__all__ = ("DiracxPreferences", "OutputFormats", "get_diracx_preferences")
-
 import logging
 import sys
 from enum import Enum, StrEnum
 from functools import lru_cache
 from pathlib import Path
 
-from pydantic import AnyHttpUrl, Field
-from pydantic_settings import BaseSettings
+from pydantic import AnyHttpUrl, Field, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from .utils import dotenv_files_from_environment
 

--- a/diracx-core/src/diracx/core/s3.py
+++ b/diracx-core/src/diracx/core/s3.py
@@ -2,12 +2,6 @@
 
 from __future__ import annotations
 
-__all__ = (
-    "s3_bucket_exists",
-    "s3_object_exists",
-    "generate_presigned_upload",
-)
-
 import base64
 from typing import TYPE_CHECKING, TypedDict, cast
 

--- a/diracx-core/src/diracx/core/settings.py
+++ b/diracx-core/src/diracx/core/settings.py
@@ -1,14 +1,5 @@
 from __future__ import annotations
 
-from diracx.core.properties import SecurityProperty
-from diracx.core.s3 import s3_bucket_exists
-
-__all__ = (
-    "SqlalchemyDsn",
-    "LocalFileUrl",
-    "ServiceSettingsBase",
-)
-
 import contextlib
 from collections.abc import AsyncIterator
 from pathlib import Path
@@ -30,6 +21,9 @@ from pydantic import (
     UrlConstraints,
 )
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from diracx.core.properties import SecurityProperty
+from diracx.core.s3 import s3_bucket_exists
 
 if TYPE_CHECKING:
     from types_aiobotocore_s3.client import S3Client

--- a/diracx-db/src/diracx/db/os/utils.py
+++ b/diracx-db/src/diracx/db/os/utils.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-__all__ = ("BaseOSDB",)
-
 import contextlib
 import json
 import logging

--- a/diracx-routers/src/diracx/routers/dependencies.py
+++ b/diracx-routers/src/diracx/routers/dependencies.py
@@ -1,17 +1,5 @@
 from __future__ import annotations
 
-__all__ = (
-    "Config",
-    "AuthDB",
-    "JobDB",
-    "JobLoggingDB",
-    "SandboxMetadataDB",
-    "TaskQueueDB",
-    "PilotAgentsDB",
-    "add_settings_annotation",
-    "AvailableSecurityProperties",
-)
-
 from typing import Annotated, TypeVar
 
 from fastapi import Depends

--- a/diracx-testing/src/diracx/testing/mock_osdb.py
+++ b/diracx-testing/src/diracx/testing/mock_osdb.py
@@ -1,10 +1,5 @@
 from __future__ import annotations
 
-__all__ = (
-    "MockOSDBMixin",
-    "fake_available_osdb_implementations",
-)
-
 import contextlib
 from datetime import datetime, timezone
 from functools import partial


### PR DESCRIPTION
I do not see why they would be useful, but convince me otherwise.