### PR TITLE
Bring epoch calculation and date validation in line with DIRAC

### DIFF
--- a/diracx-core/src/diracx/core/models.py
+++ b/diracx-core/src/diracx/core/models.py
@@ -9,7 +9,6 @@ from datetime import datetime, timezone
 from enum import StrEnum
 from typing import Literal
 
-from DIRAC.Core.Utilities import TimeUtilities
 from pydantic import AwareDatetime, BaseModel, BeforeValidator, Field
 from typing_extensions import Annotated, TypedDict
 
@@ -22,8 +21,8 @@ def good_utc_dt(v):
         v = datetime.now(tz=timezone.utc)
 
     if isinstance(v, str):
-        # The date is provided as a string in UTC
-        v = TimeUtilities.fromString(v)
+        # The date is provided as a string.
+        v = datetime.fromisoformat(v)
 
     if isinstance(v, datetime):
         if not v.tzinfo:
@@ -81,7 +80,7 @@ class InsertedJob(TypedDict):
     JobID: int
     Status: str
     MinorStatus: str
-    TimeStamp: datetime
+    TimeStamp: DiracUTCDatetime
 
 
 class JobSummaryParams(BaseModel):

--- a/diracx-core/src/diracx/core/models.py
+++ b/diracx-core/src/diracx/core/models.py
@@ -5,12 +5,37 @@ services components (db, logic, routers).
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import StrEnum
 from typing import Literal
 
-from pydantic import BaseModel, Field
-from typing_extensions import TypedDict
+from DIRAC.Core.Utilities import TimeUtilities
+from pydantic import AwareDatetime, BaseModel, BeforeValidator, Field
+from typing_extensions import Annotated, TypedDict
+
+
+def good_utc_dt(v):
+    # We need to specify that timezone is UTC because otherwise timestamp
+    # assumes local time while we mean UTC.
+    if not v:
+        # Make the UTC datetime
+        v = datetime.now(tz=timezone.utc)
+
+    if isinstance(v, str):
+        # The date is provided as a string in UTC
+        v = TimeUtilities.fromString(v)
+
+    if isinstance(v, datetime):
+        if not v.tzinfo:
+            raise ValueError(f"datetime object provided but tzinfo was None. got {v=}")
+        return v.astimezone(timezone.utc)
+
+    raise ValueError(
+        f"Incorrect date for the logging record: got {v=}. Should be a UTC datetime object."
+    )
+
+
+DiracUTCDatetime = Annotated[AwareDatetime, BeforeValidator(good_utc_dt)]
 
 
 class ScalarSearchOperator(StrEnum):
@@ -101,7 +126,7 @@ class JobLoggingRecord(BaseModel):
     status: JobStatus | Literal["idem"]
     minor_status: str
     application_status: str
-    date: datetime
+    date: DiracUTCDatetime
     source: str
 
 
@@ -130,10 +155,10 @@ class SetJobStatusReturn(BaseModel):
         Status: JobStatus | None = None
         MinorStatus: str | None = None
         ApplicationStatus: str | None = None
-        HeartBeatTime: datetime | None = None
-        StartExecTime: datetime | None = None
-        EndExecTime: datetime | None = None
-        LastUpdateTime: datetime | None = None
+        HeartBeatTime: DiracUTCDatetime | None = None
+        StartExecTime: DiracUTCDatetime | None = None
+        EndExecTime: DiracUTCDatetime | None = None
+        LastUpdateTime: DiracUTCDatetime | None = None
 
     success: dict[int, SetJobStatusReturnSuccess]
     failed: dict[int, dict[str, str]]

--- a/diracx-db/src/diracx/db/sql/job_logging/db.py
+++ b/diracx-db/src/diracx/db/sql/job_logging/db.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import time
 from datetime import timezone
 from typing import TYPE_CHECKING
 
@@ -35,14 +34,6 @@ class JobLoggingDB(BaseSQLDB):
         records: list[JobLoggingRecord],
     ):
         """Bulk insert entries to the JobLoggingDB table."""
-
-        def get_epoc(date):
-            return (
-                time.mktime(date.timetuple())
-                + date.microsecond / 1000000.0
-                - MAGIC_EPOC_NUMBER
-            )
-
         # First, fetch the maximum SeqNums for the given job_ids
         seqnum_stmt = (
             select(
@@ -70,7 +61,7 @@ class JobLoggingDB(BaseSQLDB):
                     "MinorStatus": record.minor_status,
                     "ApplicationStatus": record.application_status[:255],
                     "StatusTime": record.date,
-                    "StatusTimeOrder": get_epoc(record.date),
+                    "StatusTimeOrder": record.date.timestamp() - MAGIC_EPOC_NUMBER,
                     "StatusSource": record.source[:32],
                 }
             )


### PR DESCRIPTION
`time.mktime()` was being used in the JobLoggingDB code but DIRAC uses `datetime.timestamp()`. `mktime` assumes local time. 