### PR TITLE
fix: Fixed JoseError error handling

### DIFF
--- a/diracx-routers/src/diracx/routers/auth/token.py
+++ b/diracx-routers/src/diracx/routers/auth/token.py
@@ -7,7 +7,7 @@ import os
 from typing import Annotated, Literal
 
 from fastapi import Depends, Form, Header, HTTPException, status
-from joserfc.errors import DecodeError, ExpiredTokenError, InvalidKeyIdError
+from joserfc.errors import JoseError
 
 from diracx.core.exceptions import (
     DiracHttpResponseError,
@@ -146,9 +146,7 @@ async def get_oidc_token(
         ) from e
     except (
         InvalidCredentialsError,
-        DecodeError,
-        ExpiredTokenError,
-        InvalidKeyIdError,
+        JoseError,
     ) as e:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/diracx-routers/src/diracx/routers/utils/users.py
+++ b/diracx-routers/src/diracx/routers/utils/users.py
@@ -6,7 +6,7 @@ from typing import Annotated, Any
 
 from fastapi import Depends, HTTPException, status
 from fastapi.security import OpenIdConnect
-from joserfc.errors import DecodeError, ExpiredTokenError
+from joserfc.errors import JoseError
 from joserfc.jwt import JWTClaimsRegistry
 from pydantic import BaseModel, GetCoreSchemaHandler, GetJsonSchemaHandler
 from pydantic_core import CoreSchema, core_schema
@@ -98,7 +98,7 @@ async def verify_dirac_access_token(
                 iss={"essential": True, "value": settings.token_issuer},
             ),
         )
-    except (DecodeError, ExpiredTokenError) as e:
+    except JoseError as e:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid JWT",


### PR DESCRIPTION
We need to catch JoseError to avoid 500 errors.

Added two tests to make sure that we handle other errors.