### PR TITLE
fix: job admins cannot get summaries including jobs from other users

### DIFF
--- a/diracx-logic/src/diracx/logic/jobs/query.py
+++ b/diracx-logic/src/diracx/logic/jobs/query.py
@@ -88,7 +88,10 @@ async def summary(
     body: SummaryParams,
 ):
     """Show information suitable for plotting."""
-    if not config.Operations["Defaults"].Services.JobMonitoring.GlobalJobsInfo:
+    if (
+        not config.Operations["Defaults"].Services.JobMonitoring.GlobalJobsInfo
+        and preferred_username
+    ):
         body.search.append(
             {
                 "parameter": "Owner",


### PR DESCRIPTION
Very similar to https://github.com/DIRACGrid/diracx/pull/469

Problems to get the summaries, preventing us from getting suggestions in the search bar in `diracx-web`.