### PR TITLE
fix: pin joserfc to minimum version 1.1.0

### DIFF
--- a/diracx-core/pyproject.toml
+++ b/diracx-core/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "cachetools",
     "email_validator",
     "gitpython",
-    "joserfc",
+    "joserfc >=1.1.0",
     "pydantic >=2.10",
     "pydantic-settings",
     "pyyaml",


### PR DESCRIPTION
## Summary
- Pin joserfc dependency to version >=1.1.0 to resolve import error with KeySetSerialization