### PR TITLE
fix: job admins cannot see jobs from other users

### DIFF
--- a/diracx-logic/src/diracx/logic/jobs/query.py
+++ b/diracx-logic/src/diracx/logic/jobs/query.py
@@ -24,7 +24,7 @@ async def search(
     job_db: JobDB,
     job_parameters_db: JobParametersDB,
     job_logging_db: JobLoggingDB,
-    preferred_username: str,
+    preferred_username: str | None,
     page: int = 1,
     per_page: int = 100,
     body: JobSearchParams | None = None,
@@ -46,7 +46,10 @@ async def search(
                 body.parameters = ["JobID"] + (body.parameters or [])
 
     # TODO: Apply all the job policy stuff properly using user_info
-    if not config.Operations["Defaults"].Services.JobMonitoring.GlobalJobsInfo:
+    if (
+        not config.Operations["Defaults"].Services.JobMonitoring.GlobalJobsInfo
+        and preferred_username
+    ):
         body.search.append(
             {
                 "parameter": "Owner",

--- a/diracx-routers/src/diracx/routers/jobs/query.py
+++ b/diracx-routers/src/diracx/routers/jobs/query.py
@@ -9,6 +9,7 @@ from diracx.core.models import (
     JobSearchParams,
     JobSummaryParams,
 )
+from diracx.core.properties import JOB_ADMINISTRATOR
 from diracx.logic.jobs.query import search as search_bl
 from diracx.logic.jobs.query import summary as summary_bl
 
@@ -143,12 +144,16 @@ async def search(
     """
     await check_permissions(action=ActionType.QUERY, job_db=job_db)
 
+    preferred_username: str | None = user_info.preferred_username
+    if JOB_ADMINISTRATOR in user_info.properties:
+        preferred_username = None
+
     total, jobs = await search_bl(
         config=config,
         job_db=job_db,
         job_parameters_db=job_parameters_db,
         job_logging_db=job_logging_db,
-        preferred_username=user_info.preferred_username,
+        preferred_username=preferred_username,
         page=page,
         per_page=per_page,
         body=body,


### PR DESCRIPTION
Currently users with `JOB_ADMINISTRATORS` properties cannot see jobs of other users because of: https://github.com/aldbr/diracx/blob/a37ff0db0dab93ce90d44938310ba35ed1f1cbd9/diracx-logic/src/diracx/logic/jobs/query.py#L49-L60

I don't know if this is the best way of handling that problem, because I see some `TODO` notes like `# TODO: Apply all the job policy stuff properly using user_info`.

I am coming with some unit tests soon.

