### PR TITLE
fix: move cern-specific config option from diracx to lhcbdiracx

### DIFF
--- a/diracx-core/src/diracx/core/config/schema.py
+++ b/diracx-core/src/diracx/core/config/schema.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from datetime import date, datetime
+from datetime import datetime
 from typing import Annotated, Any, MutableMapping, TypeVar
 
 from pydantic import BaseModel as _BaseModel
@@ -72,13 +72,6 @@ class UserConfig(BaseModel):
     Email: EmailStr | None = None
     Suspended: list[str] = []
     Quota: int | None = None
-    # TODO: These should be LHCbDIRAC specific
-    CERNAccountType: str | None = None
-    PrimaryCERNAccount: str | None = None
-    CERNPersonId: int | None = None
-
-    # Mapping from VO name to affiliation end date (YYYY-MM-DD)
-    AffiliationEnds: dict[str, date] = Field(default_factory=dict)
 
 
 class GroupConfig(BaseModel):


### PR DESCRIPTION
Goes with https://gitlab.cern.ch/lhcb-dirac/lhcbdiracx/-/merge_requests/44
If accepted, I think we should merge the `lhcbdiracx` MR before this one to make sure we will always cover the CERN-specific config attributes.

Note: in `lhcbdiracx`, attributes are not `str |None` anymore, but `str`.