### PR TITLE
[HotFix]: Bad error handling can lead to a 500 error

### DIFF
--- a/diracx-logic/src/diracx/logic/auth/utils.py
+++ b/diracx-logic/src/diracx/logic/auth/utils.py
@@ -8,7 +8,6 @@ import secrets
 import httpx
 from authlib.integrations.starlette_client import OAuthError
 from authlib.jose import JsonWebKey, JsonWebToken
-from authlib.jose.errors import DecodeError
 from authlib.oidc.core import IDToken
 from cachetools import TTLCache
 from cryptography.fernet import Fernet
@@ -195,13 +194,10 @@ def read_token(
 ) -> dict:
     # First transform it into bytes, then return a jwt object
     # Don't take settings as a parameter to allow claims_options to be None or something else
-    try:
-        encoded_payload = payload.encode("ascii")
-        jwt = JsonWebToken(token_algorithm)
-        decoded_jwt = jwt.decode(encoded_payload, key, claims_options=claims_options)
-        decoded_jwt.validate()
-    except DecodeError as e:
-        raise ValueError("wrong json payload") from e
+    encoded_payload = payload.encode("ascii")
+    jwt = JsonWebToken(token_algorithm)
+    decoded_jwt = jwt.decode(encoded_payload, key, claims_options=claims_options)
+    decoded_jwt.validate()
     return decoded_jwt
 
 

--- a/diracx-routers/src/diracx/routers/auth/management.py
+++ b/diracx-routers/src/diracx/routers/auth/management.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 from typing import Annotated, Any
 
+from authlib.jose import JoseError
 from fastapi import Depends, HTTPException, status
 from typing_extensions import TypedDict
 from uuid_utils import UUID
@@ -79,7 +80,7 @@ async def revoke_refresh_token_by_refresh_token(
         await revoke_refresh_token_by_refresh_token_bl(
             auth_db, None, refresh_token, settings
         )
-    except ValueError:
+    except JoseError:
         logger.warning("Someone tried to revoke its token but failed.")
 
     return "Refresh token revoked"


### PR DESCRIPTION
Changed the error handling in the fixed logout router: [in these lines](https://github.com/Robin-Van-de-Merghel/diracx/blob/4c72d9a5225d6e8fb930d14fafe808c3261f94a4/diracx-logic/src/diracx/logic/auth/utils.py#L193-L205).

This led if the token is badly shaped to a crash in `verify_dirac_access_token`, because we catch only `JoseError`, but we raise `ValueError` which is not caught.

I found this bug doing [CI in another PR](https://github.com/DIRACGrid/diracx/actions/runs/14658762686/job/41138418074?pr=421), but we did not catch this elsewhere because this is not tested everywhere.