### PR TITLE
fix: include LICENSE file in sub-package sdists and wheels

### DIFF
--- a/diracx-api/pyproject.toml
+++ b/diracx-api/pyproject.toml
@@ -35,6 +35,9 @@ source = "vcs"
 [tool.hatch.version.raw-options]
 root = ".."
 
+[tool.hatch.build.targets.sdist.force-include]
+"../LICENSE" = "LICENSE"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/diracx"]
 

--- a/diracx-cli/pyproject.toml
+++ b/diracx-cli/pyproject.toml
@@ -55,6 +55,9 @@ source = "vcs"
 [tool.hatch.version.raw-options]
 root = ".."
 
+[tool.hatch.build.targets.sdist.force-include]
+"../LICENSE" = "LICENSE"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/diracx"]
 

--- a/diracx-client/pyproject.toml
+++ b/diracx-client/pyproject.toml
@@ -32,6 +32,9 @@ root = ".."
 [tool.hatch.build.targets.wheel]
 packages = ["src/diracx"]
 
+[tool.hatch.build.targets.sdist.force-include]
+"../LICENSE" = "LICENSE"
+
 [tool.hatch.build.targets.wheel.force-include]
 "src/_diracx_client_importer.pth" = "_diracx_client_importer.pth"
 

--- a/diracx-core/pyproject.toml
+++ b/diracx-core/pyproject.toml
@@ -58,6 +58,9 @@ source = "vcs"
 [tool.hatch.version.raw-options]
 root = ".."
 
+[tool.hatch.build.targets.sdist.force-include]
+"../LICENSE" = "LICENSE"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/diracx"]
 

--- a/diracx-db/pyproject.toml
+++ b/diracx-db/pyproject.toml
@@ -47,6 +47,9 @@ source = "vcs"
 [tool.hatch.version.raw-options]
 root = ".."
 
+[tool.hatch.build.targets.sdist.force-include]
+"../LICENSE" = "LICENSE"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/diracx"]
 

--- a/diracx-logic/pyproject.toml
+++ b/diracx-logic/pyproject.toml
@@ -39,6 +39,9 @@ source = "vcs"
 [tool.hatch.version.raw-options]
 root = ".."
 
+[tool.hatch.build.targets.sdist.force-include]
+"../LICENSE" = "LICENSE"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/diracx"]
 

--- a/diracx-routers/pyproject.toml
+++ b/diracx-routers/pyproject.toml
@@ -65,6 +65,9 @@ source = "vcs"
 [tool.hatch.version.raw-options]
 root = ".."
 
+[tool.hatch.build.targets.sdist.force-include]
+"../LICENSE" = "LICENSE"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/diracx"]
 

--- a/diracx-testing/pyproject.toml
+++ b/diracx-testing/pyproject.toml
@@ -40,5 +40,8 @@ source = "vcs"
 [tool.hatch.version.raw-options]
 root = ".."
 
+[tool.hatch.build.targets.sdist.force-include]
+"../LICENSE" = "LICENSE"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/diracx"]


### PR DESCRIPTION
## Summary
- Each sub-package (`diracx-api/`, `diracx-core/`, etc.) was missing the LICENSE file in published sdists and wheels because hatchling only auto-discovers license files in the package's own directory, not the monorepo root
- Added `[tool.hatch.build.targets.sdist.force-include]` to all 8 sub-package `pyproject.toml` files to pull the root `LICENSE` into each sdist
- The wheel (built from the sdist) then auto-discovers the LICENSE and places it in `.dist-info/licenses/`