### PR TITLE
fix: use PAT and API-based PR lookup for draft conversion

### DIFF
--- a/.github/workflows/draft-on-changes-requested.yml
+++ b/.github/workflows/draft-on-changes-requested.yml
@@ -5,29 +5,11 @@ on:
     workflows: ["Record Changes Requested"]
     types: [completed]
 
-permissions:
-  pull-requests: write
-  actions: read
+permissions: {}
 
 jobs:
-  get-pr:
-    if: github.event.workflow_run.conclusion == 'success'
-    runs-on: ubuntu-latest
-    outputs:
-      pr_number: ${{ steps.pr.outputs.number }}
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: pr-info
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ github.token }}
-      - id: pr
-        run: echo "number=$(cat pr_number.txt)" >> "$GITHUB_OUTPUT"
-
   draft:
-    needs: get-pr
-    permissions:
-      pull-requests: write
+    if: github.event.workflow_run.conclusion == 'success'
     uses: DIRACGrid/management/.github/workflows/draft-on-changes-requested.yml@master
-    with:
-      pr_number: ${{ fromJSON(needs.get-pr.outputs.pr_number) }}
+    secrets:
+      token: ${{ secrets.DRAFT_PAT }}

--- a/.github/workflows/record-changes-requested.yml
+++ b/.github/workflows/record-changes-requested.yml
@@ -9,8 +9,4 @@ jobs:
     if: github.event.review.state == 'changes_requested'
     runs-on: ubuntu-latest
     steps:
-      - run: echo "${{ github.event.pull_request.number }}" > pr_number.txt
-      - uses: actions/upload-artifact@v4
-        with:
-          name: pr-info
-          path: pr_number.txt
+      - run: 'true'


### PR DESCRIPTION
## Summary
- Drop artifact-based PR number passing in favour of API-based PR lookup from workflow_run context
- Use a PAT (DRAFT_PAT secret) for the convertPullRequestToDraft GraphQL mutation, as GITHUB_TOKEN cannot perform this operation