### PR TITLE
fix: use workflow_run pattern for fork PR compatibility

### DIFF
--- a/.github/workflows/draft-on-changes-requested.yml
+++ b/.github/workflows/draft-on-changes-requested.yml
@@ -1,13 +1,33 @@
 name: Draft on Changes Requested
 
 on:
-  pull_request_review:
-    types: [submitted]
+  workflow_run:
+    workflows: ["Record Changes Requested"]
+    types: [completed]
 
 permissions:
   pull-requests: write
+  actions: read
 
 jobs:
+  get-pr:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.pr.outputs.number }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: pr-info
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+      - id: pr
+        run: echo "number=$(cat pr_number.txt)" >> "$GITHUB_OUTPUT"
+
   draft:
-    if: github.event.review.state == 'changes_requested'
+    needs: get-pr
+    permissions:
+      pull-requests: write
     uses: DIRACGrid/management/.github/workflows/draft-on-changes-requested.yml@master
+    with:
+      pr_number: ${{ fromJSON(needs.get-pr.outputs.pr_number) }}

--- a/.github/workflows/record-changes-requested.yml
+++ b/.github/workflows/record-changes-requested.yml
@@ -1,0 +1,16 @@
+name: Record Changes Requested
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  record:
+    if: github.event.review.state == 'changes_requested'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ github.event.pull_request.number }}" > pr_number.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pr-info
+          path: pr_number.txt


### PR DESCRIPTION
## Summary
- Replaces the single-file `draft-on-changes-requested.yml` workflow with a two-file `workflow_run` pattern
- Adds `record-changes-requested.yml` that runs on `pull_request_review` to save the PR number as an artifact
- Updates `draft-on-changes-requested.yml` to trigger via `workflow_run`, which gets full base repo permissions even for fork PRs
- This fixes the issue where the `GITHUB_TOKEN` gets read-only permissions for PRs from forks