### PR TITLE
fix: skip CI on release-please PRs

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -4,9 +4,9 @@ on:
   push:
     tags:
       - 'v*'
+  pull_request:
     paths-ignore:
       - 'CHANGELOG.md'
-  pull_request:
   schedule:
     - cron: '0 10 * * *'
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - 'CHANGELOG.md'
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'CHANGELOG.md'
 
 defaults:
   run:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - 'CHANGELOG.md'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## Summary
- Move `paths-ignore` from `push` triggers to `pull_request` triggers
- Release-please PRs (which only modify `CHANGELOG.md`) now skip CI jobs
- Tag pushes for releases still run deployment workflows normally
- Push to main continues to run all tests after PR merge

Fixes #685