### PR TITLE
fix: EdDSA to Ed25519 token migration

### DIFF
--- a/diracx-core/pyproject.toml
+++ b/diracx-core/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "cachetools",
     "email_validator",
     "gitpython",
-    "joserfc >=1.1.0",
+    "joserfc >=1.5.0",
     "pydantic >=2.10",
     "pydantic-settings",
     "pyyaml",

--- a/diracx-core/src/diracx/core/settings.py
+++ b/diracx-core/src/diracx/core/settings.py
@@ -204,7 +204,8 @@ class AuthSettings(ServiceSettingsBase):
     generation and verification.
     """
 
-    token_allowed_algorithms: list[str] = ["RS256", "EdDSA"]  # noqa: S105
+    # TODO: EdDSA should be removed later due to "SecurityWarning: EdDSA is deprecated via RFC 9864"
+    token_allowed_algorithms: list[str] = ["RS256", "EdDSA", "Ed25519"]  # noqa: S105
     """List of allowed cryptographic algorithms for JWT token signing.
 
     Supported algorithms include RS256 (RSA with SHA-256) and EdDSA

--- a/diracx-core/src/diracx/core/settings.py
+++ b/diracx-core/src/diracx/core/settings.py
@@ -208,8 +208,8 @@ class AuthSettings(ServiceSettingsBase):
     token_allowed_algorithms: list[str] = ["RS256", "EdDSA", "Ed25519"]  # noqa: S105
     """List of allowed cryptographic algorithms for JWT token signing.
 
-    Supported algorithms include RS256 (RSA with SHA-256) and EdDSA
-    (Edwards-curve Digital Signature Algorithm). Default: ["RS256", "EdDSA"]
+    Supported algorithms include RS256 (RSA with SHA-256) and Ed25519
+    (Edwards-curve Digital Signature Algorithm). Default: ["RS256", "Ed25519"]
     """
 
     access_token_expire_minutes: int = 20

--- a/diracx-core/tests/test_secrets.py
+++ b/diracx-core/tests/test_secrets.py
@@ -15,7 +15,7 @@ def test_token_signing_key(tmp_path):
             OKPKey.generate_key(
                 parameters={
                     "key_ops": ["sign", "verify"],
-                    "alg": "EdDSA",
+                    "alg": "Ed25519",
                     "kid": uuid7().hex,
                 }
             )

--- a/diracx-logic/src/diracx/logic/__main__.py
+++ b/diracx-logic/src/diracx/logic/__main__.py
@@ -40,7 +40,7 @@ def new_key(
     """Create a fresh private signing key."""
     parameters = {
         "key_ops": ["sign", "verify"],
-        "alg": "EdDSA",
+        "alg": "Ed25519",
         "kid": uuid7().hex,
     }
     return JWKRegistry.generate_key(

--- a/diracx-routers/tests/auth/test_standard.py
+++ b/diracx-routers/tests/auth/test_standard.py
@@ -869,15 +869,12 @@ async def test_keystore(test_client):
     # Add the rsa key to the keystore
     jwks.keys.append(rsa_key)
 
-    # TODO: what's the point of this here?
-    #  Since it's the same as before (because we added Ed25519 back meanwhile)
-    #  Maybe a wrong copy paste?
     auth_settings = AuthSettings(
         token_issuer=issuer,
         token_allowed_algorithms=[
             "RS256",
             "Ed25519",
-        ],  # We purposefully remove Ed25519 (?)
+        ],
         token_keystore=json.dumps(jwks.as_dict(private=True)),
         state_key=state_key,
         allowed_redirects=allowed_redirects,

--- a/diracx-routers/tests/auth/test_standard.py
+++ b/diracx-routers/tests/auth/test_standard.py
@@ -783,8 +783,7 @@ async def test_refresh_token_invalid(test_client, auth_httpx_mock: HTTPXMock):
 
     new_auth_settings = AuthSettings(
         token_issuer="https://iam-auth.web.cern.ch/",
-        # TODO: EdDSA should be removed later due to "SecurityWarning: EdDSA is deprecated via RFC 9864"
-        token_allowed_algorithms=["EdDSA", "RS256", "Ed25519"],
+        token_allowed_algorithms=["RS256", "Ed25519"],
         token_keystore=json.dumps(KeySet(keys=[key]).as_dict(private=True)),
         state_key=Fernet.generate_key(),
         allowed_redirects=[

--- a/diracx-routers/tests/auth/test_standard.py
+++ b/diracx-routers/tests/auth/test_standard.py
@@ -783,7 +783,8 @@ async def test_refresh_token_invalid(test_client, auth_httpx_mock: HTTPXMock):
 
     new_auth_settings = AuthSettings(
         token_issuer="https://iam-auth.web.cern.ch/",
-        token_allowed_algorithms=["EdDSA", "RS256"],
+        # TODO: EdDSA should be removed later due to "SecurityWarning: EdDSA is deprecated via RFC 9864"
+        token_allowed_algorithms=["EdDSA", "RS256", "Ed25519"],
         token_keystore=json.dumps(KeySet(keys=[key]).as_dict(private=True)),
         state_key=Fernet.generate_key(),
         allowed_redirects=[
@@ -833,34 +834,34 @@ async def test_keystore(test_client):
             "kid": uuid7().hex,
         },
     )
-    eddsa_key = OKPKey.generate_key(
+    ed25519_key = OKPKey.generate_key(
         "Ed25519",
         {
             "key_ops": ["sign", "verify"],
-            "alg": "EdDSA",
+            "alg": "Ed25519",
             "kid": uuid7().hex,
         },
     )
 
-    # Generate the keystore with eddsa key only first
-    jwks = KeySet(keys=[eddsa_key])
+    # Generate the keystore with ed25519 key only first
+    jwks = KeySet(keys=[ed25519_key])
 
     # Generate the keystore with rsa key only first
     auth_settings = AuthSettings(
         token_issuer=issuer,
-        token_allowed_algorithms=["RS256"],  # We purposefully remove EdDSA
+        token_allowed_algorithms=["RS256"],  # We purposefully remove Ed25519
         token_keystore=json.dumps(jwks.as_dict(private=True)),
         state_key=state_key,
         allowed_redirects=allowed_redirects,
     )
 
     # Encode/Decode with the keystore: should not work
-    # because EdDSA is not part of the allowed algorithms
+    # because Ed25519 is not part of the allowed algorithms
     with pytest.raises(UnsupportedAlgorithmError):
         token = create_token(payload, auth_settings)
 
-    # Add EdDSA to the allowed algorithms
-    auth_settings.token_allowed_algorithms.append("EdDSA")
+    # Add Ed25519 to the allowed algorithms
+    auth_settings.token_allowed_algorithms.append("Ed25519")
 
     # Encode/Decode with the keystore: should work
     token = create_token(payload, auth_settings)
@@ -869,9 +870,15 @@ async def test_keystore(test_client):
     # Add the rsa key to the keystore
     jwks.keys.append(rsa_key)
 
+    # TODO: what's the point of this here?
+    #  Since it's the same as before (because we added Ed25519 back meanwhile)
+    #  Maybe a wrong copy paste?
     auth_settings = AuthSettings(
         token_issuer=issuer,
-        token_allowed_algorithms=["RS256", "EdDSA"],  # We purposefully remove EdDSA
+        token_allowed_algorithms=[
+            "RS256",
+            "Ed25519",
+        ],  # We purposefully remove Ed25519 (?)
         token_keystore=json.dumps(jwks.as_dict(private=True)),
         state_key=state_key,
         allowed_redirects=allowed_redirects,
@@ -882,7 +889,7 @@ async def test_keystore(test_client):
     await verify_dirac_refresh_token(token, auth_settings)
 
     # Remove 'sign' operation from the RSA key:
-    # should still work because eddsa_key is still there
+    # should still work because ed25519_key is still there
     auth_settings.token_keystore.jwks.keys[1].get("key_ops").remove("sign")
     token = create_token(payload, auth_settings)
     await verify_dirac_refresh_token(token, auth_settings)

--- a/diracx-testing/src/diracx/testing/utils.py
+++ b/diracx-testing/src/diracx/testing/utils.py
@@ -61,7 +61,7 @@ def private_key() -> OKPKey:
     return OKPKey.generate_key(
         parameters={
             "key_ops": ["sign", "verify"],
-            "alg": "EdDSA",
+            "alg": "Ed25519",
             "kid": uuid7().hex,
         }
     )

--- a/docs/admin/reference/env-variables.md
+++ b/docs/admin/reference/env-variables.md
@@ -71,12 +71,12 @@ generation and verification.
 
 ### `DIRACX_SERVICE_AUTH_TOKEN_ALLOWED_ALGORITHMS`
 
-*Optional*, default value: `['RS256', 'EdDSA']`
+*Optional*, default value: `['RS256', 'EdDSA', 'Ed25519']`
 
 List of allowed cryptographic algorithms for JWT token signing.
 
-Supported algorithms include RS256 (RSA with SHA-256) and EdDSA
-(Edwards-curve Digital Signature Algorithm). Default: ["RS256", "EdDSA"]
+Supported algorithms include RS256 (RSA with SHA-256) and Ed25519
+(Edwards-curve Digital Signature Algorithm). Default: ["RS256", "Ed25519"]
 
 ### `DIRACX_SERVICE_AUTH_ACCESS_TOKEN_EXPIRE_MINUTES`
 


### PR DESCRIPTION
cc @aldbr
Closes: #718 

Changes:
- changed token creation algorithm to be Ed25519 instead of EdDSA
- added Ed25519 to the authorized algorithm list. EdDSA is still listed as authorized algorithm so people have time to rotate keys before full migration

# Documentation:
## Token migration and keys rotation
The EdDSA token algorithm is being deprecated by RFC 9864, so it should be replaced with the Ed25519 token algorithm. To do this, users need to rotate their token keys using `diracx` rotate function.

**Prerequisites:** 
- Existing EdDSA keys prior to the migration.
- Ensure `joserfc >= 1.5.0`, otherwise, it won't work.

**Important note:** 
Once the migration from EdDSA to Ed25519 is complete, it is **recommended** to rotate the Ed25519 keys after a certain period of time.

### Locally (using DiracX demo) - only used as tests for this PR
1. Create a demo instance using the main branch (or any branch without this PR implementation): `{PATH}/run_demo {PATH}/diracx`
- _Note 1: you must create the demo instance from another branch due to the behavior of `diracx-charts`. If you create the demo instance from this PR branch, it will automatically generate an Ed25519 key, preventing you from properly testing the migration/rotation process._
- _Note 2: ensure your pixi environment includes `joserfc >= 1.5.0` before creating the demo instance. You will later need to switch branches, and without the correct joserfc version, the new Ed25519 implementation will not work properly._
2. Export Kube configuration and retrieve token secret: `kubectl get secret diracx-jwks -o yaml`, output:
```
apiVersion: v1
data:
  jwks.json: ewogICJrZXlzIjogWwogICAgewogICAgICAiY3J2IjogIkVkMjU1MTkiLAogICAgICAieCI6ICJhck9YQmhtejNzY2xtMXZZcm5KTEdLSzJ3WWNfLWcxaGYtRW9wcVV5VVFvIiwKICAgICAgImQiOiAiZHRQeEJUcVRsdmZkVmVlYzlBdnFuTTZQekJHelItNlRnTGZ0NE5rcVZpdyIsCiAgICAgICJrZXlfb3BzIjogWwogICAgICAgICJzaWduIiwKICAgICAgICAidmVyaWZ5IgogICAgICBdLAogICAgICAiYWxnIjogIkVkRFNBIiwKICAgICAgImtpZCI6ICIwMTljNmJmMzU2YjU3ZGMyYjg3MjY3ZTNkZmM2NmQ5OCIsCiAgICAgICJrdHkiOiAiT0tQIgogICAgfQogIF0KfQ==
...
```
3. Save old keys as `jwks.json`: `echo "{jwks.json.VALUE}" | base64 --decode > jwks.json`
- _Note: values inside `jwks.json` should only contain `"alg": "EdDSA"` before migration._
4. Switch branch to this PR branch, keeping the same demo instance
5. Log-in: `dirac login diracAdmin`, it should work.
6. Rotate the keys using `jwks.json`: `python -m diracx.logic rotate-jwk --jwks-path jwks.json`
- _Note 1: values inside `jwks.json` should now contain `"alg": "EdDSA"` and `"alg": "Ed25519"`_
- _Note 2: note all `kid` values in `jwks.json` for later use._
7. Update token secret value and restart the pods: 
- `kubectl create secret generic diracx-jwks --namespace="$namespace" --from-file=jwks.json --dry-run=client -o yaml | kubectl apply -f -`
- `kubectl rollout restart deployment diracx-demo`

### Production
The following procedure applies both to:
- Migrating from **EdDSA** to **Ed25519** (one-time only)
- Periodically rotating **Ed25519** keys

1. Retrieve your token secret id: `kubectl get secret`
2. Export Kube configuration and retrieve token secret: `kubectl get secret diracx-jwks -o yaml`, output:
```
apiVersion: v1
data:
  jwks.json: ewogICJrZXlzIjogWwogICAgewogICAgICAiY3J2IjogIkVkMjU1MTkiLAogICAgICAieCI6ICJhck9YQmhtejNzY2xtMXZZcm5KTEdLSzJ3WWNfLWcxaGYtRW9wcVV5VVFvIiwKICAgICAgImQiOiAiZHRQeEJUcVRsdmZkVmVlYzlBdnFuTTZQekJHelItNlRnTGZ0NE5rcVZpdyIsCiAgICAgICJrZXlfb3BzIjogWwogICAgICAgICJzaWduIiwKICAgICAgICAidmVyaWZ5IgogICAgICBdLAogICAgICAiYWxnIjogIkVkRFNBIiwKICAgICAgImtpZCI6ICIwMTljNmJmMzU2YjU3ZGMyYjg3MjY3ZTNkZmM2NmQ5OCIsCiAgICAgICJrdHkiOiAiT0tQIgogICAgfQogIF0KfQ==
...
```
3. Save old keys as `jwks.json`: `echo "{jwks.json.VALUE}" | base64 --decode > jwks.json`
- _Note: if migrating, values inside `jwks.json` should only contain `"alg": "EdDSA"` before migration._
4. Try to log-in, it should work.
5. Rotate the keys using `jwks.json` and `diracx` rotate function: `python -m diracx.logic rotate-jwk --jwks-path jwks.json`
- _Note 1: if migrating, values inside `jwks.json` should now contain `"alg": "EdDSA"` and `"alg": "Ed25519"`_
- _Note 2: if migrating, note the `kid` values in `jwks.json` for later use._
7. Update token secret value and restart the pods: 
- `kubectl create secret generic {SECRET_TOKEN_ID} --namespace="$namespace" --from-file=jwks.json --dry-run=client -o yaml | kubectl apply -f -`
- `kubectl rollout restart deployment {POD_ID}`

## Check-up after the rotation
Once migration and rotation are done:
- [ ] Log-in again: it should work
- [ ] Decode `.cache/diracx/credentials.json` and verify that it contains `"alg": "Ed25519"`.
- [ ] If migrating, ensure old EdDSA key `kid` is different from new Ed25519 key `kid` _(see step 6 (local) and step 5 (production), note 2)_

diracx-charts documentation: https://github.com/DIRACGrid/diracx-charts/blob/master/docs/admin/how-to/rotate-a-secret.md#jwt-signing-keys-jwk