### PR TITLE
learn.scientific-python.org Repo Review

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    groups:
-      actions:
-        patterns:
-          - "*"
+#    groups:
+#      actions:
+#        patterns:
+#          - "*"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -72,5 +72,5 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
-          name: serivce-logs
+          name: service-logs-${{ github.job }}
           path: /tmp/service-logs/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 defaults:
   run:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - janusz_main_repo_test
   pull_request:
     branches:
       - main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - janusz_main_repo_test
   pull_request:
     branches:
       - main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,3 +42,25 @@ repos:
     hooks:
     - id: codespell
 
+  - repo: https://github.com/hukkin/mdformat
+    rev: 0.7.22  # Use the ref you want to point at
+    hooks:
+    - id: mdformat
+      # Optionally add plugins
+      additional_dependencies:
+      - mdformat-gfm
+      - mdformat-black
+
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.10.0  # Use the ref you want to point at
+    hooks:
+    - id: python-use-type-annotations
+    - id: python-check-blanket-noqa
+    - id: python-check-blanket-type-ignore
+    - id: python-no-eval
+    - id: python-no-log-warn
+    - id: rst-backticks
+    - id: rst-directive-colons
+    - id: rst-inline-touching-normal
+    - id: text-unicode-replacement-char
+    # ...

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     rev: 'v0.11.6'
     hooks:
       - id: ruff
-        args: ["--fix"]
+        args: ["--fix", "--show-fixes"]
 
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 25.1.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,7 @@ repos:
     rev: v2.4.1
     hooks:
     -   id: codespell
+    exclude: ^(diracx-client/src/diracx/client/_generated|diracx-[a-z]+/tests/|diracx-testing/|build|extensions/gubbins/gubbins-client/src/gubbins/client/_generated)
 
 -   repo: https://github.com/executablebooks/mdformat
     rev: 0.7.22  # Use the ref you want to point at
@@ -50,6 +51,7 @@ repos:
         additional_dependencies:
         -   mdformat-gfm
         -   mdformat-black
+        exclude: ^(diracx-client/src/diracx/client/_generated|diracx-[a-z]+/tests/|diracx-testing/|build|extensions/gubbins/gubbins-client/src/gubbins/client/_generated)
 
 -   repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0  # Use the ref you want to point at
@@ -63,6 +65,7 @@ repos:
     -   id: rst-directive-colons
     -   id: rst-inline-touching-normal
     -   id: text-unicode-replacement-char
+    exclude: ^(diracx-client/src/diracx/client/_generated|diracx-[a-z]+/tests/|diracx-testing/|build|extensions/gubbins/gubbins-client/src/gubbins/client/_generated)
     # ...
 
 -   repo: https://github.com/adamchainz/blacken-docs
@@ -71,6 +74,7 @@ repos:
     -   id: blacken-docs
         additional_dependencies:
         -   black==25.1.0 # use sync-pre-commit-deps below??
+    exclude: ^(diracx-client/src/diracx/client/_generated|diracx-[a-z]+/tests/|diracx-testing/|build|extensions/gubbins/gubbins-client/src/gubbins/client/_generated)
 
 -   repo: https://github.com/pre-commit/sync-pre-commit-deps
     rev: v0.0.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
     rev: v2.4.1
     hooks:
     -   id: codespell
-    exclude: ^(diracx-client/src/diracx/client/_generated|diracx-[a-z]+/tests/|diracx-testing/|build|extensions/gubbins/gubbins-client/src/gubbins/client/_generated)
+        exclude: ^(diracx-client/src/diracx/client/_generated|diracx-[a-z]+/tests/|diracx-testing/|build|extensions/gubbins/gubbins-client/src/gubbins/client/_generated)
 
 -   repo: https://github.com/executablebooks/mdformat
     rev: 0.7.22  # Use the ref you want to point at
@@ -65,7 +65,7 @@ repos:
     -   id: rst-directive-colons
     -   id: rst-inline-touching-normal
     -   id: text-unicode-replacement-char
-    exclude: ^(diracx-client/src/diracx/client/_generated|diracx-[a-z]+/tests/|diracx-testing/|build|extensions/gubbins/gubbins-client/src/gubbins/client/_generated)
+        exclude: ^(diracx-client/src/diracx/client/_generated|diracx-[a-z]+/tests/|diracx-testing/|build|extensions/gubbins/gubbins-client/src/gubbins/client/_generated)
     # ...
 
 -   repo: https://github.com/adamchainz/blacken-docs
@@ -74,7 +74,7 @@ repos:
     -   id: blacken-docs
         additional_dependencies:
         -   black==25.1.0 # use sync-pre-commit-deps below??
-    exclude: ^(diracx-client/src/diracx/client/_generated|diracx-[a-z]+/tests/|diracx-testing/|build|extensions/gubbins/gubbins-client/src/gubbins/client/_generated)
+        exclude: ^(diracx-client/src/diracx/client/_generated|diracx-[a-z]+/tests/|diracx-testing/|build|extensions/gubbins/gubbins-client/src/gubbins/client/_generated)
 
 -   repo: https://github.com/pre-commit/sync-pre-commit-deps
     rev: v0.0.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,32 +1,32 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 default_language_version:
-  python: python3
+    python: python3
 
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
+-   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
-      - id: check-yaml
-      - id: check-added-large-files
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: 'v0.11.6'
     hooks:
-      - id: ruff
+    -   id: ruff
         args: ["--fix", "--show-fixes"]
 
-  - repo: https://github.com/psf/black-pre-commit-mirror
+-   repo: https://github.com/psf/black-pre-commit-mirror
     rev: 25.1.0
     hooks:
-      - id: black
+    -   id: black
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
+-   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.15.0
     hooks:
-      - id: mypy
+    -   id: mypy
         additional_dependencies:
           - pydantic
           - sqlalchemy
@@ -37,30 +37,42 @@ repos:
           - boto3-stubs[essential]
         exclude: ^(diracx-client/src/diracx/client/_generated|diracx-[a-z]+/tests/|diracx-testing/|build|extensions/gubbins/gubbins-client/src/gubbins/client/_generated)
 
-  - repo: https://github.com/codespell-project/codespell
+-   repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
     hooks:
-    - id: codespell
+    -   id: codespell
 
-  - repo: https://github.com/executablebooks/mdformat
+-   repo: https://github.com/executablebooks/mdformat
     rev: 0.7.22  # Use the ref you want to point at
     hooks:
-    - id: mdformat
+    -   id: mdformat
       # Optionally add plugins
-      additional_dependencies:
-      - mdformat-gfm
-      - mdformat-black
+        additional_dependencies:
+        -   mdformat-gfm
+        -   mdformat-black
 
-  - repo: https://github.com/pre-commit/pygrep-hooks
+-   repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0  # Use the ref you want to point at
     hooks:
-    - id: python-use-type-annotations
-    - id: python-check-blanket-noqa
-    - id: python-check-blanket-type-ignore
-    - id: python-no-eval
-    - id: python-no-log-warn
-    - id: rst-backticks
-    - id: rst-directive-colons
-    - id: rst-inline-touching-normal
-    - id: text-unicode-replacement-char
+    -   id: python-use-type-annotations
+    -   id: python-check-blanket-noqa
+    -   id: python-check-blanket-type-ignore
+    -   id: python-no-eval
+    -   id: python-no-log-warn
+    -   id: rst-backticks
+    -   id: rst-directive-colons
+    -   id: rst-inline-touching-normal
+    -   id: text-unicode-replacement-char
     # ...
+
+-   repo: https://github.com/adamchainz/blacken-docs
+    rev: ""  # replace with latest tag on GitHub
+    hooks:
+    -   id: blacken-docs
+        additional_dependencies:
+        -   black==25.1.0 # use sync-pre-commit-deps below??
+
+-   repo: https://github.com/pre-commit/sync-pre-commit-deps
+    rev: v0.0.3
+    hooks:
+    -   id: sync-pre-commit-deps

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
     rev: v2.4.1
     hooks:
     -   id: codespell
-        exclude: ^(diracx-client/src/diracx/client/_generated|diracx-[a-z]+/tests/|diracx-testing/|build|extensions/gubbins/gubbins-client/src/gubbins/client/_generated)
+        args: ["--ignore-regex=^(diracx-client/src/diracx/client/_generated|diracx-[a-z]+/tests/|diracx-testing/|build|extensions/gubbins/gubbins-client/src/gubbins/client/_generated)"]
 
 -   repo: https://github.com/executablebooks/mdformat
     rev: 0.7.22  # Use the ref you want to point at

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
     rev: v2.4.1
     hooks:
     -   id: codespell
-        args: ["--ignore-regex=^(diracx-client/src/diracx/client/_generated|diracx-[a-z]+/tests/|diracx-testing/|build|extensions/gubbins/gubbins-client/src/gubbins/client/_generated)"]
+        args: ["--skip=diracx-client/src/diracx/client/_generated/*, diracx-[a-z]*/tests/*, diracx-testing/*, build/*, extensions/gubbins/gubbins-client/src/gubbins/client/_generated/*"]
 
 -   repo: https://github.com/executablebooks/mdformat
     rev: 0.7.22  # Use the ref you want to point at

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
     hooks:
     - id: codespell
 
-  - repo: https://github.com/hukkin/mdformat
+  - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.22  # Use the ref you want to point at
     hooks:
     - id: mdformat

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: ruff
         args: ["--fix"]
 
-  - repo: https://github.com/psf/black
+  - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 25.1.0
     hooks:
       - id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,7 @@ repos:
     # ...
 
 -   repo: https://github.com/adamchainz/blacken-docs
-    rev: ""  # replace with latest tag on GitHub
+    rev: "v1.12.1"  # replace with latest tag on GitHub
     hooks:
     -   id: blacken-docs
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,3 +36,9 @@ repos:
           - types-aiobotocore[essential]
           - boto3-stubs[essential]
         exclude: ^(diracx-client/src/diracx/client/_generated|diracx-[a-z]+/tests/|diracx-testing/|build|extensions/gubbins/gubbins-client/src/gubbins/client/_generated)
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+    - id: codespell
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
         additional_dependencies:
         -   mdformat-gfm
         -   mdformat-black
-        exclude: ^(diracx-client/src/diracx/client/_generated|diracx-[a-z]+/tests/|diracx-testing/|build|extensions/gubbins/gubbins-client/src/gubbins/client/_generated)
+        exclude: ^(diracx-client/src/diracx/client/_generated|diracx-[a-z]+/tests/|diracx-testing/|build|extensions/gubbins/gubbins-client/src/gubbins/client/_generated|extensions/gubbins/gubbins-client/tests)
 
 -   repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0  # Use the ref you want to point at
@@ -61,12 +61,13 @@ repos:
     -   id: python-check-blanket-type-ignore
     -   id: python-no-eval
     -   id: python-no-log-warn
-    -   id: rst-backticks
-    -   id: rst-directive-colons
-    -   id: rst-inline-touching-normal
     -   id: text-unicode-replacement-char
-        exclude: ^(diracx-client/src/diracx/client/_generated|diracx-[a-z]+/tests/|diracx-testing/|build|extensions/gubbins/gubbins-client/src/gubbins/client/_generated)
-    # ...
+        exclude: |
+            (?x)(
+                ^extensions/gubbins/gubbins-client/tests|
+                ^diracx-client/src/diracx/client/_generated
+            )
+#        exclude: ^(extensions/gubbins/gubbins-client/tests)
 
 -   repo: https://github.com/adamchainz/blacken-docs
     rev: "v1.12.1"  # replace with latest tag on GitHub

--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ The documentation is scattered around [various files](./docs/).
 - [The NeXt Dirac Incarnation - CHEP 24](https://indico.cern.ch/event/1338689/contributions/6010971/)
 - [Eventually coming with some Documentation - Dirac User Workshop 24](https://indico.cern.ch/event/1341205/contributions/5972930/)
 - [Demo and Technical details - Dirac & Rucio Workshop 23](https://indico.cern.ch/event/1252369/contributions/5515392/)
-- [Dirac: future Part1](https://indico.cern.ch/event/1292287/) and [Part2 -  Bild-Dev meeting June 23](https://indico.cern.ch/event/1297397/)
+- [Dirac: future Part1](https://indico.cern.ch/event/1292287/) and [Part2 - Bild-Dev meeting June 23](https://indico.cern.ch/event/1297397/)

--- a/diracx-cli/src/diracx/cli/auth.py
+++ b/diracx-cli/src/diracx/cli/auth.py
@@ -6,8 +6,8 @@ import asyncio
 import json
 import os
 from asyncio import sleep
-from datetime import datetime, timedelta, timezone
-from typing import Annotated, Optional
+from datetime import UTC, datetime, timedelta
+from typing import Annotated
 
 import typer
 
@@ -43,14 +43,14 @@ def vo_callback(vo: str | None) -> str:
 @app.async_command()
 async def login(
     vo: Annotated[
-        Optional[str],
+        str | None,
         typer.Argument(callback=vo_callback, help="Virtual Organization name"),
     ] = None,
-    group: Optional[str] = typer.Option(
+    group: str | None = typer.Option(
         None,
         help="Group name within the VO. If not provided, the default group for the VO will be used.",
     ),
-    property: Optional[list[str]] = typer.Option(
+    property: list[str] | None = typer.Option(
         None,
         help=(
             "List of properties to add to the default properties of the group. "
@@ -83,10 +83,8 @@ async def login(
             scope=" ".join(scopes),
         )
         print("Now go to:", data.verification_uri_complete)
-        expires = datetime.now(tz=timezone.utc) + timedelta(
-            seconds=data.expires_in - 30
-        )
-        while expires > datetime.now(tz=timezone.utc):
+        expires = datetime.now(tz=UTC) + timedelta(seconds=data.expires_in - 30)
+        while expires > datetime.now(tz=UTC):
             print(".", end="", flush=True)
             response = await api.auth.get_oidc_token(device_code=data.device_code, client_id=api.client_id)  # type: ignore
             if isinstance(response, DeviceFlowErrorResponse):
@@ -136,6 +134,6 @@ async def logout():
 
 
 @app.callback()
-def callback(output_format: Optional[str] = None):
+def callback(output_format: str | None = None):
     if output_format is not None:
         os.environ["DIRACX_OUTPUT_FORMAT"] = output_format

--- a/diracx-cli/src/diracx/cli/internal/config.py
+++ b/diracx-cli/src/diracx/cli/internal/config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated
 
 import git
 import typer
@@ -54,7 +54,7 @@ def add_vo(
     config_repo: str,
     *,
     vo: Annotated[str, typer.Option()],
-    default_group: Optional[str] = "user",
+    default_group: str | None = "user",
     idp_url: Annotated[str, typer.Option()],
     idp_client_id: Annotated[str, typer.Option()],
 ):
@@ -133,7 +133,7 @@ def add_user(
     config_repo: str,
     *,
     vo: Annotated[str, typer.Option()],
-    groups: Annotated[Optional[list[str]], typer.Option("--group")] = None,
+    groups: Annotated[list[str] | None, typer.Option("--group")] = None,
     sub: Annotated[str, typer.Option()],
     preferred_username: Annotated[str, typer.Option()],
 ):

--- a/diracx-cli/tests/test_jobs.py
+++ b/diracx-cli/tests/test_jobs.py
@@ -41,7 +41,7 @@ async def jdl_file():
 
 async def test_submit(with_cli_login, jdl_file, capfd):
     """Test submitting a job using a JDL file."""
-    with open(jdl_file, "r") as temp_file:
+    with open(jdl_file) as temp_file:
         await cli.jobs.submit([temp_file])
 
     cap = capfd.readouterr()
@@ -52,7 +52,7 @@ async def test_submit(with_cli_login, jdl_file, capfd):
 async def test_search(with_cli_login, jdl_file, capfd):
     """Test searching for jobs."""
     # Submit 20 jobs
-    with open(jdl_file, "r") as x:
+    with open(jdl_file) as x:
         what_we_submit = x.read()
     jdls = [StringIO(what_we_submit) for _ in range(20)]
 

--- a/diracx-client/tests/test_auth.py
+++ b/diracx-client/tests/test_auth.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import fcntl
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import jwt
 import pytest
@@ -15,7 +15,7 @@ from diracx.core.utils import serialize_credentials
 # Create a fake jwt dictionary
 REFRESH_CONTENT = {
     "jti": "f0706e0a-af1e-4538-9f1f-7b9620783cba",
-    "exp": int((datetime.now(tz=timezone.utc) + timedelta(days=1)).timestamp()),
+    "exp": int((datetime.now(tz=UTC) + timedelta(days=1)).timestamp()),
     "legacy_exchange": False,
     "dirac_policies": {},
 }
@@ -71,8 +71,7 @@ def test_get_token_valid_input_token(tmp_path):
         token_response.access_token,
         int(
             (
-                datetime.now(tz=timezone.utc)
-                + timedelta(seconds=token_response.expires_in)
+                datetime.now(tz=UTC) + timedelta(seconds=token_response.expires_in)
             ).timestamp()
         ),
     )
@@ -106,7 +105,7 @@ def test_get_token_valid_input_credential(tmp_path):
     # Verify that the returned token is the expected token
     assert isinstance(result, AccessToken)
     assert result.token == TOKEN_RESPONSE_DICT["access_token"]
-    assert result.expires_on > datetime.now(tz=timezone.utc).timestamp()
+    assert result.expires_on > datetime.now(tz=UTC).timestamp()
 
 
 def test_get_token_input_token_not_exists(tmp_path):
@@ -156,7 +155,7 @@ def test_get_token_refresh_valid(monkeypatch, tmp_path):
 
     # Create expired access token
     token_response["expires_on"] = int(
-        (datetime.now(tz=timezone.utc) - timedelta(seconds=10)).timestamp()
+        (datetime.now(tz=UTC) - timedelta(seconds=10)).timestamp()
     )
     token_response.pop("expires_in")
 
@@ -184,7 +183,7 @@ def test_get_token_refresh_valid(monkeypatch, tmp_path):
     )
 
     # Verify that the credential file has been refreshed:
-    with open(token_location, "r") as f:
+    with open(token_location) as f:
         content = f.read()
         assert content == serialize_credentials(expected_token_response)
 
@@ -203,11 +202,11 @@ def test_get_token_refresh_expired(tmp_path):
     refresh_token = REFRESH_CONTENT.copy()
 
     refresh_token["exp"] = int(
-        (datetime.now(tz=timezone.utc) - timedelta(seconds=10)).timestamp()
+        (datetime.now(tz=UTC) - timedelta(seconds=10)).timestamp()
     )
 
     token_response["expires_on"] = int(
-        (datetime.now(tz=timezone.utc) - timedelta(seconds=10)).timestamp()
+        (datetime.now(tz=UTC) - timedelta(seconds=10)).timestamp()
     )
     token_response.pop("expires_in")
     token_response["refresh_token"] = jwt.encode(refresh_token, "secret_key")

--- a/diracx-core/src/diracx/core/config/schema.py
+++ b/diracx-core/src/diracx/core/config/schema.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import os
+from collections.abc import MutableMapping
 from datetime import datetime
-from typing import Annotated, Any, MutableMapping, TypeVar
+from typing import Annotated, Any, TypeVar
 
 from pydantic import BaseModel as _BaseModel
 from pydantic import ConfigDict, EmailStr, Field, PrivateAttr, model_validator

--- a/diracx-core/src/diracx/core/config/sources.py
+++ b/diracx-core/src/diracx/core/config/sources.py
@@ -9,7 +9,7 @@ import asyncio
 import logging
 import os
 from abc import ABCMeta, abstractmethod
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Annotated
@@ -67,7 +67,7 @@ class ConfigSource(metaclass=ABCMeta):
     """
 
     # Keep a mapping between the scheme and the class
-    __registry: dict[str, type["ConfigSource"]] = {}
+    __registry: dict[str, type[ConfigSource]] = {}
     scheme: str
 
     def __init__(self, *, backend_url: ConfigSourceUrl) -> None:
@@ -114,7 +114,7 @@ class ConfigSource(metaclass=ABCMeta):
     @classmethod
     def create_from_url(
         cls, *, backend_url: ConfigSourceUrl | Path | str
-    ) -> "ConfigSource":
+    ) -> ConfigSource:
         """Factory method to produce a concrete instance depending on
         the backend URL scheme.
 
@@ -191,7 +191,7 @@ class BaseGitConfigSource(ConfigSource):
                 _tty_out=False,
                 _async=is_running_in_async_context(),
             ).strip()
-            modified = datetime.fromtimestamp(int(commit_info), tz=timezone.utc)
+            modified = datetime.fromtimestamp(int(commit_info), tz=UTC)
         except sh.ErrorReturnCode as e:
             raise BadConfigurationVersionError(
                 f"Error parsing latest revision: {e}"

--- a/diracx-core/src/diracx/core/utils.py
+++ b/diracx-core/src/diracx/core/utils.py
@@ -45,7 +45,7 @@ def serialize_credentials(token_response: TokenResponse) -> str:
     This method is separated from write_credentials to allow for DIRAC to be
     able to serialize credentials for inclusion in the proxy file.
     """
-    expires = datetime.now(tz=timezone.utc) + timedelta(
+    expires = datetime.now(tz=UTC) + timedelta(
         seconds=token_response.expires_in - EXPIRES_GRACE_SECONDS
     )
     credential_data = {
@@ -62,7 +62,7 @@ def read_credentials(location: Path) -> TokenResponse:
 
     credentials_path = location or get_diracx_preferences().credentials_path
     try:
-        with open(credentials_path, "r") as f:
+        with open(credentials_path) as f:
             # Lock the file to prevent other processes from writing to it at the same time
             fcntl.flock(f, fcntl.LOCK_SH)
             # Read the credentials from the file
@@ -76,8 +76,7 @@ def read_credentials(location: Path) -> TokenResponse:
 
     return TokenResponse(
         access_token=credentials["access_token"],
-        expires_in=credentials["expires_on"]
-        - int(datetime.now(tz=timezone.utc).timestamp()),
+        expires_in=credentials["expires_on"] - int(datetime.now(tz=UTC).timestamp()),
         token_type="Bearer",  # noqa: S106
         refresh_token=credentials.get("refresh_token"),
     )

--- a/diracx-core/tests/test_utils.py
+++ b/diracx-core/tests/test_utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import fcntl
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -40,7 +40,7 @@ def test_dotenv_files_from_environment(monkeypatch):
 
 TOKEN_RESPONSE_DICT = {
     "access_token": "test_token",
-    "expires_in": int((datetime.now(tz=timezone.utc) + timedelta(days=1)).timestamp()),
+    "expires_in": int((datetime.now(tz=UTC) + timedelta(days=1)).timestamp()),
     "token_type": "Bearer",
     "refresh_token": "test_refresh",
 }

--- a/diracx-db/src/diracx/db/sql/job/db.py
+++ b/diracx-db/src/diracx/db/sql/job/db.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 __all__ = ["JobDB"]
 
-from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, Iterable
+from collections.abc import Iterable
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import bindparam, case, delete, func, insert, select, update
 
@@ -190,9 +191,7 @@ class JobDB(BaseSQLDB):
         # TODO: add myDate and force parameters.
         for job_id in job_data.keys():
             if "Status" in job_data[job_id]:
-                job_data[job_id].update(
-                    {"LastUpdateTime": datetime.now(tz=timezone.utc)}
-                )
+                job_data[job_id].update({"LastUpdateTime": datetime.now(tz=UTC)})
         columns = set(key for attrs in job_data.values() for key in attrs.keys())
         case_expressions = {
             column: case(
@@ -238,7 +237,7 @@ class JobDB(BaseSQLDB):
                     "JobID": job_id,
                     "Command": command,
                     "Arguments": arguments,
-                    "ReceptionTime": datetime.now(tz=timezone.utc),
+                    "ReceptionTime": datetime.now(tz=UTC),
                 }
                 for job_id, command, arguments in commands
             ],
@@ -272,7 +271,7 @@ class JobDB(BaseSQLDB):
             c.name: bindparam(c.name) for c in columns
         }
         if update_timestamp:
-            values["LastUpdateTime"] = datetime.now(tz=timezone.utc)
+            values["LastUpdateTime"] = datetime.now(tz=UTC)
 
         stmt = update(Jobs).where(Jobs.job_id == bindparam("job_id")).values(**values)
         rows = await self.conn.execute(stmt, update_parameters)

--- a/diracx-db/src/diracx/db/sql/job_logging/db.py
+++ b/diracx-db/src/diracx/db/sql/job_logging/db.py
@@ -95,7 +95,7 @@ class JobLoggingDB(BaseSQLDB):
                     status,
                     minor_status,
                     application_status,
-                    status_time.replace(tzinfo=timezone.utc),
+                    status_time.replace(tzinfo=UTC),
                     status_source,
                 ]
             )

--- a/diracx-db/src/diracx/db/sql/pilot_agents/db.py
+++ b/diracx-db/src/diracx/db/sql/pilot_agents/db.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from sqlalchemy import insert
 
@@ -24,7 +24,7 @@ class PilotAgentsDB(BaseSQLDB):
         if pilot_stamps is None:
             pilot_stamps = {}
 
-        now = datetime.now(tz=timezone.utc)
+        now = datetime.now(tz=UTC)
 
         # Prepare the list of dictionaries for bulk insertion
         values = [

--- a/diracx-db/src/diracx/db/sql/utils/base.py
+++ b/diracx-db/src/diracx/db/sql/utils/base.py
@@ -99,7 +99,7 @@ class BaseSQLDB(metaclass=ABCMeta):
         self._engine: AsyncEngine | None = None
 
     @classmethod
-    def available_implementations(cls, db_name: str) -> list[type["BaseSQLDB"]]:
+    def available_implementations(cls, db_name: str) -> list[type[BaseSQLDB]]:
         """Return the available implementations of the DB in reverse priority order."""
         db_classes: list[type[BaseSQLDB]] = [
             entry_point.load()

--- a/diracx-db/src/diracx/db/sql/utils/functions.py
+++ b/diracx-db/src/diracx/db/sql/utils/functions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import hashlib
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
 from sqlalchemy import DateTime, func
@@ -104,7 +104,7 @@ def sqlite_date_trunc(element, compiler, **kw):
 
 
 def substract_date(**kwargs: float) -> datetime:
-    return datetime.now(tz=timezone.utc) - timedelta(**kwargs)
+    return datetime.now(tz=UTC) - timedelta(**kwargs)
 
 
 def hash(code: str):

--- a/diracx-db/tests/auth/test_device_flow.py
+++ b/diracx-db/tests/auth/test_device_flow.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import secrets
-from datetime import timezone
+from datetime import UTC
 
 import pytest
 from sqlalchemy.exc import NoResultFound
@@ -98,7 +98,7 @@ async def test_device_flow_lookup(auth_db: AuthDB, monkeypatch):
 
         res = await auth_db.get_device_flow(device_code1)
         # The device code should be expired
-        assert res["CreationTime"].replace(tzinfo=timezone.utc) > substract_date(
+        assert res["CreationTime"].replace(tzinfo=UTC) > substract_date(
             seconds=MAX_VALIDITY
         )
 

--- a/diracx-db/tests/opensearch/test_index_template.py
+++ b/diracx-db/tests/opensearch/test_index_template.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import opensearchpy
 import pytest
@@ -8,7 +8,7 @@ import pytest
 from diracx.testing.osdb import DummyOSDB
 
 DUMMY_DOCUMENT = {
-    "DateField": datetime.now(tz=timezone.utc),
+    "DateField": datetime.now(tz=UTC),
     "IntField": 1234,
     "KeywordField1": "keyword1",
     "KeywordField2": "keyword two",

--- a/diracx-db/tests/opensearch/test_search.py
+++ b/diracx-db/tests/opensearch/test_search.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import contextlib
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from functools import partial
 
 import pytest
@@ -11,7 +11,7 @@ from diracx.testing.mock_osdb import MockOSDBMixin
 from diracx.testing.osdb import DummyOSDB
 
 DOC1 = {
-    "DateField": datetime.now(tz=timezone.utc),
+    "DateField": datetime.now(tz=UTC),
     "IntField": 1234,
     "KeywordField0": "a",
     "KeywordField1": "keyword1",
@@ -20,7 +20,7 @@ DOC1 = {
     "UnknownField": "unknown field 1",
 }
 DOC2 = {
-    "DateField": datetime.now(tz=timezone.utc) - timedelta(days=1, minutes=34),
+    "DateField": datetime.now(tz=UTC) - timedelta(days=1, minutes=34),
     "IntField": 679,
     "KeywordField0": "c",
     "KeywordField1": "keyword1",
@@ -29,7 +29,7 @@ DOC2 = {
     "UnknownField": "unknown field 2",
 }
 DOC3 = {
-    "DateField": datetime.now(tz=timezone.utc) - timedelta(days=1),
+    "DateField": datetime.now(tz=UTC) - timedelta(days=1),
     "IntField": 42,
     "KeywordField0": "b",
     "KeywordField1": "keyword2",

--- a/diracx-logic/src/diracx/logic/auth/token.py
+++ b/diracx-logic/src/diracx/logic/auth/token.py
@@ -388,9 +388,7 @@ async def get_device_flow(auth_db: AuthDB, device_code: str, max_validity: int):
     """Get the device flow from the DB and check few parameters before returning it."""
     res = await auth_db.get_device_flow(device_code)
 
-    if res["CreationTime"].replace(tzinfo=timezone.utc) < substract_date(
-        seconds=max_validity
-    ):
+    if res["CreationTime"].replace(tzinfo=UTC) < substract_date(seconds=max_validity):
         raise ExpiredFlowError()
 
     if res["Status"] == FlowStatus.READY:

--- a/diracx-logic/src/diracx/logic/jobs/status.py
+++ b/diracx-logic/src/diracx/logic/jobs/status.py
@@ -13,8 +13,9 @@ __all__ = [
 import logging
 from asyncio import TaskGroup
 from collections import defaultdict
-from datetime import datetime, timezone
-from typing import Any, Iterable
+from collections.abc import Iterable
+from datetime import UTC, datetime
+from typing import Any
 from unittest.mock import MagicMock
 
 from DIRAC.Core.Utilities.ClassAd.ClassAdLight import ClassAd
@@ -204,7 +205,7 @@ async def set_job_statuses(
             if new_status:
                 job_data.update(additional_attributes.get(job_id, {}))
                 job_data["Status"] = new_status
-                job_data["LastUpdateTime"] = str(datetime.now(timezone.utc))
+                job_data["LastUpdateTime"] = str(datetime.now(UTC))
             if new_minor:
                 job_data["MinorStatus"] = new_minor
             if new_application:
@@ -339,7 +340,7 @@ async def reschedule_jobs(
 
         if job_attrs["RescheduleCounter"] > reschedule_max:
             status_changes[job_id] = {
-                datetime.now(tz=timezone.utc): JobStatusUpdate(
+                datetime.now(tz=UTC): JobStatusUpdate(
                     Status=JobStatus.FAILED,
                     MinorStatus=JobMinorStatus.MAX_RESCHEDULING,
                     ApplicationStatus="Unknown",
@@ -420,7 +421,7 @@ async def reschedule_jobs(
         additional_attrs = {
             "Site": site,
             "UserPriority": priority,
-            "RescheduleTime": datetime.now(tz=timezone.utc),
+            "RescheduleTime": datetime.now(tz=UTC),
             "RescheduleCounter": jobs_to_resched[job_id]["RescheduleCounter"],
         }
 
@@ -429,7 +430,7 @@ async def reschedule_jobs(
 
         # set new status
         status_changes[job_id] = {
-            datetime.now(tz=timezone.utc): JobStatusUpdate(
+            datetime.now(tz=UTC): JobStatusUpdate(
                 Status=JobStatus.RECEIVED,
                 MinorStatus=JobMinorStatus.RESCHEDULED,
                 ApplicationStatus="Unknown",
@@ -565,7 +566,7 @@ async def add_heartbeat(
         raise ValueError(f"Failed to lookup job IDs: {data.keys()=} {results=}")
     status_changes = {
         int(result["JobID"]): {
-            datetime.now(timezone.utc): JobStatusUpdate(
+            datetime.now(UTC): JobStatusUpdate(
                 Status=JobStatus.RUNNING,
                 Source="Heartbeat",
             )

--- a/diracx-logic/src/diracx/logic/jobs/submission.py
+++ b/diracx-logic/src/diracx/logic/jobs/submission.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from copy import deepcopy
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from DIRAC.Core.Utilities.ClassAd.ClassAdLight import ClassAd
 from DIRAC.Core.Utilities.ReturnValues import returnValueOrRaise
@@ -130,7 +130,7 @@ async def submit_jdl_jobs(
         f'Jobs added to the JobDB", "{submitted_job_ids} for {user_info.preferred_username}/{user_info.dirac_group}'
     )
 
-    job_created_time = datetime.now(timezone.utc)
+    job_created_time = datetime.now(UTC)
     await job_logging_db.insert_records(
         [
             JobLoggingRecord(
@@ -192,8 +192,8 @@ async def create_jdl_jobs(jobs: list[JobSubmissionSpec], job_db: JobDB):
             job_id = job_id_task.result()
             job_attrs = {
                 "JobID": job_id,
-                "LastUpdateTime": datetime.now(tz=timezone.utc),
-                "SubmissionTime": datetime.now(tz=timezone.utc),
+                "LastUpdateTime": datetime.now(tz=UTC),
+                "SubmissionTime": datetime.now(tz=UTC),
                 "Owner": job.owner,
                 "OwnerGroup": job.owner_group,
                 "VO": job.vo,

--- a/diracx-routers/src/diracx/routers/access_policies.py
+++ b/diracx-routers/src/diracx/routers/access_policies.py
@@ -65,7 +65,7 @@ class BaseAccessPolicy(metaclass=ABCMeta):
     @classmethod
     def available_implementations(cls, access_policy_name: str):
         """Return the available implementations of the AccessPolicy in reverse priority order."""
-        policy_classes: list[type["BaseAccessPolicy"]] = [
+        policy_classes: list[type[BaseAccessPolicy]] = [
             entry_point.load()
             for entry_point in select_from_extension(
                 group="diracx.access_policies", name=access_policy_name

--- a/diracx-routers/src/diracx/routers/configuration.py
+++ b/diracx-routers/src/diracx/routers/configuration.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Annotated
 
 from fastapi import (
@@ -50,7 +50,7 @@ async def serve_config(
         try:
             not_before = datetime.strptime(
                 if_modified_since, LAST_MODIFIED_FORMAT
-            ).astimezone(timezone.utc)
+            ).astimezone(UTC)
         except ValueError:
             pass
         else:

--- a/diracx-routers/src/diracx/routers/fastapi_classes.py
+++ b/diracx-routers/src/diracx/routers/fastapi_classes.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-from typing import Any, Callable, TypeVar, cast
+from collections.abc import Callable
+from typing import Any, TypeVar, cast
 
 from fastapi import APIRouter, FastAPI
 from starlette.routing import Route

--- a/diracx-routers/src/diracx/routers/otel.py
+++ b/diracx-routers/src/diracx/routers/otel.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Optional
 
 from fastapi import FastAPI
 
@@ -43,7 +42,7 @@ class OTELSettings(ServiceSettingsBase):
     grpc_insecure: bool = True
     # headers to pass to the OTEL Collector
     # e.g. {"tenant_id": "lhcbdiracx-cert"}
-    headers: Optional[dict[str, str]] = None
+    headers: dict[str, str] | None = None
 
 
 def instrument_otel(app: FastAPI) -> None:

--- a/diracx-routers/tests/auth/test_standard.py
+++ b/diracx-routers/tests/auth/test_standard.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import secrets
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
@@ -571,7 +571,7 @@ async def test_refresh_token_expired(
 
     # Modify the expiration time (utc now - 5 hours)
     refresh_payload["exp"] = int(
-        (datetime.now(tz=timezone.utc) - timedelta(hours=5)).timestamp()
+        (datetime.now(tz=UTC) - timedelta(hours=5)).timestamp()
     )
 
     # Encode it differently

--- a/diracx-routers/tests/jobs/test_query.py
+++ b/diracx-routers/tests/jobs/test_query.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from http import HTTPStatus
 
 import pytest
@@ -644,13 +644,13 @@ async def test_get_job_status_history(
 
     new_status = JobStatus.CHECKING.value
     new_minor_status = "JobPath"
-    before = datetime.now(timezone.utc)
+    before = datetime.now(UTC)
 
     r = normal_user_client.patch(
         "/api/jobs/status",
         json={
             valid_job_id: {
-                datetime.now(tz=timezone.utc).isoformat(): {
+                datetime.now(tz=UTC).isoformat(): {
                     "Status": new_status,
                     "MinorStatus": new_minor_status,
                 }
@@ -658,7 +658,7 @@ async def test_get_job_status_history(
         },
     )
 
-    after = datetime.now(timezone.utc)
+    after = datetime.now(UTC)
 
     assert r.status_code == 200, r.json()
     assert r.json()["success"][str(valid_job_id)]["Status"] == new_status

--- a/diracx-routers/tests/jobs/test_status.py
+++ b/diracx-routers/tests/jobs/test_status.py
@@ -54,7 +54,7 @@ def test_set_job_status(normal_user_client: TestClient, valid_job_id: int):
         "/api/jobs/status",
         json={
             valid_job_id: {
-                datetime.now(tz=timezone.utc).isoformat(): {
+                datetime.now(tz=UTC).isoformat(): {
                     "Status": new_status,
                     "MinorStatus": new_minor_status,
                 }
@@ -94,7 +94,7 @@ def test_set_job_status_invalid_job(
         "/api/jobs/status",
         json={
             invalid_job_id: {
-                datetime.now(tz=timezone.utc).isoformat(): {
+                datetime.now(tz=UTC).isoformat(): {
                     "Status": JobStatus.CHECKING.value,
                     "MinorStatus": "JobPath",
                 }
@@ -117,7 +117,7 @@ def test_set_job_status_offset_naive_datetime_return_bad_request(
     valid_job_id: int,
 ):
     # Act
-    date = datetime.now(tz=timezone.utc).isoformat(sep=" ").split("+")[0]
+    date = datetime.now(tz=UTC).isoformat(sep=" ").split("+")[0]
     r = normal_user_client.patch(
         "/api/jobs/status",
         json={
@@ -166,7 +166,7 @@ def test_set_job_status_cannot_make_impossible_transitions(
         "/api/jobs/status",
         json={
             valid_job_id: {
-                datetime.now(tz=timezone.utc).isoformat(): {
+                datetime.now(tz=UTC).isoformat(): {
                     "Status": new_status,
                     "MinorStatus": new_minor_status,
                 }
@@ -226,7 +226,7 @@ def test_set_job_status_force(normal_user_client: TestClient, valid_job_id: int)
         "/api/jobs/status",
         json={
             valid_job_id: {
-                datetime.now(tz=timezone.utc).isoformat(): {
+                datetime.now(tz=UTC).isoformat(): {
                     "Status": new_status,
                     "MinorStatus": new_minor_status,
                 }
@@ -288,7 +288,7 @@ def test_set_job_status_bulk(normal_user_client: TestClient, valid_job_ids):
         "/api/jobs/status",
         json={
             job_id: {
-                datetime.now(timezone.utc).isoformat(): {
+                datetime.now(UTC).isoformat(): {
                     "Status": new_status,
                     "MinorStatus": new_minor_status,
                 }
@@ -332,7 +332,7 @@ def test_set_job_status_with_invalid_job_id(
         "/api/jobs/status",
         json={
             invalid_job_id: {
-                datetime.now(tz=timezone.utc).isoformat(): {
+                datetime.now(tz=UTC).isoformat(): {
                     "Status": JobStatus.CHECKING.value,
                     "MinorStatus": "JobPath",
                 }
@@ -477,7 +477,7 @@ def test_delete_job_valid_job_id(normal_user_client: TestClient, valid_job_id: i
         "/api/jobs/status",
         json={
             valid_job_id: {
-                str(datetime.now(tz=timezone.utc)): {
+                str(datetime.now(tz=UTC)): {
                     "Status": JobStatus.DELETED,
                     "MinorStatus": "Checking accounting",
                 }
@@ -512,7 +512,7 @@ def test_delete_job_invalid_job_id(normal_user_client: TestClient, invalid_job_i
         "/api/jobs/status",
         json={
             invalid_job_id: {
-                str(datetime.now(tz=timezone.utc)): {
+                str(datetime.now(tz=UTC)): {
                     "Status": JobStatus.DELETED,
                     "MinorStatus": "Checking accounting",
                 }
@@ -534,7 +534,7 @@ def test_delete_bulk_jobs_valid_job_ids(
         "/api/jobs/status",
         json={
             job_id: {
-                str(datetime.now(tz=timezone.utc)): {
+                str(datetime.now(tz=UTC)): {
                     "Status": JobStatus.DELETED,
                     "MinorStatus": "Checking accounting",
                 }
@@ -571,7 +571,7 @@ def test_delete_bulk_jobs_invalid_job_ids(
         "/api/jobs/status",
         json={
             job_id: {
-                str(datetime.now(tz=timezone.utc)): {
+                str(datetime.now(tz=UTC)): {
                     "Status": JobStatus.DELETED,
                     "MinorStatus": "Checking accounting",
                 }
@@ -601,7 +601,7 @@ def test_delete_bulk_jobs_mix_of_valid_and_invalid_job_ids(
         "/api/jobs/status",
         json={
             job_id: {
-                str(datetime.now(tz=timezone.utc)): {
+                str(datetime.now(tz=UTC)): {
                     "Status": JobStatus.DELETED,
                     "MinorStatus": "Checking accounting",
                 }
@@ -649,7 +649,7 @@ def test_kill_job_valid_job_id(normal_user_client: TestClient, valid_job_id: int
         "/api/jobs/status",
         json={
             valid_job_id: {
-                str(datetime.now(timezone.utc)): {
+                str(datetime.now(UTC)): {
                     "Status": JobStatus.KILLED,
                     "MinorStatus": "Marked for termination",
                 }
@@ -687,7 +687,7 @@ def test_kill_job_invalid_job_id(normal_user_client: TestClient, invalid_job_id:
         "/api/jobs/status",
         json={
             int(invalid_job_id): {
-                str(datetime.now(timezone.utc)): {
+                str(datetime.now(UTC)): {
                     "Status": JobStatus.KILLED,
                     "MinorStatus": "Marked for termination",
                 }
@@ -711,7 +711,7 @@ def test_kill_bulk_jobs_valid_job_ids(
         "/api/jobs/status",
         json={
             job_id: {
-                str(datetime.now(timezone.utc)): {
+                str(datetime.now(UTC)): {
                     "Status": JobStatus.KILLED,
                     "MinorStatus": "Marked for termination",
                 }
@@ -753,7 +753,7 @@ def test_kill_bulk_jobs_invalid_job_ids(
         "/api/jobs/status",
         json={
             job_id: {
-                str(datetime.now(timezone.utc)): {
+                str(datetime.now(UTC)): {
                     "Status": JobStatus.KILLED,
                     "MinorStatus": "Marked for termination",
                 }
@@ -785,7 +785,7 @@ def test_kill_bulk_jobs_mix_of_valid_and_invalid_job_ids(
         "/api/jobs/status",
         json={
             job_id: {
-                str(datetime.now(timezone.utc)): {
+                str(datetime.now(UTC)): {
                     "Status": JobStatus.KILLED,
                     "MinorStatus": "Marked for termination",
                 }
@@ -967,7 +967,7 @@ def test_patch_metadata(normal_user_client: TestClient, valid_job_id: int):
         assert j["ApplicationStatus"] == "Unknown"
 
     # Act
-    hbt = str(datetime.now(timezone.utc))
+    hbt = str(datetime.now(UTC))
     r = normal_user_client.patch(
         "/api/jobs/metadata",
         json={
@@ -1031,7 +1031,7 @@ def test_bad_patch_metadata(normal_user_client: TestClient, valid_job_id: int):
         assert j["ApplicationStatus"] == "Unknown"
 
     # Act
-    hbt = str(datetime.now(timezone.utc))
+    hbt = str(datetime.now(UTC))
     r = normal_user_client.patch(
         "/api/jobs/metadata",
         json={

--- a/diracx-testing/src/diracx/testing/mock_osdb.py
+++ b/diracx-testing/src/diracx/testing/mock_osdb.py
@@ -6,9 +6,10 @@ __all__ = (
 )
 
 import contextlib
-from datetime import datetime, timezone
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
 from functools import partial
-from typing import Any, AsyncIterator
+from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
@@ -147,7 +148,7 @@ class MockOSDBMixin:
                     result.update(result.pop("extra"))
                 for k, v in list(result.items()):
                     if isinstance(v, datetime) and v.tzinfo is None:
-                        result[k] = v.replace(tzinfo=timezone.utc)
+                        result[k] = v.replace(tzinfo=UTC)
                     if v is None:
                         result.pop(k)
                 results.append(result)

--- a/diracx-testing/src/diracx/testing/utils.py
+++ b/diracx-testing/src/diracx/testing/utils.py
@@ -10,11 +10,12 @@ import os
 import re
 import ssl
 import subprocess
-from datetime import datetime, timedelta, timezone
+from collections.abc import Generator
+from datetime import UTC, datetime, timedelta
 from functools import partial
 from html.parser import HTMLParser
 from pathlib import Path
-from typing import TYPE_CHECKING, Generator
+from typing import TYPE_CHECKING
 from urllib.parse import parse_qs, urljoin, urlparse
 
 import httpx
@@ -367,7 +368,7 @@ class ClientFactory:
         with self.unauthenticated() as client:
             payload = {
                 "sub": "testingVO:yellow-sub",
-                "exp": datetime.now(tz=timezone.utc)
+                "exp": datetime.now(tz=UTC)
                 + timedelta(self.test_auth_settings.access_token_expire_minutes),
                 "iss": ISSUER,
                 "dirac_properties": [NORMAL_USER],

--- a/docs/CLIENT.md
+++ b/docs/CLIENT.md
@@ -15,15 +15,16 @@ The DiracX client is a comprehensive toolset designed to interact with various s
 ```
 
 1. **diracx-client**: A client library generated from OpenAPI specifications.
-2. **diracx-api**: A Python API to interact with services using the diracx-client.
-3. **diracx-cli**: A command-line interface for direct interaction with the services.
+1. **diracx-api**: A Python API to interact with services using the diracx-client.
+1. **diracx-cli**: A command-line interface for direct interaction with the services.
 
 ## diracx-client
 
 The `diracx-client` consists of three parts:
-* an auto-generated client library that facilitates communication with services defined by OpenAPI specifications. (the `generated` folder)
-* customization, in the `patches` folder, which mirror the structure of the generated client.
-* the base modules (`aio`, `extensions`, `models`) just exporting what we want to be exporting
+
+- an auto-generated client library that facilitates communication with services defined by OpenAPI specifications. (the `generated` folder)
+- customization, in the `patches` folder, which mirror the structure of the generated client.
+- the base modules (`aio`, `extensions`, `models`) just exporting what we want to be exporting
 
 `diracx-client` also defines a `AsyncDiracClient` class which exposes all these low level calls, and handles the authentication/authorisation aspects, as well as the interactions with extensions.
 
@@ -83,7 +84,6 @@ Optional environment variables:
 - `DIRACX_LOG_LEVEL`: logging level (e.g. `ERROR`). Defaults to `INFO`.
 - `DIRACX_CREDENTIALS_PATH`: path where access and refresh tokens are stored. Defaults to `~/.cache/diracx/credentials.json`.
 
-
 ### Getting preferences
 
 Developers can get access to the preferences through the following method:
@@ -107,8 +107,8 @@ The `diracx-api` provides a Python API for interacting with services, leveraging
 API methods are located in `diracx-api/src/diracx/api/`. To create an API method:
 
 1. Import `AsyncDiracClient`.
-2. Decorate the method with `@with_client` to handle client configuration.
-3. Pass the `client` as a keyword argument.
+1. Decorate the method with `@with_client` to handle client configuration.
+1. Pass the `client` as a keyword argument.
 
 #### Example
 
@@ -116,9 +116,9 @@ API methods are located in `diracx-api/src/diracx/api/`. To create an API method
 from diracx.client.aio import AsyncDiracClient
 from .utils import with_client
 
+
 @with_client
-async def create_sandbox(paths: list[Path], *, client: AsyncDiracClient) -> str:
-    ...
+async def create_sandbox(paths: list[Path], *, client: AsyncDiracClient) -> str: ...
 ```
 
 In this example, `paths` are the parameters of the API. The `@with_client` decorator allows the method to be called without manually managing the client:
@@ -142,8 +142,8 @@ The `diracx-cli` is a command-line interface built on `diracx-client` and `dirac
 CLI commands are located in `diracx-cli/src/diracx/cli/`. To create a CLI command:
 
 1. Import `AsyncDiracClient` and/or the diracx API.
-2. Import `utils.AsyncTyper`.
-3. Use the `@app.async_command` decorator to define commands.
+1. Import `utils.AsyncTyper`.
+1. Use the `@app.async_command` decorator to define commands.
 
 For adding a new command, it needs to be added to one of the following entrypoint:
 
@@ -164,6 +164,7 @@ from diracx.client.aio import AsyncDiracClient
 
 app = AsyncTyper()
 
+
 @app.async_command()
 async def submit(jdl: list[FileText]):
     async with AsyncDiracClient() as client:
@@ -175,7 +176,9 @@ For more details on Typer and Rich options, refer to their [Typer documentation]
 ### Associating Commands and Subcommands
 
 - Commands without subcommands (e.g., `dirac login`) should be implemented directly in `src/diracx/__init__.py` and decorated with `app.async_command()`.
+
 - Commands with subcommands (e.g., `dirac jobs submit`) should have their own modules in `src/diracx/<command>` and use `AsyncTyper`.
+
   - To associate the command with `dirac`, import the module in `src/diracx/__init__.py`:
 
   ```python

--- a/docs/CODING_CONVENTION.md
+++ b/docs/CODING_CONVENTION.md
@@ -26,9 +26,9 @@ Depending on which module you are using, there could be rules to follow that are
 ```python
 import pytest
 
+
 @pytest.fixture
-def my_ficture():
-    ...
+def my_ficture(): ...
 ```
 
 </td>
@@ -38,9 +38,9 @@ def my_ficture():
 ```python
 from pytest import fixture
 
+
 @fixture
-def my_ficture():
-    ...
+def my_ficture(): ...
 ```
 
 </td>
@@ -50,12 +50,14 @@ def my_ficture():
 <td>
 
 `datetime`
+
 </td>
 
 <td>
 
 ```python
 from datetime import datetime, timedelta
+
 delay = datetime.now() + timedelta(hours=1)
 ```
 
@@ -65,6 +67,7 @@ delay = datetime.now() + timedelta(hours=1)
 
 ```python
 import datetime
+
 delay = datetime.datetime.now() + datetime.timedelta(hours=1)
 ```
 
@@ -75,6 +78,7 @@ delay = datetime.datetime.now() + datetime.timedelta(hours=1)
 <td>
 
 `SQL Alchemy`
+
 </td>
 
 <td>
@@ -82,13 +86,11 @@ delay = datetime.datetime.now() + datetime.timedelta(hours=1)
 ```python
 class Owners(Base):
     __tablename__ = "Owners"
-    owner_id = Column("OwnerID",
-        Integer,
-        primary_key=True,
-        autoincrement=True)
+    owner_id = Column("OwnerID", Integer, primary_key=True, autoincrement=True)
     creation_time = DateNowColumn("CreationTime")
     name = Column("Name", String(255))
 ```
+
 </td>
 
 <td>
@@ -96,17 +98,15 @@ class Owners(Base):
 ```python
 class Owners(Base):
     __tablename__ = "Owners"
-    OwnerID = Column(Integer,
-        primary_key=True,
-        autoincrement=True)
+    OwnerID = Column(Integer, primary_key=True, autoincrement=True)
     CreationTime = DateNowColumn()
     Name = Column(String(255))
 ```
+
 </td>
 </tr>
 
 </table>
-
 
 ## Structure
 
@@ -117,7 +117,6 @@ The following structures principles may also be followed:
 - If we need more files (think of jobs, which have the sandbox, the joblogging, etc), we put them in a sub module (e.g routers.job). The code goes in a specific file (job.py, joblogging.py) but we use the the __init__.py to expose the specific file
 
 See [this issue](https://github.com/DIRACGrid/diracx/issues/268).
-
 
 ## Architecture
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -8,8 +8,8 @@ Confidential information (such as passwords) is only handled in Settings, see th
 The DiracX configuration is stored as a single YAML file.
 We recommend that this is stored within a Git repository, and DiracX provides two git-based backends can be used by servers:
 
-* `git+file`: Refers to a local git repository. This must be stored on a shared volume which is made available to all DiracX servers.
-* `git+https`: Refers to a remote git repository that can be stored on any standard git host.
+- `git+file`: Refers to a local git repository. This must be stored on a shared volume which is made available to all DiracX servers.
+- `git+https`: Refers to a remote git repository that can be stored on any standard git host.
 
 ## Structure of the CS
 
@@ -46,19 +46,24 @@ import zlib
 from pathlib import Path
 
 import DIRAC
+
 DIRAC.initialize()
 from DIRAC import gConfig
 from DIRAC.Core.Utilities.ReturnValues import returnValueOrRaise
 from DIRAC.ConfigurationSystem.Client.ConfigurationClient import ConfigurationClient
 
-client = ConfigurationClient(url=gConfig.getValue("/DIRAC/Configuration/MasterServer", ""))
+client = ConfigurationClient(
+    url=gConfig.getValue("/DIRAC/Configuration/MasterServer", "")
+)
 data = returnValueOrRaise(client.getCompressedData())
 data = zlib.decompress(data)
 with tempfile.NamedTemporaryFile() as tmp:
     tmp.write(data)
     tmp.flush()
     cmd = ["dirac", "internal", "legacy", "cs-sync", tmp.name, "default.yml"]
-    subprocess.run(cmd, env=os.environ | {"DIRAC_COMPAT_ENABLE_CS_CONVERSION": "yes"}, check=True)
+    subprocess.run(
+        cmd, env=os.environ | {"DIRAC_COMPAT_ENABLE_CS_CONVERSION": "yes"}, check=True
+    )
 
 print("Synced CS to default.yml, now you can review the changes and commit/push them")
 ```

--- a/docs/DATABASES.md
+++ b/docs/DATABASES.md
@@ -23,7 +23,6 @@ export DIRACX_DB_URL_MYDB="mysql+aiomysql://user:pass@hostname:3306/MyDB"
 
 See the DiracX helm chart for more details about configuring access to databases.
 
-
 ### Using SQL databases
 
 See the services/tasks documentation for details about how the database classes should be used.

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,13 +1,13 @@
-
 Start from DIRAC v8
 
 Edit the CS:
-* DiracX/DisabledVO is all of them
-* DiracX/LegacyClientEnabled is empty
+
+- DiracX/DisabledVO is all of them
+- DiracX/LegacyClientEnabled is empty
 
 Add in the CS:
-* conversion info
 
+- conversion info
 
 Update to v9
 

--- a/docs/OPENTELEMETRY.md
+++ b/docs/OPENTELEMETRY.md
@@ -2,10 +2,10 @@
 
 > :warning: **Experimental**: opentelemetry is an evolving product, and so is our implementation of it.
 
-``diracx`` is capable of sending [OpenTelemetry](https://opentelemetry.io/) data to a collector. The settings are controled by the
-``diracx.routers.otel.OTELSettings`` classes
+`diracx` is capable of sending [OpenTelemetry](https://opentelemetry.io/) data to a collector. The settings are controled by the
+`diracx.routers.otel.OTELSettings` classes
 
-``diracx`` will then export metrics, traces, and logs. For the moment, nothing is really instrumented, but the infrastructure is there
+`diracx` will then export metrics, traces, and logs. For the moment, nothing is really instrumented, but the infrastructure is there
 
 ![OTEL Logs](./otel-logs.png)
 ![OTEL Metrics](./otel-metrics.png)

--- a/docs/README.md
+++ b/docs/README.md
@@ -78,12 +78,10 @@ pytest --demo-dir=../diracx-charts/
 
 This only runs the diracx server, not any dependency like external IdP.
 
-
 ```bash
 # In the `diracx` folder
 ./run_local.sh
 ```
-
 
 ## Add a DB
 
@@ -91,7 +89,6 @@ Database classes live in `src/diracx/db/sql/<dbname>`. Have a look at the `src/d
 
 > [!NOTE]
 > We do not want to use the `ORM` part of `SQLAlchemy` (only the `core`) for performance reasons
-
 
 ## Dependency injection
 
@@ -107,8 +104,7 @@ def my_route(
     settings: Annotated[AuthSettings, Depends(AuthSettings.create)],
     job_db: Annotated[JobDB, Depends(JobDB.transaction)],
     user_info: Annotated[UserInfo, Depends(verify_dirac_token)],
-) -> MyReturnType:
-    ...
+) -> MyReturnType: ...
 ```
 
 ### Configuration
@@ -139,8 +135,8 @@ See the `UserInfo` class for the available properties.
 To add a router there are two steps:
 
 1. Create a module in `diracx.routers` for the given service.
-2. Add an entry to the `diracx.services` entrypoint.
-3. Do not forget the Access Policy (see chapter lower down)
+1. Add an entry to the `diracx.services` entrypoint.
+1. Do not forget the Access Policy (see chapter lower down)
 
 We'll now make a `/parking/` router which contains information store in the `DummyDB`.
 
@@ -158,12 +154,10 @@ diracx.services =
 	parking = diracx.routers.parking:router
 ```
 
-
 This will prefix the routes with `/parking/` and mark them with the `"parking"` tag in the OpenAPI spec.
 
 > [!WARNING]
 > Any modification in the `setup.cfg` requires to re-install install `diracx`, even if it is a developer installation (`pip install -e`)
-
 
 ## Conventions
 

--- a/docs/ROADMAP.MD
+++ b/docs/ROADMAP.MD
@@ -2,20 +2,20 @@
 
 ## Getting to 0.0.1
 
-* First release contains:
-    * All service/client underpinnings
-    * Extension support
-    * JobStateUpdateHandler can be replaced by DiracX
-* Prior to release: Install in LHCbDIRAC production to ensure full functionality.
+- First release contains:
+  - All service/client underpinnings
+  - Extension support
+  - JobStateUpdateHandler can be replaced by DiracX
+- Prior to release: Install in LHCbDIRAC production to ensure full functionality.
 
 ### What do we need to get there?
 
-* [ ] Finish any DIRAC v9 cleanups
-* [ ] Get LHCbDIRAC certification running stably with DIRAC v9
-* [ ] Finish legacy adapter for JobStateUpdateClient
-* [ ] Admin VO
-* [ ] Ensure the helm chart is stable for updates
-* [ ] Make sure the docs are complete
+- [ ] Finish any DIRAC v9 cleanups
+- [ ] Get LHCbDIRAC certification running stably with DIRAC v9
+- [ ] Finish legacy adapter for JobStateUpdateClient
+- [ ] Admin VO
+- [ ] Ensure the helm chart is stable for updates
+- [ ] Make sure the docs are complete
 
 ## After 0.0.1
 
@@ -23,16 +23,16 @@ For the migration, we want to prioritize deprecating DIRAC over adding new funct
 
 Work towards DiracX 1.0.0 is highly parallelizable and is split into three main work packages:
 
-* **Core:** Tasks in the core work package are worked on by the core DiracX team and provide fundamental underpinnings.
-* **WMS:** Work on the Workload Management System (WMS) includes the matcher, pilot authentication, and pilot submission.
-* **CWL**: The CWL work package is focused on supporting Common Workflow Language features. These will be the first truly new functionality that is available and will focus on the experience of users.
+- **Core:** Tasks in the core work package are worked on by the core DiracX team and provide fundamental underpinnings.
+- **WMS:** Work on the Workload Management System (WMS) includes the matcher, pilot authentication, and pilot submission.
+- **CWL**: The CWL work package is focused on supporting Common Workflow Language features. These will be the first truly new functionality that is available and will focus on the experience of users.
 
 To avoid bottlenecks in the development process the roadmap segments parts of DiracX to enable the system to run in parallel to the legacy DIRAC installation. For example when migrating the job matching infrastructure:
 
-* The `JobDB` contents is left unmodified.
-* DIRAC and DiracX matching infrastructure runs in parallel
-* Existing pilots match jobs from both DIRAC and DiracX.
-* When submitting a job, the matching process is assigned to either DIRAC or DiracX. Deciding which infrastructure to use can be done either probabilistically and/or based on attributes of the job.
+- The `JobDB` contents is left unmodified.
+- DIRAC and DiracX matching infrastructure runs in parallel
+- Existing pilots match jobs from both DIRAC and DiracX.
+- When submitting a job, the matching process is assigned to either DIRAC or DiracX. Deciding which infrastructure to use can be done either probabilistically and/or based on attributes of the job.
 
 This allows the migration to be independent of other modernizations. A similar strategy is used for migrating the pilot and transformation infrastructure.
 

--- a/docs/SERVICES.md
+++ b/docs/SERVICES.md
@@ -42,6 +42,7 @@ Example:
 @add_settings_annotation
 class AuthSettings(ServiceSettingsBase):
     """Settings for the authentication service."""
+
     model_config = SettingsConfigDict(env_prefix="DIRACX_SERVICE_AUTH_")
 
     token_key: TokenSigningKey
@@ -61,8 +62,7 @@ Usage example:
 
 ```python
 @router.get("/openid-configuration")
-async def get_openid_configuration(settings: AuthSettings):
-    ...
+async def get_openid_configuration(settings: AuthSettings): ...
 ```
 
 ### User Info
@@ -71,8 +71,9 @@ To retrieve information about the current user, depend on `AuthorizedUserInfo`.
 
 ```python
 @router.get("/userinfo")
-async def userinfo(user_info: Annotated[AuthorizedUserInfo, Depends(verify_dirac_access_token)]):
-    ...
+async def userinfo(
+    user_info: Annotated[AuthorizedUserInfo, Depends(verify_dirac_access_token)],
+): ...
 ```
 
 **TODO:** Consider avoiding the need to manually specify the annotation.
@@ -83,8 +84,7 @@ To extract information from the central DIRAC configuration:
 
 ```python
 @router.post("/summary")
-async def summary(config: Annotated[Config, Depends(ConfigSource.create)]):
-    ...
+async def summary(config: Annotated[Config, Depends(ConfigSource.create)]): ...
 ```
 
 The `Config` object is cached efficiently between requests and automatically refreshed. It is strongly typed and immutable for the duration of a request.
@@ -100,9 +100,9 @@ Example:
 ```python
 from diracx.routers.dependencies import JobDB, JobLoggingDB
 
+
 @router.delete("/{job_id}")
-async def delete_single_job(job_db: JobDB, job_logging_db: JobLoggingDB):
-    ...
+async def delete_single_job(job_db: JobDB, job_logging_db: JobLoggingDB): ...
 ```
 
 There are advanced and uncommon scenarios where committing a transaction is necessary even when returning an error response (e.g., revoking tokens in the database and returning an error to a potentially malicious user). In such cases, explicitly committing the transaction before raising an exception is crucial. Without this explicit commit, the intended changes would be rolled back along with the transaction, leading to unintended consequences:
@@ -136,9 +136,9 @@ Example:
 ```python
 from diracx.routers.dependencies import JobParametersDB
 
+
 @router.post("/search", responses=EXAMPLE_RESPONSES)
-async def search(job_parameters_db: JobParametersDB):
-    ...
+async def search(job_parameters_db: JobParametersDB): ...
 ```
 
 ## Permission Management
@@ -158,6 +158,7 @@ Each route must have a policy as an argument and call it:
 ```python
 from .access_policies import ActionType, CheckWMSPolicyCallable
 
+
 @router.post("/")
 async def submit_jobs(
     job_definitions: Annotated[list[str], Body()],
@@ -175,17 +176,18 @@ Some routes do not need access permissions, like the authorization ones, in whic
 ```python
 from .access_policies import open_access
 
+
 @open_access
 @router.get("/")
-async def serve_config():
-    ...
+async def serve_config(): ...
 ```
 
 Implementing a new `AccessPolicy` is done by:
+
 1. Creating a module in `diracx.routers.<service>access_policies.py`
-2. Creating a new class inheriting from `BaseAccessPolicy`
-3. For specific instructions, see `diracx-routers/src/diracx/routers/access_policies.py`
-4. Adding an entry to the `diracx.access_policies` entrypoint.
+1. Creating a new class inheriting from `BaseAccessPolicy`
+1. For specific instructions, see `diracx-routers/src/diracx/routers/access_policies.py`
+1. Adding an entry to the `diracx.access_policies` entrypoint.
 
 > [!WARNING]
 > When running tests, no permission is checked. This is to allow testing the router behavior with respect to the policy behavior. For testing a policy, see for example `diracx-routers/tests/jobs/test_wms_access_policy.py`
@@ -196,8 +198,8 @@ When routes are defined they're automatically included in the OpenAPI specificat
 This is then used to automatically generate client bindings and means that more of the Python code is included in the externally visible interface than is typically expected.
 To ensure consistency, the following rules must be followed:
 
-* All routers must be tagged and the first tag becomes the name of the sub-client.
-* The name of the route becomes the name of the client method.
-* Uses of `fastapi.Form` must specify a `description`.
+- All routers must be tagged and the first tag becomes the name of the sub-client.
+- The name of the route becomes the name of the client method.
+- Uses of `fastapi.Form` must specify a `description`.
 
-[^1]: The only exception is `/.well-known/`.
+\[^1\]: The only exception is `/.well-known/`.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,11 +1,11 @@
 What we do
 
-* each package runs unit tests in different jobs to ensure that there is no hidden dependencies: pytest and mypy
-* run the integration tests (against the demo) in a single job
+- each package runs unit tests in different jobs to ensure that there is no hidden dependencies: pytest and mypy
+- run the integration tests (against the demo) in a single job
 
 For the unit test, we start with a crude conda environment, and do pip install of the package.
 Note: `diracx-logic` does not contain any unit tests, developers are expected to run tests from `diracx-routers`.
 
-For the integration tests, we always use the [services|tasks|client] dev image and do a pip install directly with ``--no-deps``.
+For the integration tests, we always use the [services|tasks|client] dev image and do a pip install directly with `--no-deps`.
 
 Same for unit tests (router tests use `services:dev`, etc)

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -3,11 +3,13 @@
 DiracX is a comprehensive Python package, composed of several interconnected submodules. It's designed to provide robust and versatile functionalities, primarily through these key components:
 
 1. **User-Facing Components**:
+
    - **`diracx`**: This is the primary interface for users, integrating both the Command Line Interface (CLI) and Python API.
    - **`diracx-routers`**: Serves as the server component, offering HTTPS endpoints.
    - **`diracx-tasks`**: Handles operations executed by DiracX servers, either periodically or upon request.
 
-2. **Containerization**:
+1. **Containerization**:
+
    - Each component is available as a container image, packaging DiracX along with all necessary dependencies.
 
 ## Python Modules
@@ -70,7 +72,6 @@ flowchart BT
 
 ```
 
-
 ### Versioning Strategy
 
 - Currently, and as long as `DIRAC` and `diracx` coexist, we employ a versioning format of v0.<major>.<patch>.
@@ -82,14 +83,17 @@ flowchart BT
 DiracX utilizes a structured approach to containerization:
 
 1. **Base Image**:
+
    - All container images start from `diracx/base`.
 
-2. **Specialized Base Images**:
+1. **Specialized Base Images**:
+
    - `diracx/services-base`
    - `diracx/tasks-base`
    - `diracx/client-base`
 
-3. **Image Versioning and Building**:
+1. **Image Versioning and Building**:
+
    - Images are built periodically (e.g., every Monday) and tagged as `YYYY.MM.DD.P`.
    - A DiracX release triggers the creation of new `DiracXService`, `diracx/tasks`, and `diracx/client` images, based on specific `diracx/base` tags.
    - This approach ensures stability in production environments.

--- a/environment.yml
+++ b/environment.yml
@@ -9,3 +9,6 @@ dependencies:
   - python-gfal2
   - mypy
   - codespell
+  - mdformat
+  - mdformat-gfm
+  - mdformat-black

--- a/environment.yml
+++ b/environment.yml
@@ -10,5 +10,3 @@ dependencies:
   - mypy
   - codespell
   - mdformat
-  - mdformat-gfm
-  - mdformat-black

--- a/environment.yml
+++ b/environment.yml
@@ -8,3 +8,4 @@ dependencies:
   - m2crypto
   - python-gfal2
   - mypy
+  - codespell

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -1,4 +1,3 @@
-
 # Gubbins
 
 `gubbins` is a `diracx` extension. It is a show-case for everything which is possible to extend.
@@ -24,24 +23,23 @@ Any use cases not listed here are not supported, if you think you need additiona
 
 NOTE: This documentation is still a work in progress!!!
 
-
 ## QUESTIONS
 
 What to do with the `environment.yaml` ? should we replicate wht's in diracx ?
 
-
 ## General statements
 
 The fact of having `gubbins` as a subfolder has a few downside which you will not suffer if having your extension in a separate repository:
-* the `root` of `setuptools_scm` in the various `pyproject.toml` will only be `..` for your extension
+
+- the `root` of `setuptools_scm` in the various `pyproject.toml` will only be `..` for your extension
 
 ## CI
 
 The extension is tested in the CI.
 
-What is in the [action file](``.github/workflows/extensions.yaml``) should in fact be split in multiple jobs under ``.github/workflows/`` of your repo.
+What is in the [action file](%60%60.github/workflows/extensions.yaml%60%60) should in fact be split in multiple jobs under `.github/workflows/` of your repo.
 
-Here we use the local versions of `diracx` packages to make sure we are always up to date, and that a change in `diracx` does not break the extension mechanisms. But in your real extension, you will want to depend on published package (i.e. ``pip install diracx-routers`` instead of ``pip install -e ./diracx-routers`` for example), and on published docker images.
+Here we use the local versions of `diracx` packages to make sure we are always up to date, and that a change in `diracx` does not break the extension mechanisms. But in your real extension, you will want to depend on published package (i.e. `pip install diracx-routers` instead of `pip install -e ./diracx-routers` for example), and on published docker images.
 
 Moreover, the `gubbins` docker images are never uploaded, and are only passed from on job to the next. You should definitely upload yours.
 
@@ -87,11 +85,9 @@ A [router test](extensions/gubbins/gubbins-routers/tests/test_gubbins_job_manage
 > [!WARNING]
 > in the [test dependency](gubbins/gubbins-routers/tests/test_gubbins_job_manager.py), you need to specify both the original DiracX `JobDB` as well as the extended one `GubbinsJobDB`. To avoid that inconvenience, reuse the same name (i.e. `JobDB` instead of `GubbinsJobDB`)
 
-
 ## Routers
 
 The `gubbins-router` package contains the extension for the DB.
-
 
 ### New router
 
@@ -101,47 +97,51 @@ The `gubbins-router` package contains the extension for the DB.
 
 `well-known` overwrites the `dirac-metadata` endpoint. It also changes the return type and makes use of gubbins' specific configs.
 
-
 ## Client
 
 The requirements are the following:
 
-* Working with the `DiracClient` should allow you to call the API from the extension
-* It should be possible to use directly the extension client (i.e. `GubbinsClient`)
-* Methods/Operations/models that are patched in `diracx` cannot be re-patched in the extension
-
+- Working with the `DiracClient` should allow you to call the API from the extension
+- It should be possible to use directly the extension client (i.e. `GubbinsClient`)
+- Methods/Operations/models that are patched in `diracx` cannot be re-patched in the extension
 
 ### New client
 
 To create a client extension:
-* mirror the structure of the `diracx-client`
-* Generate a client in `generated` using `Autorest` For this the best is to have a temporary router test writing the `openapi.json` somewhere
+
+- mirror the structure of the `diracx-client`
+- Generate a client in `generated` using `Autorest` For this the best is to have a temporary router test writing the `openapi.json` somewhere
+
 ```python
 r = normal_user_client.get("/api/openapi.json")
-with open('/tmp/openapi.json', 'wt') as f:
+with open("/tmp/openapi.json", "wt") as f:
     json.dump(r.json(), f, indent=2)
 ```
-* The autorest command then looks something like
+
+- The autorest command then looks something like
+
 ```bash
 autorest --python --input-file=/tmp/openapi.json --models-mode=msrest --namespace=generated --output-folder=gubbins-client/src/gubbins/
 ```
 
-* Create the `patches` directory, simply exporting the generated `clients`(both [sync](gubbins/gubbins-client/src/gubbins/client/patches/__init__.py) and [async](gubbins/gubbins-client/src/gubbins/client/patches/aio/__init__.py))
-* Define the base modules to export what is needed
-* The [top init](gubbins/gubbins-client/src/gubbins/client/__init__.py) MUST have
+- Create the `patches` directory, simply exporting the generated `clients`(both [sync](gubbins/gubbins-client/src/gubbins/client/patches/__init__.py) and [async](gubbins/gubbins-client/src/gubbins/client/patches/aio/__init__.py))
+- Define the base modules to export what is needed
+- The [top init](gubbins/gubbins-client/src/gubbins/client/__init__.py) MUST have
+
 ```python
 import diracx.client
 ```
 
-* Generate the autorest client (see CI `regenerate_client`)
+- Generate the autorest client (see CI `regenerate_client`)
 
 ## CLI
 
 The following CLI extensions are supported:
-* add a new subcommand
-* extend an existing subcommand
-* modify an existing subcommand
-* no `gubbins` CI, everything through `dirac` cli
+
+- add a new subcommand
+- extend an existing subcommand
+- modify an existing subcommand
+- no `gubbins` CI, everything through `dirac` cli
 
 The CLI is managed by the `diracx.cli` entry point
 
@@ -158,7 +158,6 @@ See the `gubbins-cli` package for instructions
 
 ### New subcommand
 
-
 `lollygag` is a new CLI command, calling the `lollygag` router.
 
 ### Changing a subcommand
@@ -169,26 +168,25 @@ For completely replacing a subcommand, it is enough to change the corresponding 
 
 You can modify the behavior of a specific CLI call, or add extra calls to an existing subcommand. The `config` CLI shows just that.
 
-
 ## Configuration
 
 Only extending the configuration is allowed. For example, you can add extra fields for the users
 
 You need to:
 
-* Redefine a new configuration [schema](gubbins/gubbins-core/src/gubbins/core/config/schema.py)
-* Declare this new class in the `diracx` entrypoint
+- Redefine a new configuration [schema](gubbins/gubbins-core/src/gubbins/core/config/schema.py)
+- Declare this new class in the `diracx` entrypoint
+
 ```toml
 [project.entry-points."diracx"]
 config = "gubbins.core.config.schema:Config"
 ```
-* Redefine a dependency for your routers to use (see [example](gubbins/gubbins-routers/src/gubbins/routers/dependencies.py))
 
+- Redefine a dependency for your routers to use (see [example](gubbins/gubbins-routers/src/gubbins/routers/dependencies.py))
 
 ## Properties
 
 Properties can only be added. This is done in the `gubbins-core` `pyproject.toml`
-
 
 ```toml
 [project.entry-points."diracx"]
@@ -197,22 +195,20 @@ properties_module = "gubbins.core.properties"
 
 [properties](gubbins/gubbins-core/src/gubbins/core/properties.py) illustrates how to do it
 
-
 ## Writing tests
 
 `diracx-testing` package contains a lot of useful tools for testing `diracx` and its extensions.
 
 Note that even if you have your own `testing` package depending on `diracx-testing`, you should specify it when calling `pytest` (see various `pyprojects.toml`)
 
-
 ## Work on gubbins
 
 Working on this test extension is tricky as it is a subdirectory. if you want to debug it you need to:
 
-* buid the `gubbins` docker images (or download an art)
-* copy the files somewhere else
-* edit the pyproject
-* run_demo
+- buid the `gubbins` docker images (or download an art)
+- copy the files somewhere else
+- edit the pyproject
+- run_demo
 
 This is what is done in the [CI](../.github/workflows/extensions.yml)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,9 @@ ignore = [
     "D401",
     "D404",
 ]
+extend-select = [
+  "UP",  # pyupgrade
+]
 
 [tool.ruff.lint.isort]
 required-imports = ["from __future__ import annotations"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ testing = ["diracx-testing"]
 packages = []
 
 [build-system]
-requires = ["setuptools>=61", "wheel", "setuptools_scm>=8"]
+requires = ["setuptools>=61", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
@@ -139,6 +139,7 @@ module = 'sh.*'
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]
+minversion = "8"
 testpaths = [
     "diracx-api/tests",
     "diracx-cli/tests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ exclude = [
 
 [tool.ruff.lint]
 select = [
-    "E",   # pycodestyle errrors
+    "E",   # pycodestyle errors
     "F",   # pyflakes
     "B",   # flake8-bugbear
     "I",   # isort
@@ -141,6 +141,7 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 minversion = "8"
 log_cli_level = "INFO"
+xfail_strict = true
 testpaths = [
     "diracx-api/tests",
     "diracx-cli/tests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,7 @@ ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 minversion = "8"
+log_cli_level = "INFO"
 testpaths = [
     "diracx-api/tests",
     "diracx-cli/tests",
@@ -155,7 +156,9 @@ addopts = [
     "-pdiracx.testing",
     "-pdiracx.testing.osdb",
     "--import-mode=importlib",
+    "-ra", "--strict-config", "--strict-markers"
 ]
+filterwarnings = ["default"]
 asyncio_mode = "auto"
 markers = [
     "enabled_dependencies: List of dependencies which should be available to the FastAPI test client",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ profile = "black"
 
 
 [tool.mypy]
-strict = true
+strict = false
 warn_unreachable = true
 files = [
     "diracx-api/src/**/*.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,8 @@ profile = "black"
 
 
 [tool.mypy]
+strict = true
+warn_unreachable = true
 files = [
     "diracx-api/src/**/*.py",
     "diracx-cli/src/**/*.py",
@@ -124,7 +126,7 @@ allow_redefinition = true
 explicit_package_bases = true
 # disallow_untyped_defs = true
 # strict = true
-enable_error_code = ["import", "attr-defined"]
+enable_error_code = ["import", "attr-defined", "ignore-without-code", "redundant-expr", "truthy-bool"]
 
 [[tool.mypy.overrides]]
 module = 'DIRAC.*'

--- a/security_model.md
+++ b/security_model.md
@@ -5,26 +5,31 @@ Version: v0.9.0
 ## Table of Contents
 
 1. [Introduction](#introduction)
+
    - [Terms and Definitions](#terms-and-definitions)
 
-2. [DiracX Authorisation and Authentication](#diracx-authorisation-and-authentication)
+1. [DiracX Authorisation and Authentication](#diracx-authorisation-and-authentication)
+
    - [User and Group Management](#user-and-group-management)
    - [Lifetime](#lifetime)
    - [Token Profile](#token-profile)
    - [Signature Verification](#signature-verification)
    - [Issuance](#issuance)
-       - [Supported Authorisation Flows](#supported-authorisation-flows)
+     - [Supported Authorisation Flows](#supported-authorisation-flows)
    - [Pilot Jobs](#pilot-jobs)
    - [Installation Administrators](#installation-administrators)
 
-3. [External Authorization and Authentication](#external-authorization-and-authentication)
+1. [External Authorization and Authentication](#external-authorization-and-authentication)
+
    - [Storage Access](#storage-access)
    - [Computing Resources](#computing-resources)
 
-4. [Network Communication](#network-communication)
+1. [Network Communication](#network-communication)
+
    - [Certificate Signing](#certificate-signing)
 
-5. [Threat Analysis](#threat-analysis)
+1. [Threat Analysis](#threat-analysis)
+
    - [Compromised External IdP](#compromised-external-idp)
    - [Compromised Batch Submission System](#compromised-batch-submission-system)
    - [Compromised Worker Node](#compromised-worker-node)
@@ -35,9 +40,9 @@ Version: v0.9.0
    - [Compromised Hosts](#compromised-hosts)
    - [Malicious Legitimate User](#malicious-legitimate-user)
 
-6. [Legacy Compatibility and Migration](#legacy-compatibility-and-migration)
+1. [Legacy Compatibility and Migration](#legacy-compatibility-and-migration)
 
-7. [Changelog](#changelog)
+1. [Changelog](#changelog)
 
 ## Introduction
 
@@ -47,27 +52,27 @@ This document describes how DiracX enables installations to be secure and robust
 
 ### Terms and Definitions
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
 
 Commonly used terms in this document are described below.
 
-* **External IdP:** The Identity Provider that is responsible for managing a Virtual Organisation's users.
-* **Group:** A DiracX-specific extension to a user's identity that enables additional access control features. A user may be a member of many groups but only ever has one associated with their current identity. All the members of a group belong to the same Virtual Organisation.
-* **Identity:** The subject and their currently chosen group.
-* **Installation administrator:** A person responsible for managing the DiracX installation itself.
-* **Installation:** A single deployment of DiracX services.
-* **Pilot:** A job submitted to a computing resource's batch system. DiracX then uses this to run any number of DiracX jobs on behalf of users in a Virtual Organisation.
-* **Capability:** A string which represents a specific authorisation within DiracX.
-* **User:** An identity which is registered within a Virtual Organisation that is part of the DiracX installation.
-* **Virtual Organisation:** A set of users that is defined around a common set of resource-sharing rules and conditions.
+- **External IdP:** The Identity Provider that is responsible for managing a Virtual Organisation's users.
+- **Group:** A DiracX-specific extension to a user's identity that enables additional access control features. A user may be a member of many groups but only ever has one associated with their current identity. All the members of a group belong to the same Virtual Organisation.
+- **Identity:** The subject and their currently chosen group.
+- **Installation administrator:** A person responsible for managing the DiracX installation itself.
+- **Installation:** A single deployment of DiracX services.
+- **Pilot:** A job submitted to a computing resource's batch system. DiracX then uses this to run any number of DiracX jobs on behalf of users in a Virtual Organisation.
+- **Capability:** A string which represents a specific authorisation within DiracX.
+- **User:** An identity which is registered within a Virtual Organisation that is part of the DiracX installation.
+- **Virtual Organisation:** A set of users that is defined around a common set of resource-sharing rules and conditions.
 
 ## DiracX authorisation and authentication
 
 DiracX is built around the OAuth 2.0 authorisation flow, with the exception that an identity MUST always be present alongside authorisation to enable user-specific behaviours such as:
 
-* Limiting file access to a user's/group's files (POSIX style)
-* Enforcing user/group-specific quotas on compute and storage resources
-* Allowing for easier traceability
+- Limiting file access to a user's/group's files (POSIX style)
+- Enforcing user/group-specific quotas on compute and storage resources
+- Allowing for easier traceability
 
 For communication between users and DiracX services JSON Web Tokens (JWTs) are used as OAuth2 bearer tokens. The same mechanism is used whenever impersonation is required, such as running a user-provided payload in a job. The need to use encrypted JWT is not forseen.
 
@@ -90,9 +95,9 @@ Refresh tokens have a longer lifetime and are verified by a central service. Ref
 
 The access token profile contains the standardised fields from RFC-7519 (`sub`, `aud`, `iss`, `jti`) and OpenID Connect Core 1.0 (`preferred_username`). The `sub` field is unique per person per VO and there is a single issuer per installation. In addition, the token contains DiracX-specific fields:
 
-* `vo`: String containing the name of the virtual Organisation to which the user belongs. This field may change if it becomes a registered field following the merge of WLCG, EGI and SciTokens profiles, in which case we would adapt.
-* `dirac_group`: String containing the name of the current group that the user is acting as a member of. This is used only for identity purposes.
-* `dirac_capabilities`: A list of strings representing the DiracX-specific permissions for authentication.
+- `vo`: String containing the name of the virtual Organisation to which the user belongs. This field may change if it becomes a registered field following the merge of WLCG, EGI and SciTokens profiles, in which case we would adapt.
+- `dirac_group`: String containing the name of the current group that the user is acting as a member of. This is used only for identity purposes.
+- `dirac_capabilities`: A list of strings representing the DiracX-specific permissions for authentication.
 
 These fields are requested using the `scope` parameter when initiating the OAuth2 flow.
 
@@ -106,37 +111,36 @@ The JSON Web Keys required for verifying tokens are publically exposed according
 
 Users need to be issued tokens in two main contexts:
 
-* within a web browser for the DIRAC web portal
-* within an interactive terminal session
+- within a web browser for the DIRAC web portal
+- within an interactive terminal session
 
 There MAY also be other contexts in which can be issued tokens on a per-installation basis. This mechanism is very generic, and only relies on being able to receive a proof of identity from a trusted source. Some examples include:
 
-* Exchange an ID token generated by a continuous integration provider (e.g. GitLab, GitHub). These providers might be limited to read-only data access and the DiracX tokens lifetime SHOULD NOT exceed the lifetime of the CI job.
-* Exchange an ID token which is provided automatically to a Jupyter instance such as is already used by several analysis facility prototypes.
-* Using alternative mechanisms such as Kerberos to verify a user's identity. This case might be configured to only support issuing tokens with commonly required user capabilities and be prevented from accessing more powerful capabilities.
+- Exchange an ID token generated by a continuous integration provider (e.g. GitLab, GitHub). These providers might be limited to read-only data access and the DiracX tokens lifetime SHOULD NOT exceed the lifetime of the CI job.
+- Exchange an ID token which is provided automatically to a Jupyter instance such as is already used by several analysis facility prototypes.
+- Using alternative mechanisms such as Kerberos to verify a user's identity. This case might be configured to only support issuing tokens with commonly required user capabilities and be prevented from accessing more powerful capabilities.
 
 In these cases, DiracX provides options to limit the contents of tokens which are issued, such as the group, capabilities and lifetime. Installation admins MUST take care to ensure to carefully consider which additional issuance mechanisms to support.
 
 Each VO in DiracX is associated with an external identity provider which MUST:
 
-* Support the authorization code flow with Proof Key of Code Exchange
-* Only issue identity tokens for users which are intended to have access to the VO's resources
+- Support the authorization code flow with Proof Key of Code Exchange
+- Only issue identity tokens for users which are intended to have access to the VO's resources
 
 #### Supported authorisation flows
 
 DiracX issues access and refresh tokens via three OAuth2 authorisation flows:
 
-* **Authorization Code with Proof Key of Code Exchange:** This is primarily used for the DiracX web portal.
-* **Device Authorization Flow with Proof Key of Code Exchange:** This is primarily used for terminal access to DiracX services.
-* **Refresh Token Grant:** This is used with the refresh tokens issued with the other flows.
-* **Token Exchange Grant:** Enables trusted externally issued tokens to be exchanged for DiracX credentials.
+- **Authorization Code with Proof Key of Code Exchange:** This is primarily used for the DiracX web portal.
+- **Device Authorization Flow with Proof Key of Code Exchange:** This is primarily used for terminal access to DiracX services.
+- **Refresh Token Grant:** This is used with the refresh tokens issued with the other flows.
+- **Token Exchange Grant:** Enables trusted externally issued tokens to be exchanged for DiracX credentials.
 
 There is currently no need foreseen for DiracX to issue `id_tokens` as all the information is already contained in the access token.
 
 All flows involving the external IdP follow the same sequence:
 
 ![](https://user-images.githubusercontent.com/3728211/274624748-aaa0c6c1-9bcf-4c89-8344-4597b3e15cfe.png)
-
 
 ### Pilot jobs
 
@@ -170,8 +174,8 @@ Communication between components is performed using HTTP and DiracX does not dir
 
 Installations SHOULD use certificates signed by a widely trusted root certificate authority to:
 
-* Ensure clients can be securely bootstrapped
-* Prevent users from being encouraged to bypass certificate warnings when interacting with DiracX
+- Ensure clients can be securely bootstrapped
+- Prevent users from being encouraged to bypass certificate warnings when interacting with DiracX
 
 These certificates SHOULD be generated in accordance with best practices at the time.
 
@@ -185,9 +189,9 @@ Here we consider a variety of scenarios where malicious parties attempt to acces
 
 If an IdP has been compromised then DiracX no longer has a means of verifying user identities. In this situation:
 
-* The VO is banned within DiracX and can no longer be used
-* All refresh tokens for the VO are revoked
-* Review all activity from the VO
+- The VO is banned within DiracX and can no longer be used
+- All refresh tokens for the VO are revoked
+- Review all activity from the VO
 
 ### Compromised batch submission system
 
@@ -195,19 +199,19 @@ If an attacker gains access to the information held within a site's batch submis
 
 Depending on the nature of the compromise, installation admins SHOULD:
 
-* Stop submission of new pilots to the resource
-* Invalidate potentially affected pilot secrets
-* Invalidate any refresh tokens which originated from a leaked pilot secret
-* Invalidate any pilot-matching secrets which originated from a leaked pilot secret
-* Review any activity that was done with potentially compromised access tokens
+- Stop submission of new pilots to the resource
+- Invalidate potentially affected pilot secrets
+- Invalidate any refresh tokens which originated from a leaked pilot secret
+- Invalidate any pilot-matching secrets which originated from a leaked pilot secret
+- Review any activity that was done with potentially compromised access tokens
 
 ### Compromised worker node
 
 If one or more worker nodes are compromised the refresh tokens granted to them are no longer be trusted. In this situation installation admins MUST:
 
-* Invalidate any refresh tokens which were sent to the given worker node
-* Invalidate the pilot matching secret
-* Review any activity that was done with potentially compromised access tokens
+- Invalidate any refresh tokens which were sent to the given worker node
+- Invalidate the pilot matching secret
+- Review any activity that was done with potentially compromised access tokens
 
 ### Compromised refresh token
 
@@ -217,19 +221,19 @@ If a user's refresh token is exposed they MUST be able to revoke it independentl
 
 If a user's identity is compromised the installation admin MUST:
 
-* Block the user within DiracX
-* Ask the IdP to block the user and reestablish their identity
-* Revoke all refresh tokens granted to that user
-* Kill any waiting jobs within the system
-* Review all user activity
+- Block the user within DiracX
+- Ask the IdP to block the user and reestablish their identity
+- Revoke all refresh tokens granted to that user
+- Kill any waiting jobs within the system
+- Review all user activity
 
 ### Compromised JWK
 
 In the event that the JWK used for signing DIRAC tokens is compromised installation admins MUST generate new keys immediately and cease to use the previous public keys. In addition, they SHOULD:
 
-* Consider shutting down the instance entirely
-* Review the DiracX configuration service for malicious changes
-* Review all user activity
+- Consider shutting down the instance entirely
+- Review the DiracX configuration service for malicious changes
+- Review all user activity
 
 ### Compromised DB
 
@@ -239,20 +243,20 @@ For databases containing secrets (e.g. pilot secrets), the secrets are hashed su
 
 If the attacker has the means to modify the DB contents and installation admins SHOULD:
 
-* Change DB credentials
-* Review what activity might be possible as the result of access to this DB. For example, modifying the job database would enable arbitrary payload execution and the exfiltration of limited-scope user refresh tokens.
+- Change DB credentials
+- Review what activity might be possible as the result of access to this DB. For example, modifying the job database would enable arbitrary payload execution and the exfiltration of limited-scope user refresh tokens.
 
 ### Compromised hosts
 
 In the event of a host being compromised it MUST be treated as equivalent to the sections previously described:
 
-* Compromised all JWKs
-* Compromised all DBs
+- Compromised all JWKs
+- Compromised all DBs
 
 Additionally:
 
-* Any secrets DiracX services have access to (e.g. salts for hashing, passwords) MAY increase the severity of the compromise.
-* At a minimum the host SHOULD be reinstalled, though replacing the hardware might be required depending on the nature of the attacker.
+- Any secrets DiracX services have access to (e.g. salts for hashing, passwords) MAY increase the severity of the compromise.
+- At a minimum the host SHOULD be reinstalled, though replacing the hardware might be required depending on the nature of the attacker.
 
 ### Malicious legitimate user
 
@@ -268,17 +272,17 @@ In the event of malicious activity, refer to existing procedures in addition to 
 
 ## Changelog
 
-* v0.1.0 (2023-06-07): Initial draft for internal review.
-* v0.2.0 (2023-06-12): Add glossary of common terms.
-* v0.3.0 (2023-06-27):
-    * Define Identity
-    * Specify token issuer
-    * Change property to capability
-    * Add diagram of the role of the external IdP, DiracX and the user
-* v0.9.0 (2023-10-11):
-    * Specify traceability consideration
-    * Specify reference of the registered claim
-    * `vo` field in the token may change if it becomes a standard
-    * Better description of alternative mechanism to issue a token
-    * Explicit the reason for not needing to issue `id_token`
-    * Recommend to contact VO admins in case of compromission
+- v0.1.0 (2023-06-07): Initial draft for internal review.
+- v0.2.0 (2023-06-12): Add glossary of common terms.
+- v0.3.0 (2023-06-27):
+  - Define Identity
+  - Specify token issuer
+  - Change property to capability
+  - Add diagram of the role of the external IdP, DiracX and the user
+- v0.9.0 (2023-10-11):
+  - Specify traceability consideration
+  - Specify reference of the registered claim
+  - `vo` field in the token may change if it becomes a standard
+  - Better description of alternative mechanism to issue a token
+  - Explicit the reason for not needing to issue `id_token`
+  - Recommend to contact VO admins in case of compromission

--- a/tests/make_token_local.py
+++ b/tests/make_token_local.py
@@ -28,7 +28,7 @@ def main(token_key):
     preferred_username = "localuser"
     dirac_properties = [NORMAL_USER]
     settings = AuthSettings(token_key=token_key)
-    creation_time = datetime.now(tz=timezone.utc)
+    creation_time = datetime.now(tz=UTC)
     expires_in = 7 * 24 * 60 * 60
 
     access_payload = {


### PR DESCRIPTION
https://learn.scientific-python.org/development/guides/repo-review/  provides a tool to review a Python repository and points out possible Python coding improvements by using community-developed tools and suggests additional configuration for tools already used (i.e. _MyPy_ of _pre-commit_).

After entering  `diracx` repository on the website it prints quite an extensive output with possible improvements marked in red.

I'll address them one-by one:

**General:**


_[PY007](https://learn.scientific-python.org/development/guides/tasks#PY007): Supports an easy task runner (nox, tox, pixi, etc.)
Projects must have a noxfile.py, tox.ini, or tool.hatch.envs/tool.spin/tool.tox in pyproject.toml to encourage new contributors._

Not sure what to do here. The only reference to `tox` I can find in DiracX (and Dirac) and a .`gitignore` file, so it looks like someone is running tests with `tox` somewhere. Leave it out for now.

**PyProject**

_[PP003](https://learn.scientific-python.org/development/guides/packaging-classic#PP003): Does not list wheel as a build-dep
Do not include "wheel" in your build-system.requires, setuptools does this via PEP 517 already. Setuptools will also only require this for actual wheel builds, and might have version limits._

Removing it doesn't not seem to harm. Done.

_[PP302](https://learn.scientific-python.org/development/guides/pytest#PP302): Sets a minimum pytest to at least 6
Must have a minversion=, and must be at least 6 (first version to support pyproject.toml configuration).
[tool.pytest.ini_options]
minversion = "7"_

It seems like setting it to a version compatible with a current python version is OK.

_[PP304](https://learn.scientific-python.org/development/guides/pytest#PP304): Sets the log level in pytest
log_cli_level should be set. This will allow logs to be displayed on failures.
[tool.pytest.ini_options]
log_cli_level = "INFO"_

Could follow this suggestion.

_[PP305](https://learn.scientific-python.org/development/guides/pytest#PP305): Specifies xfail_strict
xfail_strict should be set. You can manually specify if a check should be strict when setting each xfail.
[tool.pytest.ini_options]
xfail_strict = true_

I haven't noticed any problems with this, can be overwritten apparently for selected `xfail` if required.

_--strict-config should be in addopts = [...]. This forces an error if a config setting is misspelled.
[tool.pytest.ini_options]
addopts = ["-ra", "--strict-config", "--strict-markers"]_

_[PP307](https://learn.scientific-python.org/development/guides/pytest#PP307): Specifies strict markers
--strict-markers should be in addopts = [...]. This forces all markers to be specified in config, avoiding misspellings.
[tool.pytest.ini_options]
addopts = ["-ra", "--strict-config", "--strict-markers"]_

Useful. checks the config for misspelled words.

_[PP308](https://learn.scientific-python.org/development/guides/pytest#PP308): Specifies useful pytest summary
An explicit summary flag like -ra should be in addopts = [...] (print summary of all fails/errors).
[tool.pytest.ini_options]
addopts = ["-ra", "--strict-config", "--strict-markers"]_

A summary might be useful, I think.

_[PP309](https://learn.scientific-python.org/development/guides/pytest#PP309): Filter warnings specified
filterwarnings must be set (probably to at least ["error"]). Python will hide important warnings otherwise, like deprecations.
[tool.pytest.ini_options]
filterwarnings = ["error"]_

`['error']` might be to high. I used `['default']` in order not to change the current behaviour.

**GitHub Actions**

_[GH102](https://learn.scientific-python.org/development/guides/gha-basic#GH102): Auto-cancel on repeated PRs
At least one workflow should auto-cancel.
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true_

I applied this suggestion, not sure what it did. It seems that a new push kills a previous workflow by default anyway.

_[GH104](https://learn.scientific-python.org/development/guides/gha-wheels#GH104): Use unique names for upload-artifact
Multiple upload-artifact usages must have unique names to be compatible with v4 (which no longer merges artifacts, but instead errors out). The most general solution is:
- uses: actions/upload-artifact@v4
  with:
    name: prefix-${{ github.job }}-${{ strategy.job-index }}

- uses: actions/download-artifact@v4
  with:
    pattern: prefix-*
    merge-multiple: true
No variable substitutions were detected in integration.yml:dirac-integration-tests._

Applied.

_[GH212](https://learn.scientific-python.org/development/guides/gha-basic#GH212): Require GHA update grouping
Projects should group their updates to avoid extra PRs and stay in sync. This is now supported by dependabot since June 2023.
    groups:
      actions:
        patterns:
          - "*"_

Any comments on this ?

**Pre-commit**

_[PC110](https://learn.scientific-python.org/development/guides/style#PC110): Uses black or ruff-format
Use https://github.com/psf/black-pre-commit-mirror instead of https://github.com/psf/black in .pre-commit-config.yaml_

Done.

_[PC160](https://learn.scientific-python.org/development/guides/style#PC160): Uses a spell checker
Must have one of https://github.com/codespell-project/codespell, https://github.com/crate-ci/typos in .pre-commit-config.yaml_


Really useful. Recommended.

_[PC170](https://learn.scientific-python.org/development/guides/style#PC170): Uses PyGrep hooks (only needed if rST present)
Must have https://github.com/pre-commit/pygrep-hooks in .pre-commit-config.yaml_

Quite a few hooks, added all suggested at their webpage.

_[PC180](https://learn.scientific-python.org/development/guides/style#PC180): Uses a markdown formatter
Must have one of https://github.com/executablebooks/mdformat, https://github.com/rbubley/mirrors-prettier in .pre-commit-config.yaml_

Just a `md` formatter.  Keeps md file pretty.



_[PC191](https://learn.scientific-python.org/development/guides/style#PC191): Ruff show fixes if fixes enabled
If --fix is present, --show-fixes must be too._

Useful, shows what was changed.

_[PC901](https://learn.scientific-python.org/development/guides/style#PC901): Custom pre-commit CI message
Should have something like this in .pre-commit-config.yaml:
ci:
  autoupdate_commit_msg: 'chore: update pre-commit hooks'_

Do we want a CI pre-commit message, if so, what should it look like ?

_[MY101](https://learn.scientific-python.org/development/guides/style#MY101): MyPy strict mode
Must have strict in the mypy config. MyPy is best with strict or nearly strict configuration. If you are happy with the strictness of your settings already, ignore this check or set strict = false explicitly.
[tool.mypy]
strict = true_

Left it at `false`. Not ready yet to fix all the errors strict checks produce...

[MY103](https://learn.scientific-python.org/development/guides/style#MY103): MyPy warn unreachable
Must have warn_unreachable (true/false) to pass this check. There are occasionally false positives (often due to platform or Python version static checks), so it's okay to set it to false if you need to. But try it first - it can catch real bugs too.
[tool.mypy]
warn_unreachable = true
[MY104](https://learn.scientific-python.org/development/guides/style#MY104): MyPy enables ignore-without-code
Must have "ignore-without-code" in enable_error_code = [...]. This will force all skips in your project to include the error code, which makes them more readable, and avoids skipping something unintended.
[tool.mypy]
enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
[MY105](https://learn.scientific-python.org/development/guides/style#MY105): MyPy enables redundant-expr
Must have "redundant-expr" in enable_error_code = [...]. This helps catch useless lines of code, like checking the same condition twice.
[tool.mypy]
enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
[MY106](https://learn.scientific-python.org/development/guides/style#MY106): MyPy enables truthy-bool
Must have "truthy-bool" in enable_error_code = []. This catches mistakes in using a value as truthy if it cannot be falsy.
[tool.mypy]
enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]

Set all above as recommended. It causes CI to fail, a closer code examination is needed. Thos checks look necessary to me.

**Ruff**

_[RF103](https://learn.scientific-python.org/development/guides/style#RF103): pyupgrade must be selected
Must select the pyupgrade UP checks. Recommended:
[tool.ruff.lint]
extend-select = [
  "UP",  # pyupgrade
]_

This change did not remove the warning (= problem with the tool?). I also noticed that pyupgrade is commented out in select. Any reason for that ?

**Documentation**

_[RTD100](https://learn.scientific-python.org/development/guides/docs#RTD100): Uses ReadTheDocs (pyproject config)
Should have a .readthedocs.yaml file in the root of the repository. Modern ReadTheDocs requires (or will require soon) this file._

I understand that documentation is build in Dirac at the moment, so this suggestion is not relevant, is it ?
 