### PR TITLE
feat: add package versions to well-known installation metadata endpoint

### DIFF
--- a/diracx-client/src/diracx/client/_generated/models/_models.py
+++ b/diracx-client/src/diracx/client/_generated/models/_models.py
@@ -743,23 +743,32 @@ class Metadata(_serialization.Model):
 
     :ivar virtual_organizations: Virtual Organizations. Required.
     :vartype virtual_organizations: dict[str, ~_generated.models.VOInfo]
+    :ivar versions: Versions. Required.
+    :vartype versions: dict[str, str]
     """
 
     _validation = {
         "virtual_organizations": {"required": True},
+        "versions": {"required": True},
     }
 
     _attribute_map = {
         "virtual_organizations": {"key": "virtual_organizations", "type": "{VOInfo}"},
+        "versions": {"key": "versions", "type": "{str}"},
     }
 
-    def __init__(self, *, virtual_organizations: Dict[str, "_models.VOInfo"], **kwargs: Any) -> None:
+    def __init__(
+        self, *, virtual_organizations: Dict[str, "_models.VOInfo"], versions: Dict[str, str], **kwargs: Any
+    ) -> None:
         """
         :keyword virtual_organizations: Virtual Organizations. Required.
         :paramtype virtual_organizations: dict[str, ~_generated.models.VOInfo]
+        :keyword versions: Versions. Required.
+        :paramtype versions: dict[str, str]
         """
         super().__init__(**kwargs)
         self.virtual_organizations = virtual_organizations
+        self.versions = versions
 
 
 class OpenIDConfiguration(_serialization.Model):

--- a/diracx-core/src/diracx/core/models.py
+++ b/diracx-core/src/diracx/core/models.py
@@ -326,6 +326,7 @@ class VOInfo(TypedDict):
 
 class Metadata(TypedDict):
     virtual_organizations: dict[str, VOInfo]
+    versions: dict[str, str]
 
 
 class HeartbeatData(BaseModel, extra="forbid"):

--- a/diracx-routers/tests/test_generic.py
+++ b/diracx-routers/tests/test_generic.py
@@ -39,7 +39,15 @@ def test_installation_metadata(test_client):
     r = test_client.get("/.well-known/dirac-metadata")
 
     assert r.status_code == 200
-    assert r.json()
+
+    data = r.json()
+
+    assert data
+    assert "virtual_organizations" in data
+    assert "versions" in data
+
+    assert "diracx-core" in data["versions"]
+    assert "diracx-routers" in data["versions"]
 
 
 @pytest.mark.xfail(reason="TODO")

--- a/extensions/gubbins/gubbins-client/src/gubbins/client/_generated/models/_models.py
+++ b/extensions/gubbins/gubbins-client/src/gubbins/client/_generated/models/_models.py
@@ -153,6 +153,8 @@ class ExtendedMetadata(_serialization.Model):
 
     :ivar virtual_organizations: Virtual Organizations. Required.
     :vartype virtual_organizations: dict[str, ~_generated.models.VOInfo]
+    :ivar versions: Versions. Required.
+    :vartype versions: dict[str, str]
     :ivar gubbins_secrets: Gubbins Secrets. Required.
     :vartype gubbins_secrets: str
     :ivar gubbins_user_info: Gubbins User Info. Required.
@@ -161,12 +163,14 @@ class ExtendedMetadata(_serialization.Model):
 
     _validation = {
         "virtual_organizations": {"required": True},
+        "versions": {"required": True},
         "gubbins_secrets": {"required": True},
         "gubbins_user_info": {"required": True},
     }
 
     _attribute_map = {
         "virtual_organizations": {"key": "virtual_organizations", "type": "{VOInfo}"},
+        "versions": {"key": "versions", "type": "{str}"},
         "gubbins_secrets": {"key": "gubbins_secrets", "type": "str"},
         "gubbins_user_info": {"key": "gubbins_user_info", "type": "{[str]}"},
     }
@@ -175,6 +179,7 @@ class ExtendedMetadata(_serialization.Model):
         self,
         *,
         virtual_organizations: Dict[str, "_models.VOInfo"],
+        versions: Dict[str, str],
         gubbins_secrets: str,
         gubbins_user_info: Dict[str, List[str]],
         **kwargs: Any
@@ -182,6 +187,8 @@ class ExtendedMetadata(_serialization.Model):
         """
         :keyword virtual_organizations: Virtual Organizations. Required.
         :paramtype virtual_organizations: dict[str, ~_generated.models.VOInfo]
+        :keyword versions: Versions. Required.
+        :paramtype versions: dict[str, str]
         :keyword gubbins_secrets: Gubbins Secrets. Required.
         :paramtype gubbins_secrets: str
         :keyword gubbins_user_info: Gubbins User Info. Required.
@@ -189,6 +196,7 @@ class ExtendedMetadata(_serialization.Model):
         """
         super().__init__(**kwargs)
         self.virtual_organizations = virtual_organizations
+        self.versions = versions
         self.gubbins_secrets = gubbins_secrets
         self.gubbins_user_info = gubbins_user_info
 

--- a/extensions/gubbins/gubbins-logic/src/gubbins/logic/auth/well_known.py
+++ b/extensions/gubbins/gubbins-logic/src/gubbins/logic/auth/well_known.py
@@ -22,6 +22,7 @@ async def get_installation_metadata(
     gubbins_metadata = ExtendedMetadata(
         gubbins_secrets="hush!",
         virtual_organizations=original_metadata["virtual_organizations"],
+        versions=original_metadata["versions"],
         gubbins_user_info=gubbins_user_info,
     )
 

--- a/extensions/gubbins/gubbins-routers/tests/test_wellknown.py
+++ b/extensions/gubbins/gubbins-routers/tests/test_wellknown.py
@@ -25,6 +25,10 @@ async def test_dirac_metadata_is_overwriten(test_client):
     )
     assert r.status_code == 200, r.json()
     assert "gubbins_secrets" in r.json(), r.json()
+    assert "versions" in r.json(), r.json()
+
+    assert "gubbins-core" in r.json()["versions"]
+    assert "gubbins-routers" in r.json()["versions"]
 
 
 async def test_openid_configuration_is_not_changed(test_client):


### PR DESCRIPTION
Add package version metadata to the `/.well-known/dirac-metadata` endpoint and also for gubbins