### PR TITLE
feat: Ensure SBAccessPolicy verifies the user owns the sandbox

### DIFF
--- a/diracx-db/src/diracx/db/sql/sandbox_metadata/db.py
+++ b/diracx-db/src/diracx/db/sql/sandbox_metadata/db.py
@@ -30,6 +30,14 @@ class SandboxMetadataDB(BaseSQLDB):
         )
         return (await self.conn.execute(stmt)).scalar_one_or_none()
 
+    async def get_sandbox_owner_id(self, pfn: str) -> int | None:
+        """Get the id of the owner of a sandbox."""
+        stmt = select(SBOwners.OwnerID).where(
+            SBOwners.OwnerID == SandBoxes.OwnerId,
+            SandBoxes.SEPFN == pfn,
+        )
+        return (await self.conn.execute(stmt)).scalar_one_or_none()
+
     async def insert_owner(self, user: UserInfo) -> int:
         stmt = insert(SBOwners).values(
             Owner=user.preferred_username,

--- a/diracx-routers/src/diracx/routers/jobs/sandboxes.py
+++ b/diracx-routers/src/diracx/routers/jobs/sandboxes.py
@@ -73,6 +73,7 @@ async def initiate_sandbox_upload(
 async def get_sandbox_file(
     pfn: Annotated[str, Query(max_length=256, pattern=SANDBOX_PFN_REGEX)],
     settings: SandboxStoreSettings,
+    sandbox_metadata_db: SandboxMetadataDB,
     user_info: Annotated[AuthorizedUserInfo, Depends(verify_dirac_access_token)],
     check_permissions: CheckSandboxPolicyCallable,
 ) -> SandboxDownloadResponse:
@@ -92,6 +93,7 @@ async def get_sandbox_file(
     )
     await check_permissions(
         action=ActionType.READ,
+        sandbox_metadata_db=sandbox_metadata_db,
         pfns=[short_pfn],
         required_prefix=required_prefix,
     )

--- a/diracx-routers/src/diracx/routers/jobs/sandboxes.py
+++ b/diracx-routers/src/diracx/routers/jobs/sandboxes.py
@@ -55,7 +55,9 @@ async def initiate_sandbox_upload(
     If the sandbox does not exist in the database then the "url" and "fields"
     should be used to upload the sandbox to the storage backend.
     """
-    await check_permissions(action=ActionType.CREATE)
+    await check_permissions(
+        action=ActionType.CREATE, sandbox_metadata_db=sandbox_metadata_db
+    )
 
     try:
         sandbox_upload_response = await initiate_sandbox_upload_bl(

--- a/diracx-routers/tests/jobs/test_wms_access_policy.py
+++ b/diracx-routers/tests/jobs/test_wms_access_policy.py
@@ -23,13 +23,23 @@ base_payload = {
 }
 
 
-class FakeDB:
+class FakeJobDB:
     async def summary(self, *args): ...
+
+
+class FakeSBMetadataDB:
+    async def get_owner_id(self, *args): ...
+    async def get_sandbox_owner_id(self, *args): ...
 
 
 @pytest.fixture
 def job_db():
-    yield FakeDB()
+    yield FakeJobDB()
+
+
+@pytest.fixture
+def sandbox_metadata_db():
+    yield FakeSBMetadataDB()
 
 
 WMS_POLICY_NAME = "WMSAccessPolicy_AlthoughItDoesNotMatter"
@@ -220,7 +230,7 @@ OTHER_USER_SANDBOX_PFN = (
 )
 
 
-async def test_sandbox_access_policy_create():
+async def test_sandbox_access_policy_create(sandbox_metadata_db):
 
     admin_user = AuthorizedUserInfo(properties=[JOB_ADMINISTRATOR], **base_payload)
     normal_user = AuthorizedUserInfo(properties=[NORMAL_USER], **base_payload)
@@ -230,6 +240,7 @@ async def test_sandbox_access_policy_create():
         await SandboxAccessPolicy.policy(
             SANDBOX_POLICY_NAME,
             normal_user,
+            sandbox_metadata_db=sandbox_metadata_db,
         )
 
     # An admin cannot create any resource
@@ -238,6 +249,7 @@ async def test_sandbox_access_policy_create():
             SANDBOX_POLICY_NAME,
             admin_user,
             action=ActionType.CREATE,
+            sandbox_metadata_db=sandbox_metadata_db,
             pfns=[USER_SANDBOX_PFN],
         )
 
@@ -246,13 +258,14 @@ async def test_sandbox_access_policy_create():
         SANDBOX_POLICY_NAME,
         normal_user,
         action=ActionType.CREATE,
+        sandbox_metadata_db=sandbox_metadata_db,
         pfns=[USER_SANDBOX_PFN],
     )
 
     ##############
 
 
-async def test_sandbox_access_policy_read():
+async def test_sandbox_access_policy_read(sandbox_metadata_db):
 
     admin_user = AuthorizedUserInfo(properties=[JOB_ADMINISTRATOR], **base_payload)
     normal_user = AuthorizedUserInfo(properties=[NORMAL_USER], **base_payload)
@@ -261,6 +274,7 @@ async def test_sandbox_access_policy_read():
         SANDBOX_POLICY_NAME,
         admin_user,
         action=ActionType.READ,
+        sandbox_metadata_db=sandbox_metadata_db,
         pfns=[USER_SANDBOX_PFN],
         required_prefix=SANDBOX_PREFIX,
     )
@@ -269,6 +283,7 @@ async def test_sandbox_access_policy_read():
         SANDBOX_POLICY_NAME,
         admin_user,
         action=ActionType.READ,
+        sandbox_metadata_db=sandbox_metadata_db,
         pfns=[OTHER_USER_SANDBOX_PFN],
         required_prefix=SANDBOX_PREFIX,
     )
@@ -279,6 +294,7 @@ async def test_sandbox_access_policy_read():
             SANDBOX_POLICY_NAME,
             normal_user,
             action=ActionType.READ,
+            sandbox_metadata_db=sandbox_metadata_db,
             pfns=[USER_SANDBOX_PFN],
         )
 
@@ -287,6 +303,7 @@ async def test_sandbox_access_policy_read():
         SANDBOX_POLICY_NAME,
         normal_user,
         action=ActionType.READ,
+        sandbox_metadata_db=sandbox_metadata_db,
         pfns=[USER_SANDBOX_PFN],
         required_prefix=SANDBOX_PREFIX,
     )
@@ -297,6 +314,7 @@ async def test_sandbox_access_policy_read():
             SANDBOX_POLICY_NAME,
             normal_user,
             action=ActionType.READ,
+            sandbox_metadata_db=sandbox_metadata_db,
             pfns=[OTHER_USER_SANDBOX_PFN],
             required_prefix=SANDBOX_PREFIX,
         )


### PR DESCRIPTION
From #13 : "Implement sandbox permissions for downloading"

- a method getting sandbox owner info from SBOwnersDB
- ensure SandboxAccessPolicy verify the sandbox owner infos for read and query actions.