### PR TITLE
fix: legacy_exchange should not rotate tokens

### DIFF
--- a/diracx-logic/src/diracx/logic/auth/token.py
+++ b/diracx-logic/src/diracx/logic/auth/token.py
@@ -48,9 +48,11 @@ async def get_oidc_token(
     redirect_uri: str | None = None,
     code_verifier: str | None = None,
     refresh_token: str | None = None,
-) -> tuple[AccessTokenPayload, RefreshTokenPayload]:
+) -> tuple[AccessTokenPayload, RefreshTokenPayload | None]:
     """Token endpoint to retrieve the token at the end of a flow."""
     legacy_exchange = False
+    include_refresh_token = True
+    refresh_token_expire_minutes = None
 
     if grant_type == GrantType.device_code:
         assert device_code is not None
@@ -71,6 +73,8 @@ async def get_oidc_token(
             oidc_token_info,
             scope,
             legacy_exchange,
+            refresh_token_expire_minutes,
+            include_refresh_token,
         ) = await get_oidc_token_info_from_refresh_flow(
             refresh_token, auth_db, settings
         )
@@ -86,6 +90,8 @@ async def get_oidc_token(
         settings,
         available_properties,
         legacy_exchange=legacy_exchange,
+        refresh_token_expire_minutes=refresh_token_expire_minutes,
+        include_refresh_token=include_refresh_token,
     )
 
 
@@ -155,19 +161,27 @@ async def get_oidc_token_info_from_authorization_flow(
 
 async def get_oidc_token_info_from_refresh_flow(
     refresh_token: str, auth_db: AuthDB, settings: AuthSettings
-) -> tuple[dict, str, bool]:
+) -> tuple[dict, str, bool, float, bool]:
     """Get OIDC token information from the refresh token DB and check few parameters before returning it."""
     # Decode the refresh token to get the JWT ID
-    jti, _, legacy_exchange = await verify_dirac_refresh_token(refresh_token, settings)
+    jti, exp, legacy_exchange = await verify_dirac_refresh_token(
+        refresh_token, settings
+    )
 
     # Get some useful user information from the refresh token entry in the DB
     refresh_token_attributes = await auth_db.get_refresh_token(jti)
 
     sub = refresh_token_attributes["Sub"]
 
+    # Get the remaining time in minutes before the token expires
+    remaining_minutes = (
+        datetime.fromtimestamp(exp, timezone.utc) - datetime.now(timezone.utc)
+    ).total_seconds() / 60
+
     # Check if the refresh token was obtained from the legacy_exchange endpoint
-    # If it is the case, we bypass the refresh token rotation mechanism
     if not legacy_exchange:
+        include_refresh_token = True
+
         # Refresh token rotation: https://datatracker.ietf.org/doc/html/rfc6749#section-10.4
         # Check that the refresh token has not been already revoked
         # This might indicate that a potential attacker try to impersonate someone
@@ -188,6 +202,10 @@ async def get_oidc_token_info_from_refresh_flow(
         # Part of the refresh token rotation mechanism:
         # Revoke the refresh token provided, a new one needs to be generated
         await auth_db.revoke_refresh_token(jti)
+    else:
+        # We bypass the refresh token rotation mechanism
+        # and we don't want to generate a new refresh token
+        include_refresh_token = False
 
     # Build an ID token and get scope from the refresh token attributes received
     oidc_token_info = {
@@ -197,7 +215,13 @@ async def get_oidc_token_info_from_refresh_flow(
         "preferred_username": refresh_token_attributes["PreferredUsername"],
     }
     scope = refresh_token_attributes["Scope"]
-    return (oidc_token_info, scope, legacy_exchange)
+    return (
+        oidc_token_info,
+        scope,
+        legacy_exchange,
+        remaining_minutes,
+        include_refresh_token,
+    )
 
 
 BASE_64_URL_SAFE_PATTERN = (
@@ -215,8 +239,8 @@ async def perform_legacy_exchange(
     available_properties: set[SecurityProperty],
     settings: AuthSettings,
     config: Config,
-    expires_minutes: int | None = None,
-) -> tuple[AccessTokenPayload, RefreshTokenPayload]:
+    expires_minutes: float | None = None,
+) -> tuple[AccessTokenPayload, RefreshTokenPayload | None]:
     """Endpoint used by legacy DIRAC to mint tokens for proxy -> token exchange."""
     if match := re.fullmatch(LEGACY_EXCHANGE_PATTERN, authorization):
         raw_token = base64.urlsafe_b64decode(match.group(1))
@@ -253,9 +277,10 @@ async def exchange_token(
     settings: AuthSettings,
     available_properties: set[SecurityProperty],
     *,
-    refresh_token_expire_minutes: int | None = None,
+    refresh_token_expire_minutes: float | None = None,
     legacy_exchange: bool = False,
-) -> tuple[AccessTokenPayload, RefreshTokenPayload]:
+    include_refresh_token: bool = True,
+) -> tuple[AccessTokenPayload, RefreshTokenPayload | None]:
     """Method called to exchange the OIDC token for a DIRAC generated access token."""
     # Extract dirac attributes from the OIDC scope
     parsed_scope = parse_and_validate_scope(scope, config, available_properties)
@@ -290,26 +315,29 @@ async def exchange_token(
     # Merge the VO with the subject to get a unique DIRAC sub
     sub = f"{vo}:{sub}"
 
-    # Insert the refresh token with user details into the RefreshTokens table
-    # User details are needed to regenerate access tokens later
-    jti, creation_time = await insert_refresh_token(
-        auth_db=auth_db,
-        subject=sub,
-        preferred_username=preferred_username,
-        scope=scope,
-    )
+    creation_time = datetime.now(timezone.utc)
+    refresh_payload: RefreshTokenPayload | None = None
+    if include_refresh_token:
+        # Insert the refresh token with user details into the RefreshTokens table
+        # User details are needed to regenerate access tokens later
+        jti, creation_time = await insert_refresh_token(
+            auth_db=auth_db,
+            subject=sub,
+            preferred_username=preferred_username,
+            scope=scope,
+        )
 
-    # Generate refresh token payload
-    if refresh_token_expire_minutes is None:
-        refresh_token_expire_minutes = settings.refresh_token_expire_minutes
-    refresh_payload: RefreshTokenPayload = {
-        "jti": str(jti),
-        "exp": creation_time + timedelta(minutes=refresh_token_expire_minutes),
-        # legacy_exchange is used to indicate that the original refresh token
-        # was obtained from the legacy_exchange endpoint
-        "legacy_exchange": legacy_exchange,
-        "dirac_policies": {},
-    }
+        # Generate refresh token payload
+        if refresh_token_expire_minutes is None:
+            refresh_token_expire_minutes = settings.refresh_token_expire_minutes
+        refresh_payload = {
+            "jti": str(jti),
+            "exp": creation_time + timedelta(minutes=refresh_token_expire_minutes),
+            # legacy_exchange is used to indicate that the original refresh token
+            # was obtained from the legacy_exchange endpoint
+            "legacy_exchange": legacy_exchange,
+            "dirac_policies": {},
+        }
 
     # Generate access token payload
     # For now, the access token is only used to access DIRAC services,

--- a/diracx-routers/src/diracx/routers/access_policies.py
+++ b/diracx-routers/src/diracx/routers/access_policies.py
@@ -93,7 +93,7 @@ class BaseAccessPolicy(metaclass=ABCMeta):
 
     @staticmethod
     def enrich_tokens(
-        access_payload: AccessTokenPayload, refresh_payload: RefreshTokenPayload
+        access_payload: AccessTokenPayload, refresh_payload: RefreshTokenPayload | None
     ) -> tuple[dict, dict]:
         """This method is called when issuing a token, and can add whatever
         content it wants inside the access or refresh payload.

--- a/diracx-routers/tests/auth/test_legacy_exchange.py
+++ b/diracx-routers/tests/auth/test_legacy_exchange.py
@@ -95,6 +95,7 @@ async def test_refresh_token(test_client, legacy_credentials):
     )
     assert r.status_code == 200
     initial_refresh_token = r.json()["refresh_token"]
+    initial_access_token = r.json()["access_token"]
 
     # Refresh the access token
     request_data = {
@@ -106,6 +107,7 @@ async def test_refresh_token(test_client, legacy_credentials):
     data = r.json()
     assert r.status_code == 200, data
     new_refresh_token1 = data["refresh_token"]
+    new_access_token1 = data["access_token"]
 
     # Refresh the access token using the initial refresh token
     # In a normal case, it should have been revoked by the refresh token rotation mechanism
@@ -120,10 +122,15 @@ async def test_refresh_token(test_client, legacy_credentials):
     data = r.json()
     assert r.status_code == 200, data
     new_refresh_token2 = data["refresh_token"]
+    new_access_token2 = data["access_token"]
 
-    # Make sure that obtained refresh tokens are all different
-    assert new_refresh_token1 != initial_refresh_token
-    assert new_refresh_token1 != new_refresh_token2
+    # Make sure that obtained refresh tokens are all the same
+    assert new_refresh_token1 == initial_refresh_token
+    assert new_refresh_token2 == initial_refresh_token
+
+    # Make sure that obtained access tokens are all different
+    assert new_access_token1 != initial_access_token
+    assert new_access_token2 != initial_access_token
 
 
 async def test_disabled(test_client):

--- a/diracx-testing/src/diracx/testing/utils.py
+++ b/diracx-testing/src/diracx/testing/utils.py
@@ -184,7 +184,8 @@ class ClientFactory:
 
             @staticmethod
             def enrich_tokens(
-                access_payload: AccessTokenPayload, refresh_payload: RefreshTokenPayload
+                access_payload: AccessTokenPayload,
+                refresh_payload: RefreshTokenPayload | None,
             ):
 
                 return {"PolicySpecific": "OpenAccessForTest"}, {}


### PR DESCRIPTION
- getting a new access token through the `/token` endpoint using a refresh token obtained from a legacy exchange now returns the exact same refresh token (no rotation anymore)
- a new refresh token obtained through the `/token` endpoint using a general refresh token (rotation) will now have the same expiration date as the provided refresh token (approximately, is it a problem?)