### PR TITLE
feat: add service instance id and name to the metrics

### DIFF
--- a/diracx-routers/src/diracx/routers/otel.py
+++ b/diracx-routers/src/diracx/routers/otel.py
@@ -96,7 +96,7 @@ def instrument_otel(app: FastAPI) -> None:
         ),
         export_interval_millis=3000,
     )
-    meter_provider = MeterProvider(metric_readers=[metric_reader])
+    meter_provider = MeterProvider(metric_readers=[metric_reader], resource=resource)
     metrics.set_meter_provider(meter_provider)
 
     ###################################


### PR DESCRIPTION
Adding resource (`service_name` and `service_instance_id`) to the metrics.
Could potentially solve issues we have when multiple pods are sending metric values in parallel.
It works only if the `opentelemetry-collector.config.exporters.prometheus.resource_to_telemetry_conversion` is enabled in the helm chart.


We are trying to test the solution in LHCb context but it's not that straightforward.
