### PR TITLE
feat: use artifact-based approach for draft-on-changes-requested workflow

### DIFF
--- a/.github/workflows/draft-on-changes-requested.yml
+++ b/.github/workflows/draft-on-changes-requested.yml
@@ -8,8 +8,26 @@ on:
 permissions: {}
 
 jobs:
-  draft:
+  get-pr:
     if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    outputs:
+      pr_number: ${{ steps.pr.outputs.number }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: pr-info
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+      - id: pr
+        run: echo "number=$(cat pr_number.txt)" >> "$GITHUB_OUTPUT"
+
+  draft:
+    needs: get-pr
     uses: DIRACGrid/management/.github/workflows/draft-on-changes-requested.yml@master
+    with:
+      pr_number: ${{ fromJSON(needs.get-pr.outputs.pr_number) }}
     secrets:
       token: ${{ secrets.DRAFT_PAT }}

--- a/.github/workflows/record-changes-requested.yml
+++ b/.github/workflows/record-changes-requested.yml
@@ -9,4 +9,8 @@ jobs:
     if: github.event.review.state == 'changes_requested'
     runs-on: ubuntu-latest
     steps:
-      - run: 'true'
+      - run: echo "${{ github.event.pull_request.number }}" > pr_number.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pr-info
+          path: pr_number.txt


### PR DESCRIPTION
## Summary
- Switch to artifact-based approach for passing PR number between workflows
- `record-changes-requested.yml` uploads PR number as artifact
- `draft-on-changes-requested.yml` downloads artifact and passes PR number to reusable workflow