### PR TITLE
Removing sandboxes which are no longer assigned

### DIFF
--- a/diracx-core/src/diracx/core/s3.py
+++ b/diracx-core/src/diracx/core/s3.py
@@ -18,7 +18,12 @@ from botocore.errorfactory import ClientError
 from .models import ChecksumAlgorithm
 
 if TYPE_CHECKING:
+    from typing import TypedDict
+
     from types_aiobotocore_s3.client import S3Client
+
+    class S3Object(TypedDict):
+        Key: str
 
 
 class S3PresignedPostInfo(TypedDict):
@@ -83,7 +88,7 @@ def b16_to_b64(hex_string: str) -> str:
 
 
 async def s3_bulk_delete_with_retry(
-    s3_client, bucket: str, objects: list[dict[str, str]]
+    s3_client, bucket: str, objects: list[S3Object]
 ) -> None:
     max_attempts = 5
     delay = 1.0

--- a/diracx-db/src/diracx/db/sql/sandbox_metadata/db.py
+++ b/diracx-db/src/diracx/db/sql/sandbox_metadata/db.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
     Table,
     and_,
     delete,
+    exists,
     insert,
     literal,
     or_,
@@ -236,7 +237,10 @@ class SandboxMetadataDB(BaseSQLDB):
         """
         conditions = [
             # If it has assigned to a job but is no longer mapped it can be removed
-            # and_(SandBoxes.Assigned, ~exists(SandBoxes.SBId == SBEntityMapping.SBId)),
+            and_(
+                SandBoxes.Assigned,
+                ~exists().where(SBEntityMapping.SBId == SandBoxes.SBId),
+            ),
             # If the sandbox is still unassigned after 15 days, remove it
             and_(~SandBoxes.Assigned, days_since(SandBoxes.LastAccessTime) >= 15),
         ]


### PR DESCRIPTION
This pull request introduces enhancements to type safety, database query logic, and sandbox cleanup functionality across multiple modules. The most important changes include the introduction of the `TypedDict` type for S3 objects, improvements to database query conditions, and the addition of concurrency control for sandbox cleanup operations.

### Type Safety Improvements:
* [`diracx-core/src/diracx/core/s3.py`](diffhunk://#diff-b1e7805875c076b980fe06e23ddc6e9127bc6de5015e6e99a6c5134a839522abR21-R27): Added a `TypedDict` named `S3Object` to define the structure of S3 object dictionaries, improving type safety in `s3_bulk_delete_with_retry`. [[1]](diffhunk://#diff-b1e7805875c076b980fe06e23ddc6e9127bc6de5015e6e99a6c5134a839522abR21-R27) [[2]](diffhunk://#diff-b1e7805875c076b980fe06e23ddc6e9127bc6de5015e6e99a6c5134a839522abL86-R91)
* [`diracx-logic/src/diracx/logic/jobs/sandboxes.py`](diffhunk://#diff-eb0bf656f26a0c1dcba22d1b5a39a58b46a648bb0eda81e7865854f98cfbf92bR26-R28): Updated `clean_sandboxes` to use `S3Object` for type safety when handling S3 object batches. [[1]](diffhunk://#diff-eb0bf656f26a0c1dcba22d1b5a39a58b46a648bb0eda81e7865854f98cfbf92bR26-R28) [[2]](diffhunk://#diff-eb0bf656f26a0c1dcba22d1b5a39a58b46a648bb0eda81e7865854f98cfbf92bL200-R237)

### Database Query Enhancements:
* [`diracx-db/src/diracx/db/sql/sandbox_metadata/db.py`](diffhunk://#diff-1f48b8bdc92df0db86525f69717b1c6034b1cd97bef3c36374eeaded2ebd7a9cL239-R243): Refactored the `delete_unused_sandboxes` query to use `exists().where()` for improved readability and maintainability.

### Sandbox Cleanup Functionality:
* [`diracx-logic/src/diracx/logic/jobs/sandboxes.py`](diffhunk://#diff-eb0bf656f26a0c1dcba22d1b5a39a58b46a648bb0eda81e7865854f98cfbf92bL200-R237): Enhanced `clean_sandboxes` to support concurrency using `asyncio.Semaphore` and `asyncio.TaskGroup`, allowing for controlled parallel batch processing during sandbox cleanup. Added a helper function `delete_batch_and_log` for better modularity and logging.

### Miscellaneous:
* [`diracx-logic/src/diracx/logic/jobs/sandboxes.py`](diffhunk://#diff-eb0bf656f26a0c1dcba22d1b5a39a58b46a648bb0eda81e7865854f98cfbf92bR3-R5): Added `import asyncio` to enable asynchronous operations for sandbox cleanup.
* [`diracx-db/src/diracx/db/sql/sandbox_metadata/db.py`](diffhunk://#diff-1f48b8bdc92df0db86525f69717b1c6034b1cd97bef3c36374eeaded2ebd7a9cR16): Added the `exists` import for use in database query refactoring.