### PR TITLE
doc: Moving the coding convention documentation and fixing the db location

### DIFF
--- a/docs/CODING_CONVENTION.md
+++ b/docs/CODING_CONVENTION.md
@@ -1,10 +1,27 @@
-Opinionated decisions
+# Coding Conventions
 
-TODO:
+Most style are enforced with the pre-commit hooks which automatically reformat the code and sort the imports.
+Code should follow PEP-8, particularly for [naming conventions](https://peps.python.org/pep-0008/#prescriptive-naming-conventions) as these aren't modified by the pre-commit hooks.
 
-# pytest
+## Module Specifications
 
-DO
+Depending on which module you are using, there could be rules to follow that are listed below.
+
+<table>
+<thead>
+<tr>
+    <th>Module</th>
+    <th>Do</th>
+    <th>Do not</th>
+<tr>
+</thead>
+
+<tr>
+<td>
+
+`pytest`</td>
+
+<td>
 
 ```python
 import pytest
@@ -14,7 +31,9 @@ def my_ficture():
     ...
 ```
 
-DONT
+</td>
+
+<td>
 
 ```python
 from pytest import fixture
@@ -24,63 +43,86 @@ def my_ficture():
     ...
 ```
 
-# datetime
+</td>
+</tr>
 
-DO
+<tr>
+<td>
+
+`datetime`
+</td>
+
+<td>
 
 ```python
 from datetime import datetime, timedelta
 delay = datetime.now() + timedelta(hours=1)
 ```
 
-DONT
+</td>
+
+<td>
 
 ```python
 import datetime
 delay = datetime.datetime.now() + datetime.timedelta(hours=1)
 ```
 
+</td>
+</tr>
 
-ALWAYS DO
+<tr>
+<td>
 
-```python
-from __future__ import annotations
-```
+`SQL Alchemy`
+</td>
 
-# SQL Alchemy
-
-DO
+<td>
 
 ```python
 class Owners(Base):
     __tablename__ = "Owners"
-    owner_id = Column("OwnerID", Integer, primary_key=True, autoincrement=True)
+    owner_id = Column("OwnerID", 
+        Integer, 
+        primary_key=True, 
+        autoincrement=True)
     creation_time = DateNowColumn("CreationTime")
     name = Column("Name", String(255))
 ```
+</td>
 
-DONT
+<td>
 
 ```python
 class Owners(Base):
     __tablename__ = "Owners"
-    OwnerID = Column(Integer, primary_key=True, autoincrement=True)
+    OwnerID = Column(Integer, 
+        primary_key=True, 
+        autoincrement=True)
     CreationTime = DateNowColumn()
     Name = Column(String(255))
 ```
+</td>
+</tr>
+
+</table>
 
 
-# Structure
+## Structure
 
-(https://github.com/DIRACGrid/diracx/issues/268)
+The following structures principles may also be followed:
 
-* `__init__.py` should not contain code, but `__all__`
-* at a package level (router for example) we have one file per system (configuration.py for example)
-* If we need more files (think of jobs, which have the sandbox, the joblogging, etc), we put them in a sub module (e.g routers.job). The code goes in a specific file (job.py, joblogging.py) but we use the the __init__.py to expose the specific file
+- `__init__.py` should not contain code, but `__all__`
+- At a package level (router for example) we have one file per system (configuration.py for example)
+- If we need more files (think of jobs, which have the sandbox, the joblogging, etc), we put them in a sub module (e.g routers.job). The code goes in a specific file (job.py, joblogging.py) but we use the the __init__.py to expose the specific file
+
+See [this issue](https://github.com/DIRACGrid/diracx/issues/268).
 
 
-# Architecture
+## Architecture
 
-* `diracx-routers` should deal with user interactions through HTTPs. It is expected to deal with permissions and should call `diracx-logic`. Results returned should be translated into HTTP responses.
-* `diracx-logic` should embed Dirac specificities. It should encapsulate the logic of the services and should call `diracx-db` to interact with databases.
-* `diracx-db` should contain atomic methods (complex logic is expected to be located in `diracx-db`).
+To make sure that each part of DiracX is doing only what it is supposed to do, you also need to follow these instructions:
+
+- `diracx-routers` should deal with user interactions through HTTPs. It is expected to deal with permissions and should call `diracx-logic`. Results returned should be translated into HTTP responses.
+- `diracx-logic` should embed Dirac specificities. It should encapsulate the logic of the services and should call `diracx-db` to interact with databases.
+- `diracx-db` should contain atomic methods (complex logic is expected to be located in `diracx-db`).

--- a/docs/CODING_CONVENTION.md
+++ b/docs/CODING_CONVENTION.md
@@ -82,9 +82,9 @@ delay = datetime.datetime.now() + datetime.timedelta(hours=1)
 ```python
 class Owners(Base):
     __tablename__ = "Owners"
-    owner_id = Column("OwnerID", 
-        Integer, 
-        primary_key=True, 
+    owner_id = Column("OwnerID",
+        Integer,
+        primary_key=True,
         autoincrement=True)
     creation_time = DateNowColumn("CreationTime")
     name = Column("Name", String(255))
@@ -96,8 +96,8 @@ class Owners(Base):
 ```python
 class Owners(Base):
     __tablename__ = "Owners"
-    OwnerID = Column(Integer, 
-        primary_key=True, 
+    OwnerID = Column(Integer,
+        primary_key=True,
         autoincrement=True)
     CreationTime = DateNowColumn()
     Name = Column(String(255))

--- a/docs/README.md
+++ b/docs/README.md
@@ -87,9 +87,10 @@ This only runs the diracx server, not any dependency like external IdP.
 
 ## Add a DB
 
-Database classes live in `src/diracx/db/<dbname>`. Have a look at the `src/diracx/db/dummy/` to see how to implement your own DB
+Database classes live in `src/diracx/db/sql/<dbname>`. Have a look at the `src/diracx/db/sql/dummy/` to see how to implement your own DB.
 
-* We do not want to use the `ORM` part of `SQLAlchemy` (only the `core`) for performance reasons
+> [!NOTE]  
+> We do not want to use the `ORM` part of `SQLAlchemy` (only the `core`) for performance reasons
 
 
 ## Dependency injection
@@ -168,15 +169,4 @@ This will prefix the routes with `/parking/` and mark them with the `"parking"` 
 
 ### Coding style
 
-Most style are enforced with the pre-commit hooks which automatically reformat the code and sort the imports.
-Code should follow PEP-8, particularly for [naming conventions](https://peps.python.org/pep-0008/#prescriptive-naming-conventions) as these aren't modified by the pre-commit hooks.
-
-#### Import style
-
-In addition to the automatic sorting
-
-```python
-from datetime import datetime, timedelta, timezone
-
-import pytest
-```
+The coding style used and followed by DiracX is situated in it own page at [coding_convention.md](CODING_CONVENTION.md), and is mostly inspired by the PEP-8 convention.

--- a/docs/README.md
+++ b/docs/README.md
@@ -89,7 +89,7 @@ This only runs the diracx server, not any dependency like external IdP.
 
 Database classes live in `src/diracx/db/sql/<dbname>`. Have a look at the `src/diracx/db/sql/dummy/` to see how to implement your own DB.
 
-> [!NOTE]  
+> [!NOTE]
 > We do not want to use the `ORM` part of `SQLAlchemy` (only the `core`) for performance reasons
 
 


### PR DESCRIPTION
Continuation of https://github.com/DIRACGrid/diracx/pull/410... With a fresh branch.

- Moving the part from `/docs/README.md` to `/docs/CODING_CONVENTION.md`
- Coding convention documentation restructured : from sections to a table
- Adding clear text around the instructions
- In `/docs/README.md`, changing the database classes path