### PR TITLE
test: add test to verify with_config_repo uses extension Config

### DIFF
--- a/extensions/gubbins/gubbins-core/tests/test_config.py
+++ b/extensions/gubbins/gubbins-core/tests/test_config.py
@@ -36,3 +36,33 @@ def test_remote_git_config_source(monkeypatch):
     assert isinstance(modified, datetime.datetime)
     result = remote_conf.read_raw(hexsha, modified)
     assert isinstance(result, Config)
+
+
+def test_with_config_repo_uses_gubbins_config(with_config_repo):
+    """Verify with_config_repo fixture uses gubbins Config, not base Config.
+
+    The with_config_repo fixture must use select_from_extension() to discover
+    the Config class, so extensions like gubbins can add fields to the schema.
+
+    Before the fix (DIRACGrid/diracx#727), the fixture directly imported Config
+    from diracx.core.config, bypassing the extension system. This caused the
+    fixture to serialize config using base UserConfig (without GubbinsSpecificInfo),
+    so the JSON file wouldn't contain gubbins-specific fields.
+
+    This test reads the raw JSON to verify it contains GubbinsSpecificInfo,
+    which proves the fixture used gubbins Config for serialization.
+    """
+    import json
+
+    # Read the raw JSON file created by the fixture
+    config_file = with_config_repo / "default.yml"
+    raw_config = json.loads(config_file.read_text())
+
+    # The JSON should contain GubbinsSpecificInfo in user configs
+    # This field only exists if gubbins Config was used to serialize
+    for vo_config in raw_config["Registry"].values():
+        for user_config in vo_config["Users"].values():
+            assert "GubbinsSpecificInfo" in user_config, (
+                "GubbinsSpecificInfo not found in JSON - fixture may not be using "
+                "extension-aware Config discovery"
+            )


### PR DESCRIPTION
Example failure before the fix in #727

```bash
$ git revert 49d0fb8c2718a5668f330219025832365119d15d
[fix/testing-config-extension-aware a1e6b44e] Revert "fix: use extension-aware Config discovery in testing fixture (#727)"
 1 file changed, 2 insertions(+), 5 deletions(-)


$ pixi run pytest-gubbins -k test_with_config_repo_uses_gubbins_config
✨ Pixi task (pytest-gubbins in default-gubbins): cd extensions/gubbins/ && pytest -k test_with_config_repo_uses_gubbins_config: (Run the tests for gubbins)
======================================================================================================================================= test session starts ========================================================================================================================================
platform darwin -- Python 3.11.14, pytest-8.4.2, pluggy-1.6.0 -- /Users/cburr/Development/DIRAC-dev/diracx/.pixi/envs/default-gubbins/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/cburr/Development/DIRAC-dev/diracx/extensions/gubbins
configfile: pyproject.toml
testpaths: gubbins-api/tests, gubbins-cli/tests, gubbins-client/tests, gubbins-core/tests, gubbins-db/tests, gubbins-routers/tests
plugins: anyio-4.12.1, xdist-3.8.0, httpx-0.35.0, github-actions-annotate-failures-0.3.0, asyncio-1.0.0, cov-7.0.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 21 items / 20 deselected / 1 selected

gubbins-core/tests/test_config.py::test_with_config_repo_uses_gubbins_config FAILED                                                                                                                                                                                                          [100%]

============================================================================================================================================= FAILURES =============================================================================================================================================
____________________________________________________________________________________________________________________________ test_with_config_repo_uses_gubbins_config _____________________________________________________________________________________________________________________________

with_config_repo = PosixPath('/private/var/folders/1g/q2y74s696ng0v_cmb9sv7qgr0000gn/T/pytest-of-cburr/pytest-13017/cs-repo0')

    def test_with_config_repo_uses_gubbins_config(with_config_repo):
        """Verify with_config_repo fixture uses gubbins Config, not base Config.

        The with_config_repo fixture must use select_from_extension() to discover
        the Config class, so extensions like gubbins can add fields to the schema.

        Before the fix (DIRACGrid/diracx#727), the fixture directly imported Config
        from diracx.core.config, bypassing the extension system. This caused the
        fixture to serialize config using base UserConfig (without GubbinsSpecificInfo),
        so the JSON file wouldn't contain gubbins-specific fields.

        This test reads the raw JSON to verify it contains GubbinsSpecificInfo,
        which proves the fixture used gubbins Config for serialization.
        """
        import json

        # Read the raw JSON file created by the fixture
        config_file = with_config_repo / "default.yml"
        raw_config = json.loads(config_file.read_text())

        # The JSON should contain GubbinsSpecificInfo in user configs
        # This field only exists if gubbins Config was used to serialize
        for vo_config in raw_config["Registry"].values():
            for user_config in vo_config["Users"].values():
>               assert "GubbinsSpecificInfo" in user_config, (
                    "GubbinsSpecificInfo not found in JSON - fixture may not be using "
                    "extension-aware Config discovery"
                )
E               AssertionError: GubbinsSpecificInfo not found in JSON - fixture may not be using extension-aware Config discovery
E               assert 'GubbinsSpecificInfo' in {'DNs': [], 'Email': None, 'PreferedUsername': 'chaen', 'Quota': None, ...}

gubbins-core/tests/test_config.py:65: AssertionError
========================================================================================================================================== tests coverage ==========================================================================================================================================
________________________________________________________________________________________________________________________ coverage: platform darwin, python 3.11.14-final-0 _________________________________________________________________________________________________________________________

Name                                                                         Stmts   Miss  Cover   Missing
----------------------------------------------------------------------------------------------------------
gubbins-cli/src/gubbins/cli/__init__.py                                          0      0   100%
gubbins-cli/src/gubbins/cli/config.py                                            7      2    71%   14, 20
gubbins-cli/src/gubbins/cli/lollygag.py                                         16      7    56%   17, 26-28, 36-38
gubbins-client/src/gubbins/client/_generated/__init__.py                        11      2    82%   18-19
gubbins-client/src/gubbins/client/_generated/_client.py                         37     21    43%   41-70, 90-92, 95, 98-99, 102
gubbins-client/src/gubbins/client/_generated/_configuration.py                  18     12    33%   23-25, 28-36
gubbins-client/src/gubbins/client/_generated/_patch.py                           5      0   100%
gubbins-client/src/gubbins/client/_generated/_serialization.py                1018    855    16%   76-132, 152-164, 188, 202-203, 215-216, 228-232, 245-260, 269-271, 280, 283, 287, 291-295, 304-309, 326-327, 370-371, 377-388, 400-401, 423-433, 437-444, 456-490, 499-500, 511, 550-567, 580-692, 706-741, 754-766, 779-798, 811-820, 833-858, 864-868, 884-889, 900-912, 930-984, 994-1018, 1032-1077, 1081-1093, 1103, 1113-1114, 1124, 1134, 1144-1147, 1157-1162, 1172-1174, 1185-1192, 1211-1237, 1249-1256, 1260-1277, 1283-1302, 1314-1316, 1331-1333, 1337, 1341-1348, 1358-1363, 1369-1446, 1463-1490, 1502-1503, 1519-1587, 1590-1608, 1620-1633, 1648-1655, 1677-1699, 1710-1745, 1758-1803, 1813-1825, 1836-1844, 1857-1889, 1907-1929, 1942-1951, 1966-1989, 2000-2002, 2013-2018, 2029-2035, 2046-2048, 2059-2066, 2077-2084, 2095-2101, 2112-2127, 2138-2164, 2176-2184
gubbins-client/src/gubbins/client/_generated/_utils/__init__.py                  0      0   100%
gubbins-client/src/gubbins/client/_generated/_utils/serialization.py          1018    851    16%   74-128, 144-156, 180, 192-193, 205-206, 218-222, 235-242, 251-253, 262, 265, 269, 273-277, 286-291, 304-305, 346-347, 353-362, 374-375, 397-407, 411-416, 428-454, 463-464, 475, 544-643, 657-686, 699-711, 724-741, 754-763, 776-801, 805-809, 825-830, 841-853, 871-917, 927-947, 959-1002, 1006-1018, 1028, 1038-1039, 1049, 1059, 1069-1072, 1082-1087, 1097-1099, 1110-1117, 1136-1157, 1169-1176, 1180-1197, 1203-1220, 1232-1234, 1247-1249, 1253, 1257-1264, 1274-1279, 1283-1353, 1368-1395, 1407-1408, 1422-1481, 1484-1499, 1511-1524, 1539-1545, 1567-1583, 1594-1625, 1636-1672, 1682-1688, 1699-1705, 1716-1748, 1764-1786, 1799-1808, 1823-1842, 1853-1855, 1866-1871, 1882-1888, 1899-1901, 1912-1919, 1930-1935, 1946-1950, 1961-1973, 1984-2010, 2022-2030
gubbins-client/src/gubbins/client/_generated/_utils/utils.py                    30     24    20%   12-14, 23-31, 35-40, 44-49
gubbins-client/src/gubbins/client/_generated/aio/__init__.py                    11      2    82%   18-19
gubbins-client/src/gubbins/client/_generated/aio/_client.py                     37     21    43%   41-70, 92-94, 97, 100-101, 104
gubbins-client/src/gubbins/client/_generated/aio/_configuration.py              18     12    33%   23-25, 28-36
gubbins-client/src/gubbins/client/_generated/aio/_patch.py                       5      0   100%
gubbins-client/src/gubbins/client/_generated/aio/operations/__init__.py         12      0   100%
gubbins-client/src/gubbins/client/_generated/aio/operations/_operations.py     754    625    17%   81-85, 97-132, 144-179, 191-226, 238-273, 289-295, 341-378, 399-435, 455-492, 504-539, 552-587, 602-638, 650-685, 747-789, 811-848, 864-868, 899-943, 959-963, 1033-1080, 1100-1136, 1150-1186, 1200-1236, 1254-1291, 1307-1348, 1400-1443, 1534-1582, 1652-1699, 1780-1828, 1879-1922, 2036-2092, 2164-2211, 2261-2308, 2324-2328, 2342-2378, 2390-2425, 2437-2472
gubbins-client/src/gubbins/client/_generated/aio/operations/_patch.py            4      0   100%
gubbins-client/src/gubbins/client/_generated/models/__init__.py                  9      0   100%
gubbins-client/src/gubbins/client/_generated/models/_enums.py                   40      0   100%
gubbins-client/src/gubbins/client/_generated/models/_models.py                 289    169    42%   83-90, 131-134, 159-160, 185-186, 230-233, 258-259, 319-326, 345-346, 404-409, 454-458, 494-497, 733-769, 819-823, 943-956, 987-989, 1040-1044, 1081-1084, 1130-1133, 1179-1183, 1224-1226, 1290-1297, 1328-1330, 1362-1364, 1405-1408, 1457-1461, 1526-1532, 1569-1572, 1620-1623, 1671-1674
gubbins-client/src/gubbins/client/_generated/operations/__init__.py             12      0   100%
gubbins-client/src/gubbins/client/_generated/operations/_operations.py        1019    858    16%   39-49, 53-63, 67-77, 81-91, 95-110, 114-128, 132-147, 151-161, 165-175, 181-196, 200-210, 224-244, 250-265, 275-293, 297-310, 314-334, 338-353, 359-374, 380-396, 400-418, 422-432, 436-454, 458-471, 475-493, 497-507, 511-531, 535-548, 552-565, 571-586, 590-600, 604-614, 630-634, 646-681, 693-728, 740-775, 787-822, 838-844, 888-925, 946-982, 1002-1039, 1051-1086, 1099-1134, 1149-1185, 1197-1232, 1294-1336, 1358-1395, 1411-1415, 1446-1490, 1506-1510, 1580-1627, 1647-1683, 1697-1733, 1747-1783, 1799-1836, 1852-1893, 1945-1988, 2079-2127, 2197-2244, 2325-2373, 2426-2469, 2583-2639, 2709-2756, 2806-2853, 2869-2873, 2887-2923, 2935-2970, 2982-3017
gubbins-client/src/gubbins/client/_generated/operations/_patch.py                3      0   100%
gubbins-client/src/gubbins/client/aio.py                                         7      0   100%
gubbins-client/src/gubbins/client/models.py                                      3      0   100%
gubbins-core/src/gubbins/core/__init__.py                                        1      0   100%
gubbins-core/src/gubbins/core/config/__init__.py                                 1      0   100%
gubbins-core/src/gubbins/core/config/schema.py                                  12      0   100%
gubbins-db/src/gubbins/db/__init__.py                                            3      0   100%
gubbins-db/src/gubbins/db/sql/__init__.py                                        4      0   100%
gubbins-db/src/gubbins/db/sql/jobs/__init__.py                                   0      0   100%
gubbins-db/src/gubbins/db/sql/jobs/db.py                                        20     12    40%   20-21, 34-48
gubbins-db/src/gubbins/db/sql/jobs/schema.py                                     7      0   100%
gubbins-db/src/gubbins/db/sql/lollygag/__init__.py                               0      0   100%
gubbins-db/src/gubbins/db/sql/lollygag/db.py                                    26     13    50%   25, 28-30, 33-35, 38-43, 46-48
gubbins-db/src/gubbins/db/sql/lollygag/schema.py                                14      0   100%
----------------------------------------------------------------------------------------------------------
TOTAL                                                                         4471   3486    22%
===================================================================================================================================== short test summary info ======================================================================================================================================
FAILED gubbins-core/tests/test_config.py::test_with_config_repo_uses_gubbins_config - AssertionError: GubbinsSpecificInfo not found in JSON - fixture may not be using extension-aware Config discovery
================================================================================================================================= 1 failed, 20 deselected in 1.06s =================================================================================================================================
```