### PR TITLE
Use uuid7

### DIFF
--- a/diracx-db/pyproject.toml
+++ b/diracx-db/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "opensearch-py[async]",
     "pydantic >=2.10",
     "sqlalchemy[aiomysql,aiosqlite] >= 2",
+    "uuid-utils",
 ]
 dynamic = ["version"]
 

--- a/diracx-db/src/diracx/db/sql/auth/db.py
+++ b/diracx-db/src/diracx/db/sql/auth/db.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import secrets
-from uuid import UUID, uuid4
 
 from sqlalchemy import insert, select, update
 from sqlalchemy.exc import IntegrityError, NoResultFound
+from uuid_utils import UUID, uuid7
 
 from diracx.core.exceptions import (
     AuthorizationError,
@@ -126,7 +126,7 @@ class AuthDB(BaseSQLDB):
         code_challenge_method: str,
         redirect_uri: str,
     ) -> str:
-        uuid = str(uuid4())
+        uuid = str(uuid7())
 
         stmt = insert(AuthorizationFlows).values(
             uuid=uuid,

--- a/diracx-db/src/diracx/db/sql/dummy/db.py
+++ b/diracx-db/src/diracx/db/sql/dummy/db.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from uuid import UUID
-
 from sqlalchemy import func, insert, select
+from uuid_utils import UUID
 
 from diracx.db.sql.utils import BaseSQLDB, apply_search_filters
 

--- a/diracx-db/tests/auth/test_refresh_token.py
+++ b/diracx-db/tests/auth/test_refresh_token.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from uuid import UUID, uuid4
-
 import pytest
+from uuid_utils import UUID, uuid7
 
 from diracx.db.sql.auth.db import AuthDB
 from diracx.db.sql.auth.schema import RefreshTokenStatus
@@ -20,7 +19,7 @@ async def auth_db(tmp_path):
 async def test_insert(auth_db: AuthDB):
     """Insert two refresh tokens in the DB and check that they don't share the same JWT ID."""
     # Insert a first refresh token
-    jti1 = uuid4()
+    jti1 = uuid7()
     async with auth_db as auth_db:
         await auth_db.insert_refresh_token(
             jti1,
@@ -30,7 +29,7 @@ async def test_insert(auth_db: AuthDB):
         )
 
     # Insert a second refresh token
-    jti2 = uuid4()
+    jti2 = uuid7()
     async with auth_db as auth_db:
         await auth_db.insert_refresh_token(
             jti2,
@@ -53,7 +52,7 @@ async def test_get(auth_db: AuthDB):
     }
 
     # Insert refresh token details
-    jti = uuid4()
+    jti = uuid7()
     async with auth_db as auth_db:
         await auth_db.insert_refresh_token(
             jti,
@@ -78,7 +77,7 @@ async def test_get(auth_db: AuthDB):
         result = await auth_db.get_refresh_token(jti)
 
     # Make sure they are identical
-    result["JTI"] = UUID(result["JTI"], version=4)
+    result["JTI"] = UUID(result["JTI"])
     assert result == expected_refresh_token
 
 
@@ -97,7 +96,7 @@ async def test_get_user_refresh_tokens(auth_db: AuthDB):
     async with auth_db as auth_db:
         for sub in subjects:
             await auth_db.insert_refresh_token(
-                uuid4(),
+                uuid7(),
                 sub,
                 "username",
                 "scope",
@@ -123,7 +122,7 @@ async def test_revoke(auth_db: AuthDB):
     """Insert a refresh token in the DB, revoke it, and make sure it appears as REVOKED in the db."""
     # Insert a refresh token details
     async with auth_db as auth_db:
-        jti = uuid4()
+        jti = uuid7()
         await auth_db.insert_refresh_token(
             jti,
             "subject",
@@ -155,7 +154,7 @@ async def test_revoke_user_refresh_tokens(auth_db: AuthDB):
     async with auth_db as auth_db:
         for sub in subjects:
             await auth_db.insert_refresh_token(
-                uuid4(),
+                uuid7(),
                 sub,
                 "username",
                 "scope",
@@ -198,7 +197,7 @@ async def test_revoke_and_get_user_refresh_tokens(auth_db: AuthDB):
     jtis = []
     async with auth_db as auth_db:
         for _ in range(nb_tokens):
-            jti = uuid4()
+            jti = uuid7()
             await auth_db.insert_refresh_token(
                 jti,
                 sub,
@@ -248,7 +247,7 @@ async def test_get_refresh_tokens(auth_db: AuthDB):
     async with auth_db as auth_db:
         for sub in subjects:
             await auth_db.insert_refresh_token(
-                uuid4(),
+                uuid7(),
                 sub,
                 "username",
                 "scope",

--- a/diracx-db/tests/test_dummy_db.py
+++ b/diracx-db/tests/test_dummy_db.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import asyncio
-from uuid import uuid4
 
 import pytest
+from uuid_utils import uuid7
 
 from diracx.core.exceptions import InvalidQueryError
 from diracx.db.sql.dummy.db import DummyDB
@@ -38,7 +38,7 @@ async def test_insert_and_summary(dummy_db: DummyDB):
 
         # Add cars, belonging to the same guy
         result = await asyncio.gather(
-            *(dummy_db.insert_car(uuid4(), f"model_{i}", owner_id) for i in range(10))
+            *(dummy_db.insert_car(uuid7(), f"model_{i}", owner_id) for i in range(10))
         )
         assert result
 
@@ -100,7 +100,7 @@ async def test_successful_transaction(dummy_db):
         owner_id = await dummy_db.insert_owner(name="Magnum")
         assert owner_id
         result = await asyncio.gather(
-            *(dummy_db.insert_car(uuid4(), f"model_{i}", owner_id) for i in range(10))
+            *(dummy_db.insert_car(uuid7(), f"model_{i}", owner_id) for i in range(10))
         )
         assert result
 
@@ -142,7 +142,7 @@ async def test_failed_transaction(dummy_db):
             assert owner_id
             result = await asyncio.gather(
                 *(
-                    dummy_db.insert_car(uuid4(), f"model_{i}", owner_id)
+                    dummy_db.insert_car(uuid7(), f"model_{i}", owner_id)
                     for i in range(10)
                 )
             )
@@ -211,7 +211,7 @@ async def test_successful_with_exception_transaction(dummy_db):
             assert owner_id
             result = await asyncio.gather(
                 *(
-                    dummy_db.insert_car(uuid4(), f"model_{i}", owner_id)
+                    dummy_db.insert_car(uuid7(), f"model_{i}", owner_id)
                     for i in range(10)
                 )
             )
@@ -248,7 +248,7 @@ async def test_successful_with_exception_transaction(dummy_db):
             assert owner_id
             result = await asyncio.gather(
                 *(
-                    dummy_db.insert_car(uuid4(), f"model_{i}", owner_id)
+                    dummy_db.insert_car(uuid7(), f"model_{i}", owner_id)
                     for i in range(10)
                 )
             )

--- a/diracx-logic/pyproject.toml
+++ b/diracx-logic/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "diracx-core",
     "diracx-db",
     "pydantic >=2.10",
+    "uuid-utils",
 ]
 dynamic = ["version"]
 

--- a/diracx-logic/src/diracx/logic/auth/management.py
+++ b/diracx-logic/src/diracx/logic/auth/management.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from uuid import UUID
+from uuid_utils import UUID
 
 from diracx.db.sql import AuthDB
 

--- a/diracx-logic/src/diracx/logic/auth/token.py
+++ b/diracx-logic/src/diracx/logic/auth/token.py
@@ -6,9 +6,9 @@ import base64
 import hashlib
 import re
 from datetime import datetime, timedelta, timezone
-from uuid import UUID, uuid4
 
 from authlib.jose import JsonWebToken
+from uuid_utils import UUID, uuid7
 
 from diracx.core.config import Config
 from diracx.core.exceptions import (
@@ -347,7 +347,7 @@ async def exchange_token(
         "vo": vo,
         "iss": settings.token_issuer,
         "dirac_properties": list(properties),
-        "jti": str(uuid4()),
+        "jti": str(uuid7()),
         "preferred_username": preferred_username,
         "dirac_group": dirac_group,
         "exp": creation_time + timedelta(minutes=settings.access_token_expire_minutes),
@@ -373,7 +373,7 @@ async def insert_refresh_token(
 ) -> tuple[UUID, datetime]:
     """Insert a refresh token into the database and return the JWT ID and creation time."""
     # Generate a JWT ID
-    jti = uuid4()
+    jti = uuid7()
 
     # Insert the refresh token into the DB
     await auth_db.insert_refresh_token(

--- a/diracx-logic/src/diracx/logic/auth/utils.py
+++ b/diracx-logic/src/diracx/logic/auth/utils.py
@@ -4,7 +4,6 @@ import base64
 import hashlib
 import json
 import secrets
-from uuid import UUID
 
 import httpx
 from authlib.integrations.starlette_client import OAuthError
@@ -13,6 +12,7 @@ from authlib.oidc.core import IDToken
 from cachetools import TTLCache
 from cryptography.fernet import Fernet
 from typing_extensions import TypedDict
+from uuid_utils import UUID
 
 from diracx.core.config.schema import Config
 from diracx.core.exceptions import AuthorizationError, IAMClientError, IAMServerError
@@ -203,11 +203,7 @@ async def verify_dirac_refresh_token(
     )
     token.validate()
 
-    return (
-        UUID(token["jti"], version=4),
-        float(token["exp"]),
-        token["legacy_exchange"],
-    )
+    return UUID(token["jti"]), float(token["exp"]), token["legacy_exchange"]
 
 
 def get_allowed_user_properties(config: Config, sub, vo: str) -> set[SecurityProperty]:

--- a/diracx-routers/src/diracx/routers/auth/management.py
+++ b/diracx-routers/src/diracx/routers/auth/management.py
@@ -7,7 +7,6 @@ to get information about the user's identity.
 from __future__ import annotations
 
 from typing import Annotated, Any
-from uuid import UUID
 
 from fastapi import (
     Depends,
@@ -15,6 +14,7 @@ from fastapi import (
     status,
 )
 from typing_extensions import TypedDict
+from uuid_utils import UUID
 
 from diracx.core.exceptions import TokenNotFoundError
 from diracx.core.properties import PROXY_MANAGEMENT, SecurityProperty
@@ -74,7 +74,7 @@ async def revoke_refresh_token(
         subject = None
 
     try:
-        await revoke_refresh_token_bl(auth_db, subject, UUID(jti, version=4))
+        await revoke_refresh_token_bl(auth_db, subject, UUID(jti))
     except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/diracx-routers/tests/jobs/test_wms_access_policy.py
+++ b/diracx-routers/tests/jobs/test_wms_access_policy.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from uuid import uuid4
-
 import pytest
 from fastapi import HTTPException, status
+from uuid_utils import uuid7
 
 from diracx.core.properties import JOB_ADMINISTRATOR, NORMAL_USER
 from diracx.routers.jobs.access_policies import (
@@ -18,7 +17,7 @@ base_payload = {
     "preferred_username": "preferred_username",
     "dirac_group": "test_group",
     "vo": "lhcb",
-    "token_id": str(uuid4()),
+    "token_id": str(uuid7()),
     "bearer_token": "my_secret_token",
 }
 

--- a/diracx-testing/pyproject.toml
+++ b/diracx-testing/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "pytest-cov",
     "pytest-xdist",
     "httpx",
+    "uuid-utils",
 ]
 dynamic = ["version"]
 

--- a/diracx-testing/src/diracx/testing/utils.py
+++ b/diracx-testing/src/diracx/testing/utils.py
@@ -16,10 +16,10 @@ from html.parser import HTMLParser
 from pathlib import Path
 from typing import TYPE_CHECKING, Generator
 from urllib.parse import parse_qs, urljoin, urlparse
-from uuid import uuid4
 
 import httpx
 import pytest
+from uuid_utils import uuid7
 
 from diracx.core.models import AccessTokenPayload, RefreshTokenPayload
 
@@ -371,7 +371,7 @@ class ClientFactory:
                 + timedelta(self.test_auth_settings.access_token_expire_minutes),
                 "iss": ISSUER,
                 "dirac_properties": [NORMAL_USER],
-                "jti": str(uuid4()),
+                "jti": str(uuid7()),
                 "preferred_username": "preferred_username",
                 "dirac_group": "test_group",
                 "vo": "lhcb",
@@ -392,7 +392,7 @@ class ClientFactory:
                 "sub": "testingVO:yellow-sub",
                 "iss": ISSUER,
                 "dirac_properties": [JOB_ADMINISTRATOR],
-                "jti": str(uuid4()),
+                "jti": str(uuid7()),
                 "preferred_username": "preferred_username",
                 "dirac_group": "test_group",
                 "vo": "lhcb",

--- a/extensions/gubbins/gubbins-db/src/gubbins/db/sql/lollygag/db.py
+++ b/extensions/gubbins/gubbins-db/src/gubbins/db/sql/lollygag/db.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from uuid import UUID
-
 from diracx.db.sql.utils import BaseSQLDB, apply_search_filters
 from sqlalchemy import func, insert, select
+from uuid_utils import UUID
 
 from .schema import Base as LollygagDBBase
 from .schema import Cars, Owners

--- a/extensions/gubbins/gubbins-db/tests/test_lollygag_db.py
+++ b/extensions/gubbins/gubbins-db/tests/test_lollygag_db.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import asyncio
 from typing import TYPE_CHECKING
-from uuid import uuid4
 
 import pytest
 from diracx.core.exceptions import InvalidQueryError
 from diracx.db.sql.utils import SQLDBUnavailableError
+from uuid_utils import uuid7
 
 from gubbins.db.sql.lollygag.db import LollygagDB
 
@@ -43,7 +43,7 @@ async def test_insert_and_summary(lollygag_db: LollygagDB):
         # Add cars, belonging to the same guy
         result = await asyncio.gather(
             *(
-                lollygag_db.insert_car(uuid4(), f"model_{i}", owner_id)
+                lollygag_db.insert_car(uuid7(), f"model_{i}", owner_id)
                 for i in range(10)
             )
         )

--- a/tests/make_token_local.py
+++ b/tests/make_token_local.py
@@ -2,9 +2,10 @@
 from __future__ import annotations
 
 import argparse
-import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+
+from uuid_utils import uuid7
 
 from diracx.core.models import TokenResponse
 from diracx.core.properties import NORMAL_USER
@@ -35,7 +36,7 @@ def main(token_key):
         "vo": vo,
         "iss": settings.token_issuer,
         "dirac_properties": dirac_properties,
-        "jti": str(uuid.uuid4()),
+        "jti": str(uuid7()),
         "preferred_username": preferred_username,
         "dirac_group": dirac_group,
         "exp": creation_time + timedelta(seconds=expires_in),


### PR DESCRIPTION
This pull request introduces a migration from `uuid4` to `uuid7` for generating unique identifiers. The change improves the temporal ordering of UUIDs, which can be beneficial for database indexing. I won't go into why and suggest anybody unaware of UUID v7 reads https://uuid7.com/.

At the moment it isn't available in the Python standard library (having only recently been accepted and still having "draft" status) so the `uuid-utils` library is used. There is a decent chance it'll be included in Python 3.14 later this year.

To see that this isn't a theoretical improvement, you can see pretty clearly when I switched to this in LHCb's DB monitoring (see below). This doesn't give a complete story as the DB is still poisened by the existing uuid4 records which is why there is a tail effect.

<img width="982" alt="Screenshot 2025-04-17 at 08 30 05" src="https://github.com/user-attachments/assets/15a77940-9fdb-491d-b0ba-9bb5e1140980" />

It also halved the average duration of `exchangeProxyForToken` calls and significantly improved the tail latency:

With uuid4:

<img width="1455" alt="Screenshot 2025-04-17 at 08 49 39" src="https://github.com/user-attachments/assets/1b4dd1c0-f723-438e-95c2-a23b5a6a4900" />

With uuid7 (mostly, still only 8 hours after switching):

<img width="1454" alt="Screenshot 2025-04-17 at 08 55 33" src="https://github.com/user-attachments/assets/5bd3f4ec-f85f-417a-b4e2-24170364382e" />


