### PR TITLE
fix: remove preferred username from the search body of the summary if admin

### DIFF
--- a/diracx-logic/src/diracx/logic/jobs/query.py
+++ b/diracx-logic/src/diracx/logic/jobs/query.py
@@ -84,7 +84,7 @@ async def search(
 async def summary(
     config: Config,
     job_db: JobDB,
-    preferred_username: str,
+    preferred_username: str | None,
     body: SummaryParams,
 ):
     """Show information suitable for plotting."""

--- a/diracx-routers/src/diracx/routers/jobs/query.py
+++ b/diracx-routers/src/diracx/routers/jobs/query.py
@@ -304,9 +304,13 @@ async def summary(
     """
     await check_permissions(action=ActionType.QUERY, job_db=job_db)
 
+    preferred_username: str | None = user_info.preferred_username
+    if JOB_ADMINISTRATOR in user_info.properties:
+        preferred_username = None
+
     return await summary_bl(
         config=config,
         job_db=job_db,
-        preferred_username=user_info.preferred_username,
+        preferred_username=preferred_username,
         body=body,
     )


### PR DESCRIPTION
Aims at fixing the `summary` for the admins by completing the work done in https://github.com/DIRACGrid/diracx/pull/616