### PR TITLE
fix: naming of the client well_known get installation metadata

### DIFF
--- a/diracx-cli/src/diracx/cli/auth.py
+++ b/diracx-cli/src/diracx/cli/auth.py
@@ -23,7 +23,7 @@ app = AsyncTyper()
 
 async def installation_metadata():
     async with DiracClient() as api:
-        return await api.well_known.installation_metadata()
+        return await api.well_known.get_installation_metadata()
 
 
 def vo_callback(vo: str | None) -> str:


### PR DESCRIPTION
Found out using the dirac cli `dirac login`: 
```
│ /home/npigoux/DIRAC/diracx/diracx-cli/src/diracx/cli/auth.py:26 in               │
│ installation_metadata                                                            │
│                                                                                  │
│    23                                                                            │
│    24 async def installation_metadata():                                         │
│    25 │   async with DiracClient() as api:                                       │
│ ❱  26 │   │   return await api.well_known.installation_metadata()                │
│    27                                                                            │
│    28                                                                            │
│    29 def vo_callback(vo: str | None) -> str:                                    │
│                                                                                  │
│ ╭──────────────────────────────── locals ────────────────────────────────╮       │
│ │ api = <diracx.client.patches.aio.DiracClient object at 0x714ea4e79110> │       │
│ ╰────────────────────────────────────────────────────────────────────────╯       │
╰──────────────────────────────────────────────────────────────────────────────────
```
It happened that the client installation_metadata method name has been changed here: https://github.com/DIRACGrid/diracx/commit/87ea27ac6289fa23bea6fe5af58390f24ca9ca98
