### PR TITLE
fix (JobParametersDB): Ensure index names are lowercase in case the VO has capital letters

### DIFF
--- a/diracx-db/src/diracx/db/os/job_parameters.py
+++ b/diracx-db/src/diracx/db/os/job_parameters.py
@@ -25,7 +25,8 @@ class JobParametersDB(BaseOSDB):
 
     def index_name(self, vo, doc_id: int) -> str:
         split = int(int(doc_id) // 1e6)
-        return f"{self.index_prefix}_{vo}_{split}m"
+        # The index name must be lowercase or opensearchpy will throw.
+        return f"{self.index_prefix}_{vo.lower()}_{split}m"
 
     def upsert(self, vo, doc_id, document):
         document = {

--- a/diracx-db/tests/opensearch/test_search.py
+++ b/diracx-db/tests/opensearch/test_search.py
@@ -105,7 +105,9 @@ async def prefilled_db(request):
     impl = request.param
     async with resolve_fixtures_hack(request, impl) as dummy_opensearch_db:
         await dummy_opensearch_db.upsert("dummyvo", 798811211, DOC1)
-        await dummy_opensearch_db.upsert("dummyvo", 998811211, DOC2)
+        # the following line tests if the index name is made properly lowercase in case
+        # the VO has capital letters e.g. "diracAdmin"
+        await dummy_opensearch_db.upsert("dummyVO", 998811211, DOC2)
         await dummy_opensearch_db.upsert("dummyvo", 798811212, DOC3)
 
         # Force a refresh to make sure the documents are available


### PR DESCRIPTION
This is causing cypress tests to fail in https://github.com/DIRACGrid/diracx-web/pull/327 due to the job status change failing when killing a job as it sets a parameter in the JobParameterDB with vo=`diracAdmin`, which leads to a non-lowercase index name, which opensearch dislikes.