### PR TITLE
[BUG] fix: Fixed verify_token error

### DIFF
--- a/diracx-routers/src/diracx/routers/utils/users.py
+++ b/diracx-routers/src/diracx/routers/utils/users.py
@@ -6,6 +6,7 @@ from typing import Annotated, Any
 
 from fastapi import Depends, HTTPException, status
 from fastapi.security import OpenIdConnect
+from joserfc.errors import JoseError
 from joserfc.jwt import JWTClaimsRegistry
 from pydantic import BaseModel, GetCoreSchemaHandler, GetJsonSchemaHandler
 from pydantic_core import CoreSchema, core_schema
@@ -97,7 +98,7 @@ async def verify_dirac_access_token(
                 iss={"essential": True, "value": settings.token_issuer},
             ),
         )
-    except ValueError as e:
+    except (ValueError, JoseError) as e:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid JWT",


### PR DESCRIPTION
```
  File "/diracx_source/diracx/diracx-routers/src/diracx/routers/utils/users.py", line 92, in verify_dirac_access_token
    claims = read_token(
             ^^^^^^^^^^^
  File "/diracx_source/diracx/diracx-logic/src/diracx/logic/auth/utils.py", line 204, in read_token
    claims_requests.validate(token.claims)
  File "/opt/conda/lib/python3.11/site-packages/joserfc/rfc7519/registry.py", line 51, in validate
    func(value)
  File "/opt/conda/lib/python3.11/site-packages/joserfc/rfc7519/registry.py", line 111, in validate_exp
    raise ExpiredTokenError()
```