### PR TITLE
chore: adapt client to new autorest version

### DIFF
--- a/diracx-client/src/diracx/client/_generated/models/_models.py
+++ b/diracx-client/src/diracx/client/_generated/models/_models.py
@@ -5,6 +5,7 @@
 # Changes may cause incorrect behavior and will be lost if the code is regenerated.
 # --------------------------------------------------------------------------
 
+from collections.abc import MutableMapping
 import datetime
 from typing import Any, Dict, List, Optional, TYPE_CHECKING, Union
 
@@ -12,6 +13,7 @@ from .._utils import serialization as _serialization
 
 if TYPE_CHECKING:
     from .. import models as _models
+JSON = MutableMapping[str, Any]
 
 
 class BodyAuthGetOidcToken(_serialization.Model):
@@ -1522,6 +1524,10 @@ class ValidationError(_serialization.Model):
     :vartype msg: str
     :ivar type: Error Type. Required.
     :vartype type: str
+    :ivar input: Input.
+    :vartype input: any
+    :ivar ctx: Context.
+    :vartype ctx: JSON
     """
 
     _validation = {
@@ -1534,9 +1540,20 @@ class ValidationError(_serialization.Model):
         "loc": {"key": "loc", "type": "[ValidationErrorLocItem]"},
         "msg": {"key": "msg", "type": "str"},
         "type": {"key": "type", "type": "str"},
+        "input": {"key": "input", "type": "object"},
+        "ctx": {"key": "ctx", "type": "object"},
     }
 
-    def __init__(self, *, loc: List["_models.ValidationErrorLocItem"], msg: str, type: str, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        *,
+        loc: List["_models.ValidationErrorLocItem"],
+        msg: str,
+        type: str,
+        input: Optional[Any] = None,
+        ctx: Optional[JSON] = None,
+        **kwargs: Any
+    ) -> None:
         """
         :keyword loc: Location. Required.
         :paramtype loc: list[~_generated.models.ValidationErrorLocItem]
@@ -1544,11 +1561,17 @@ class ValidationError(_serialization.Model):
         :paramtype msg: str
         :keyword type: Error Type. Required.
         :paramtype type: str
+        :keyword input: Input.
+        :paramtype input: any
+        :keyword ctx: Context.
+        :paramtype ctx: JSON
         """
         super().__init__(**kwargs)
         self.loc = loc
         self.msg = msg
         self.type = type
+        self.input = input
+        self.ctx = ctx
 
 
 class ValidationErrorLocItem(_serialization.Model):

--- a/extensions/gubbins/gubbins-client/src/gubbins/client/_generated/models/_models.py
+++ b/extensions/gubbins/gubbins-client/src/gubbins/client/_generated/models/_models.py
@@ -5,6 +5,7 @@
 # Changes may cause incorrect behavior and will be lost if the code is regenerated.
 # --------------------------------------------------------------------------
 
+from collections.abc import MutableMapping
 import datetime
 from typing import Any, Dict, List, Optional, TYPE_CHECKING, Union
 
@@ -12,6 +13,7 @@ from .._utils import serialization as _serialization
 
 if TYPE_CHECKING:
     from .. import models as _models
+JSON = MutableMapping[str, Any]
 
 
 class BodyAuthGetOidcToken(_serialization.Model):
@@ -1543,6 +1545,10 @@ class ValidationError(_serialization.Model):
     :vartype msg: str
     :ivar type: Error Type. Required.
     :vartype type: str
+    :ivar input: Input.
+    :vartype input: any
+    :ivar ctx: Context.
+    :vartype ctx: JSON
     """
 
     _validation = {
@@ -1555,9 +1561,20 @@ class ValidationError(_serialization.Model):
         "loc": {"key": "loc", "type": "[ValidationErrorLocItem]"},
         "msg": {"key": "msg", "type": "str"},
         "type": {"key": "type", "type": "str"},
+        "input": {"key": "input", "type": "object"},
+        "ctx": {"key": "ctx", "type": "object"},
     }
 
-    def __init__(self, *, loc: List["_models.ValidationErrorLocItem"], msg: str, type: str, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        *,
+        loc: List["_models.ValidationErrorLocItem"],
+        msg: str,
+        type: str,
+        input: Optional[Any] = None,
+        ctx: Optional[JSON] = None,
+        **kwargs: Any
+    ) -> None:
         """
         :keyword loc: Location. Required.
         :paramtype loc: list[~_generated.models.ValidationErrorLocItem]
@@ -1565,11 +1582,17 @@ class ValidationError(_serialization.Model):
         :paramtype msg: str
         :keyword type: Error Type. Required.
         :paramtype type: str
+        :keyword input: Input.
+        :paramtype input: any
+        :keyword ctx: Context.
+        :paramtype ctx: JSON
         """
         super().__init__(**kwargs)
         self.loc = loc
         self.msg = msg
         self.type = type
+        self.input = input
+        self.ctx = ctx
 
 
 class ValidationErrorLocItem(_serialization.Model):


### PR DESCRIPTION
CI is currently failing because there is a new autorest version (e.g. https://github.com/DIRACGrid/diracx/pull/748)

Here I just regenerated the clients so that PRs can be rebased on people keep working without being bothered by the failures.

Note: what's the status of https://github.com/DIRACGrid/diracx/pull/699
That would be ideal to solve that kind of issue.