### PR TITLE
fix: require fastapi>=0.121.0 for Depends scope parameter

### DIFF
--- a/diracx-routers/pyproject.toml
+++ b/diracx-routers/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "diracx-db",
     "python-dotenv",    # TODO: We might not need this
     "python-multipart",
-    "fastapi",
+    "fastapi>=0.121.0",
     "httpx",
     "joserfc",
     "pydantic >=2.10",


### PR DESCRIPTION
## Summary
- Bump minimum FastAPI version to 0.121.0 to support the `scope` parameter in `Depends()`
- The `scope` parameter was introduced in [FastAPI 0.121.0](https://fastapi.tiangolo.com/release-notes/) via [PR #14262](https://github.com/fastapi/fastapi/pull/14262)
- Without this, tests fail with: `TypeError: Depends() got an unexpected keyword argument 'scope'`