### PR TITLE
feat: address pyproject.toml suggestions from repo review

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ testing = ["diracx-testing"]
 packages = []
 
 [build-system]
-requires = ["setuptools>=61", "wheel", "setuptools_scm>=8"]
+requires = ["setuptools>=61", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
@@ -139,6 +139,10 @@ module = 'sh.*'
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]
+minversion = "8"
+log_cli_level = "INFO"
+xfail_strict = true
+filterwarnings = ["default"]
 testpaths = [
     "diracx-api/tests",
     "diracx-cli/tests",
@@ -154,6 +158,7 @@ addopts = [
     "-pdiracx.testing",
     "-pdiracx.testing.osdb",
     "--import-mode=importlib",
+    "-ra", "--strict-config", "--strict-markers",
 ]
 asyncio_mode = "auto"
 markers = [


### PR DESCRIPTION
[PP003](https://learn.scientific-python.org/development/guides/packaging-classic#PP003): Does not list wheel as a build-dep
Do not include "wheel" in your build-system.requires, setuptools does this via PEP 517 already. Setuptools will also only require this for actual wheel builds, and might have version limits.

[PP302](https://learn.scientific-python.org/development/guides/pytest#PP302): Sets a minimum pytest to at least 6
Must have a minversion=, and must be at least 6 (first version to support pyproject.toml configuration).
[tool.pytest.ini_options]
minversion = "7"

[PP304](https://learn.scientific-python.org/development/guides/pytest#PP304): Sets the log level in pytest
log_cli_level should be set. This will allow logs to be displayed on failures.
[tool.pytest.ini_options]
log_cli_level = "INFO"

[PP305](https://learn.scientific-python.org/development/guides/pytest#PP305): Specifies xfail_strict
xfail_strict should be set. You can manually specify if a check should be strict when setting each xfail.
[tool.pytest.ini_options]
xfail_strict = true

[PP306](https://learn.scientific-python.org/development/guides/pytest#PP306): Specifies strict config
--strict-config should be in addopts = [...]. This forces an error if a config setting is misspelled.
[tool.pytest.ini_options]
addopts = ["-ra", "--strict-config", "--strict-markers"]

[PP307](https://learn.scientific-python.org/development/guides/pytest#PP307): Specifies strict markers
--strict-markers should be in addopts = [...]. This forces all markers to be specified in config, avoiding misspellings.
[tool.pytest.ini_options]
addopts = ["-ra", "--strict-config", "--strict-markers"]

[PP308](https://learn.scientific-python.org/development/guides/pytest#PP308): Specifies useful pytest summary
An explicit summary flag like -ra should be in addopts = [...] (print summary of all fails/errors).
[tool.pytest.ini_options]
addopts = ["-ra", "--strict-config", "--strict-markers"]

[PP309](https://learn.scientific-python.org/development/guides/pytest#PP309): Filter warnings specified
filterwarnings must be set (probably to at least ["error"]). Python will hide important warnings otherwise, like deprecations.

[tool.pytest.ini_options]
filterwarnings = ["default"]    <- _suggested by the tool was: "error"_