### PR TITLE
fix: reference reusable workflow from .github repo

### DIFF
--- a/.github/workflows/draft-on-changes-requested.yml
+++ b/.github/workflows/draft-on-changes-requested.yml
@@ -26,7 +26,7 @@ jobs:
 
   draft:
     needs: get-pr
-    uses: DIRACGrid/management/.github/workflows/draft-on-changes-requested.yml@master
+    uses: DIRACGrid/.github/.github/workflows/draft-on-changes-requested.yml@main
     with:
       pr_number: ${{ fromJSON(needs.get-pr.outputs.pr_number) }}
     secrets:


### PR DESCRIPTION
## Summary
- Update draft-on-changes-requested workflow to reference the reusable workflow from DIRACGrid/.github instead of DIRACGrid/management