### PR TITLE
feat: expose Content-Range response header for diracx-web running locally

### DIFF
--- a/diracx-routers/src/diracx/routers/factory.py
+++ b/diracx-routers/src/diracx/routers/factory.py
@@ -321,6 +321,7 @@ def create_app_inner(
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],
+        expose_headers=["Content-Range"],
     )
 
     configure_logger()


### PR DESCRIPTION
It's needed if we want to go to next/previous page from a local instance of `diracx-web` (launched through `npm run dev`)