### PR TITLE
fix: freeze pytest-asyncio

### DIFF
--- a/diracx-testing/pyproject.toml
+++ b/diracx-testing/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 dependencies = [
     "pytest",
-    "pytest-asyncio",
+    "pytest-asyncio==1.0.0",
     "pytest-cov",
     "pytest-xdist",
     "httpx",


### PR DESCRIPTION
The new version `1.1.0` is breaking the CI: https://github.com/DIRACGrid/diracx/actions/runs/16345163597/job/46176893538?pr=469

Probably because `resolve_fixtures_hack` is "too fragile"...
https://github.com/DIRACGrid/diracx/blob/727e8ce97a5e1a1ab1469747a702a5f7b35d5418/diracx-db/tests/opensearch/test_search.py#L42-L99