### PR TITLE
fix: Adding missing logic to requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@
 -e ./diracx-routers/[testing]
 -e ./diracx-db/[testing]
 -e ./diracx-testing/[testing]
+-e ./diracx-logic/[testing]


### PR DESCRIPTION
Added a missing module to `requirements-dev.txt` that could lead to errors in `pytest`.