### PR TITLE
refactor: added a StrEnum for Entrypoints to avoid spelling mistakes

### DIFF
--- a/diracx-cli/src/diracx/cli/__init__.py
+++ b/diracx-cli/src/diracx/cli/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from diracx.core.extensions import EntryPointGroups, select_from_extension
+from diracx.core.extensions import DiracEntryPoint, select_from_extension
 
 from .auth import app
 
@@ -11,23 +11,23 @@ __all__ = ("app",)
 cli_names = set(
     [
         entry_point.name
-        for entry_point in select_from_extension(group=EntryPointGroups.CLI)
+        for entry_point in select_from_extension(group=DiracEntryPoint.CLI)
     ]
 )
 for cli_name in cli_names:
-    entry_point = select_from_extension(group=EntryPointGroups.CLI, name=cli_name)[0]
+    entry_point = select_from_extension(group=DiracEntryPoint.CLI, name=cli_name)[0]
     app.add_typer(entry_point.load(), name=entry_point.name)
 
 
 cli_hidden_names = set(
     [
         entry_point.name
-        for entry_point in select_from_extension(group=EntryPointGroups.HIDDEN_CLI)
+        for entry_point in select_from_extension(group=DiracEntryPoint.HIDDEN_CLI)
     ]
 )
 for cli_name in cli_hidden_names:
     entry_point = select_from_extension(
-        group=EntryPointGroups.HIDDEN_CLI, name=cli_name
+        group=DiracEntryPoint.HIDDEN_CLI, name=cli_name
     )[0]
     app.add_typer(entry_point.load(), name=entry_point.name, hidden=True)
 

--- a/diracx-cli/src/diracx/cli/internal/legacy.py
+++ b/diracx-cli/src/diracx/cli/internal/legacy.py
@@ -21,7 +21,7 @@ from typer import Option
 
 from diracx.core.config import Config
 from diracx.core.config.schema import Field, SupportInfo
-from diracx.core.extensions import EntryPointGroups, select_from_extension
+from diracx.core.extensions import DiracEntryPoint, select_from_extension
 
 from ..utils import AsyncTyper
 
@@ -78,7 +78,7 @@ def cs_sync(old_file: Path, new_file: Path):
 
     _apply_fixes(raw)
     config_class: Config = select_from_extension(
-        group=EntryPointGroups.CORE, name="config"
+        group=DiracEntryPoint.CORE, name="config"
     )[0].load()
     config = config_class.model_validate(raw)
     new_file.write_text(
@@ -264,7 +264,7 @@ def generate_helm_values(
 
     from diracx.core.extensions import select_from_extension
 
-    for entry_point in select_from_extension(group=EntryPointGroups.SQL_DB):
+    for entry_point in select_from_extension(group=DiracEntryPoint.SQL_DB):
         db_name = entry_point.name
         db_config = all_db_configs.get(db_name, {})
 
@@ -310,7 +310,7 @@ def generate_helm_values(
         },
     }
 
-    for entry_point in select_from_extension(group=EntryPointGroups.OS_DB):
+    for entry_point in select_from_extension(group=DiracEntryPoint.OS_DB):
         db_name = entry_point.name
         db_config = all_db_configs.get(db_name, {})
 

--- a/diracx-core/src/diracx/core/config/sources.py
+++ b/diracx-core/src/diracx/core/config/sources.py
@@ -21,7 +21,7 @@ from cachetools import Cache, LRUCache
 from pydantic import AnyUrl, BeforeValidator, TypeAdapter, UrlConstraints
 
 from ..exceptions import BadConfigurationVersionError
-from ..extensions import EntryPointGroups, select_from_extension
+from ..extensions import DiracEntryPoint, select_from_extension
 from ..utils import TwoLevelCache
 from .schema import Config
 
@@ -215,7 +215,7 @@ class BaseGitConfigSource(ConfigSource):
             ) from e
 
         config_class: Config = select_from_extension(
-            group=EntryPointGroups.CORE, name="config"
+            group=DiracEntryPoint.CORE, name="config"
         )[0].load()
         config = config_class.model_validate(raw_obj)
         config._hexsha = hexsha

--- a/diracx-core/src/diracx/core/extensions.py
+++ b/diracx-core/src/diracx/core/extensions.py
@@ -4,7 +4,7 @@ __all__ = [
     "extensions_by_priority",
     "select_from_extension",
     "supports_extending",
-    "EntryPointGroups",
+    "DiracEntryPoint",
 ]
 
 from collections import defaultdict
@@ -18,7 +18,7 @@ T = TypeVar("T")
 P = ParamSpec("P")
 
 
-class EntryPointGroups(StrEnum):
+class DiracEntryPoint(StrEnum):
     """Available entrypoint group values."""
 
     CORE = "diracx"
@@ -29,7 +29,7 @@ class EntryPointGroups(StrEnum):
     SQL_DB = "diracx.dbs.sql"
     MIN_CLIENT_VERSION = "diracx.min_client_version"
     RESOURCES = "diracx.resources"
-    FAST_API = "diracx.services"
+    SERVICES = "diracx.services"
 
 
 @cached(cache=LRUCache(maxsize=1))
@@ -40,10 +40,10 @@ def extensions_by_priority() -> list[str]:
     importing diracx in the MetaPathFinder as part of unrelated imports
     (e.g. http.client).
     """
-    selected = entry_points().select(group=EntryPointGroups.CORE)
+    selected = entry_points().select(group=DiracEntryPoint.CORE)
     if selected is None:
         raise NotImplementedError(
-            f"No entry points found for group {EntryPointGroups.CORE}. Do you have it installed?"
+            f"No entry points found for group {DiracEntryPoint.CORE}. Do you have it installed?"
         )
     extensions = set()
     for entry_point in selected.select(name="extension"):
@@ -89,7 +89,7 @@ def supports_extending(
         name: The entry point name to search for
 
     Example:
-        @supports_extending(EntryPointGroups.RESOURCES, "find_compatible_platforms")
+        @supports_extending(DiracEntryPoint.RESOURCES, "find_compatible_platforms")
         def my_function():
             return "default implementation"
 

--- a/diracx-core/src/diracx/core/resources.py
+++ b/diracx-core/src/diracx/core/resources.py
@@ -7,10 +7,10 @@ from DIRACCommon.ConfigurationSystem.Client.Helpers.Resources import getDIRACPla
 from DIRACCommon.Core.Utilities.ReturnValues import returnValueOrRaise
 
 from diracx.core.config import Config
-from diracx.core.extensions import EntryPointGroups, supports_extending
+from diracx.core.extensions import DiracEntryPoint, supports_extending
 
 
-@supports_extending(EntryPointGroups.RESOURCES, "find_compatible_platforms")
+@supports_extending(DiracEntryPoint.RESOURCES, "find_compatible_platforms")
 def find_compatible_platforms(job_platforms: list[str], config: Config) -> list[str]:
     """Find compatible platforms for the given job platforms.
 

--- a/diracx-core/tests/test_entry_points.py
+++ b/diracx-core/tests/test_entry_points.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 from importlib.metadata import entry_points
 
-from diracx.core.extensions import EntryPointGroups
+from diracx.core.extensions import DiracEntryPoint
 
 
 def test_diracx_resources_entry_point():
     """Test that the diracx.resources entry point is properly configured."""
     # Get all entry points for the diracx.resources group
-    resources_eps = entry_points().select(group=EntryPointGroups.RESOURCES)
+    resources_eps = entry_points().select(group=DiracEntryPoint.RESOURCES)
 
     # Check that find_compatible_platforms entry point exists
     find_platforms_ep = None
@@ -31,7 +31,7 @@ def test_diracx_resources_entry_point():
 def test_entry_point_functionality():
     """Test that the entry point points to the correct function."""
     # Get the entry point
-    resources_eps = entry_points().select(group=EntryPointGroups.RESOURCES)
+    resources_eps = entry_points().select(group=DiracEntryPoint.RESOURCES)
     find_platforms_ep = None
     for ep in resources_eps:
         if ep.name == "find_compatible_platforms":

--- a/diracx-core/tests/test_extensions.py
+++ b/diracx-core/tests/test_extensions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from diracx.core.extensions import (
-    EntryPointGroups,
+    DiracEntryPoint,
     extensions_by_priority,
     select_from_extension,
     supports_extending,
@@ -27,9 +27,9 @@ def test_extensions_by_priority():
 def test_select_from_extension():
     """Test the select_from_extension function."""
     # Test with existing group
-    result = select_from_extension(group=EntryPointGroups.CORE, name="extension")
+    result = select_from_extension(group=DiracEntryPoint.CORE, name="extension")
     assert len(result) >= 1
-    assert all(ep.group == EntryPointGroups.CORE for ep in result)
+    assert all(ep.group == DiracEntryPoint.CORE for ep in result)
     assert all(ep.name == "extension" for ep in result)
 
     # Test with non-existent group

--- a/diracx-db/src/diracx/db/os/utils.py
+++ b/diracx-db/src/diracx/db/os/utils.py
@@ -15,7 +15,7 @@ from typing import Any, Self
 from opensearchpy import AsyncOpenSearch
 
 from diracx.core.exceptions import InvalidQueryError
-from diracx.core.extensions import EntryPointGroups, select_from_extension
+from diracx.core.extensions import DiracEntryPoint, select_from_extension
 from diracx.db.exceptions import DBUnavailableError
 
 logger = logging.getLogger(__name__)
@@ -93,7 +93,7 @@ class BaseOSDB(metaclass=ABCMeta):
         db_classes: list[type[BaseOSDB]] = [
             entry_point.load()
             for entry_point in select_from_extension(
-                group=EntryPointGroups.OS_DB, name=db_name
+                group=DiracEntryPoint.OS_DB, name=db_name
             )
         ]
         if not db_classes:
@@ -108,7 +108,7 @@ class BaseOSDB(metaclass=ABCMeta):
         prefixed with ``DIRACX_OS_DB_{DB_NAME}``.
         """
         conn_kwargs: dict[str, dict[str, Any]] = {}
-        for entry_point in select_from_extension(group=EntryPointGroups.OS_DB):
+        for entry_point in select_from_extension(group=DiracEntryPoint.OS_DB):
             db_name = entry_point.name
             var_name = f"DIRACX_OS_DB_{entry_point.name.upper()}"
             if var_name in os.environ:

--- a/diracx-db/src/diracx/db/sql/utils/base.py
+++ b/diracx-db/src/diracx/db/sql/utils/base.py
@@ -18,7 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, create_async_en
 from uuid_utils import UUID, uuid7
 
 from diracx.core.exceptions import InvalidQueryError
-from diracx.core.extensions import EntryPointGroups, select_from_extension
+from diracx.core.extensions import DiracEntryPoint, select_from_extension
 from diracx.core.models import (
     SearchSpec,
     SortDirection,
@@ -111,7 +111,7 @@ class BaseSQLDB(metaclass=ABCMeta):
         db_classes: list[type[BaseSQLDB]] = [
             entry_point.load()
             for entry_point in select_from_extension(
-                group=EntryPointGroups.SQL_DB, name=db_name
+                group=DiracEntryPoint.SQL_DB, name=db_name
             )
         ]
         if not db_classes:
@@ -126,7 +126,7 @@ class BaseSQLDB(metaclass=ABCMeta):
         prefixed with ``DIRACX_DB_URL_{DB_NAME}``.
         """
         db_urls: dict[str, str] = {}
-        for entry_point in select_from_extension(group=EntryPointGroups.SQL_DB):
+        for entry_point in select_from_extension(group=DiracEntryPoint.SQL_DB):
             db_name = entry_point.name
             var_name = f"DIRACX_DB_URL_{entry_point.name.upper()}"
             if var_name in os.environ:

--- a/diracx-routers/src/diracx/routers/access_policies.py
+++ b/diracx-routers/src/diracx/routers/access_policies.py
@@ -26,7 +26,7 @@ from typing import Annotated, Self
 
 from fastapi import Depends
 
-from diracx.core.extensions import EntryPointGroups, select_from_extension
+from diracx.core.extensions import DiracEntryPoint, select_from_extension
 from diracx.core.models import (
     AccessTokenPayload,
     RefreshTokenPayload,
@@ -68,7 +68,7 @@ class BaseAccessPolicy(metaclass=ABCMeta):
         policy_classes: list[type["BaseAccessPolicy"]] = [
             entry_point.load()
             for entry_point in select_from_extension(
-                group=EntryPointGroups.ACCESS_POLICY, name=access_policy_name
+                group=DiracEntryPoint.ACCESS_POLICY, name=access_policy_name
             )
         ]
         if not policy_classes:

--- a/diracx-routers/tests/test_policy.py
+++ b/diracx-routers/tests/test_policy.py
@@ -4,7 +4,7 @@ import inspect
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
-from diracx.core.extensions import EntryPointGroups, select_from_extension
+from diracx.core.extensions import DiracEntryPoint, select_from_extension
 from diracx.routers.access_policies import (
     BaseAccessPolicy,
 )
@@ -22,7 +22,7 @@ def test_all_routes_have_policy():
 
     """
     missing_security: defaultdict[list[str]] = defaultdict(list)
-    for entry_point in select_from_extension(group=EntryPointGroups.FAST_API):
+    for entry_point in select_from_extension(group=DiracEntryPoint.SERVICES):
         router: DiracxRouter = entry_point.load()
 
         # If the router was created with the

--- a/diracx-testing/src/diracx/testing/entrypoints.py
+++ b/diracx-testing/src/diracx/testing/entrypoints.py
@@ -6,7 +6,7 @@ from importlib.metadata import PackageNotFoundError, distribution, entry_points
 
 import pytest
 
-from diracx.core.extensions import EntryPointGroups
+from diracx.core.extensions import DiracEntryPoint
 
 
 def get_installed_entry_points():
@@ -14,7 +14,7 @@ def get_installed_entry_points():
     entry_pts = entry_points()
     diracx_eps = defaultdict(dict)
     for group in entry_pts.groups:
-        if EntryPointGroups.CORE in group:
+        if DiracEntryPoint.CORE in group:
             for ep in entry_pts.select(group=group):
                 diracx_eps[group][ep.name] = ep.value
     return dict(diracx_eps)

--- a/diracx-testing/src/diracx/testing/utils.py
+++ b/diracx-testing/src/diracx/testing/utils.py
@@ -23,7 +23,7 @@ import pytest
 from joserfc.jwk import KeySet, OKPKey
 from uuid_utils import uuid7
 
-from diracx.core.extensions import EntryPointGroups
+from diracx.core.extensions import DiracEntryPoint
 from diracx.core.models import AccessTokenPayload, RefreshTokenPayload
 
 if TYPE_CHECKING:
@@ -174,17 +174,17 @@ class ClientFactory:
                 return {"PolicySpecific": "OpenAccessForTest"}, {}
 
         enabled_systems = {
-            e.name for e in select_from_extension(group=EntryPointGroups.FAST_API)
+            e.name for e in select_from_extension(group=DiracEntryPoint.SERVICES)
         }
         database_urls = {
             e.name: "sqlite+aiosqlite:///:memory:"
-            for e in select_from_extension(group=EntryPointGroups.SQL_DB)
+            for e in select_from_extension(group=DiracEntryPoint.SQL_DB)
         }
         # TODO: Monkeypatch this in a less stupid way
         # TODO: Only use this if opensearch isn't available
         os_database_conn_kwargs = {
             e.name: {"sqlalchemy_dsn": "sqlite+aiosqlite:///:memory:"}
-            for e in select_from_extension(group=EntryPointGroups.OS_DB)
+            for e in select_from_extension(group=DiracEntryPoint.OS_DB)
         }
         BaseOSDB.available_implementations = partial(
             fake_available_osdb_implementations,
@@ -199,7 +199,7 @@ class ClientFactory:
         all_access_policies = {
             e.name: [AlwaysAllowAccessPolicy]
             + BaseAccessPolicy.available_implementations(e.name)
-            for e in select_from_extension(group=EntryPointGroups.ACCESS_POLICY)
+            for e in select_from_extension(group=DiracEntryPoint.ACCESS_POLICY)
         }
 
         config_source = ConfigSource.create_from_url(
@@ -421,7 +421,7 @@ def with_config_repo(tmp_path_factory):
     from diracx.core.extensions import select_from_extension
 
     # Use extension-aware Config discovery to support extensions that add fields
-    config_class = select_from_extension(group=EntryPointGroups.CORE, name="config")[
+    config_class = select_from_extension(group=DiracEntryPoint.CORE, name="config")[
         0
     ].load()
 


### PR DESCRIPTION
Closes: #622 

Changes:
-  added a `strEnum EntryPointGroups` in `/diracx-core/.../extensions.py` to avoid hardcoded strings and spelling mistakes

Questions:
- should `/docs/reference/entrypoints.md` match with https://diracx--701.org.readthedocs.build/en/701/dev/reference/entrypoints/#core-extension-registration? Should this new `enum` be documented anywhere?
> Answer: #701 contains the doc and isn't merged yet
- does places where `extension = diracx` be replaced by `EntryPointGroups.CORE`? e.g: 
``` python
# DiracX will always be there so force it to be the lowest priority
return sorted(extensions, key=lambda x: x == "diracx")
--> return sorted(extensions, key=lambda x: x == EntryPointGroups.CORE)
```
``` python
if installed_extension not in [None, "diracx"]: ...
--> if installed_extension not in [None, EntryPointGroups.CORE]: ...
```
``` python
cls.client_modules = ("diracx.client", f"{installed_extension}.client")
--> cls.client_modules = (f"{EntryPointGroups.CORE}.client", f"{installed_extension}.client")
```
> Answer: we don't touch extensions