### PR TITLE
ci: remove RUST_BACKTRACE=full from workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,6 @@ jobs:
         run: |
           # Workaround for https://github.com/prefix-dev/pixi/issues/3762
           sed -i.bak 's@editable = true@editable = false@g' pixi.toml
-          export RUST_BACKTRACE=full
           rm pixi.toml.bak
           # Add annotations to github actions
           pixi add --no-install --pypi --feature diracx-core pytest-github-actions-annotate-failures


### PR DESCRIPTION
## Summary
- Removes the `RUST_BACKTRACE=full` export from GitHub Actions workflow
- Addresses debugging setup that's no longer needed

## Test plan
- [x] Pre-commit hooks pass
- [x] CI pipeline completes successfully without the debug setting

Closes #634

🤖 Generated with [Claude Code](https://claude.ai/code)