### PR TITLE
perf: use sargable (Search ARGument ABLE) range predicates for datetime search filters

### DIFF
--- a/diracx-db/src/diracx/db/sql/utils/base.py
+++ b/diracx-db/src/diracx/db/sql/utils/base.py
@@ -421,11 +421,11 @@ def _build_datetime_range_expr(
     """
     if operator == ScalarSearchOperator.EQUAL:
         return and_(column >= start, column < end)
-    elif operator == ScalarSearchOperator.NOT_EQUAL:
+    if operator == ScalarSearchOperator.NOT_EQUAL:
         return or_(column < start, column >= end)
-    elif operator == ScalarSearchOperator.GREATER_THAN:
+    if operator == ScalarSearchOperator.GREATER_THAN:
         return column >= end
-    elif operator == ScalarSearchOperator.LESS_THAN:
+    if operator == ScalarSearchOperator.LESS_THAN:
         return column < start
     raise InvalidQueryError(
         f"Operator '{operator}' is not supported for partial datetime values"
@@ -440,7 +440,7 @@ def _build_datetime_range_multi_expr(
     """Build a sargable range expression for multiple datetime periods (IN/NOT IN)."""
     if operator == VectorSearchOperator.IN:
         return or_(*[and_(column >= s, column < e) for s, e in bounds])
-    elif operator == VectorSearchOperator.NOT_IN:
+    if operator == VectorSearchOperator.NOT_IN:
         return and_(*[or_(column < s, column >= e) for s, e in bounds])
     raise InvalidQueryError(
         f"Operator '{operator}' is not supported for partial datetime values"

--- a/diracx-db/src/diracx/db/sql/utils/functions.py
+++ b/diracx-db/src/diracx/db/sql/utils/functions.py
@@ -4,7 +4,7 @@ import hashlib
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
-from sqlalchemy import DateTime, func
+from sqlalchemy import DateTime
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql import expression
 
@@ -35,72 +35,6 @@ def mysql_utcnow(element, compiler, **kw) -> str:
 @compiles(utcnow, "sqlite")
 def sqlite_utcnow(element, compiler, **kw) -> str:
     return "DATETIME('now')"
-
-
-class date_trunc(expression.FunctionElement):  # noqa: N801
-    """Sqlalchemy function to truncate a date to a given resolution.
-
-    Primarily used to be able to query for a specific resolution of a date e.g.
-
-        select * from table where date_trunc('day', date_column) = '2021-01-01'
-        select * from table where date_trunc('year', date_column) = '2021'
-        select * from table where date_trunc('minute', date_column) = '2021-01-01 12:00'
-    """
-
-    type = DateTime()
-    # Cache does not work as intended with time resolution values, so we disable it
-    inherit_cache = False
-
-    def __init__(self, *args, time_resolution, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
-        self._time_resolution = time_resolution
-
-
-@compiles(date_trunc, "postgresql")
-def pg_date_trunc(element, compiler, **kw):
-    res = {
-        "SECOND": "second",
-        "MINUTE": "minute",
-        "HOUR": "hour",
-        "DAY": "day",
-        "MONTH": "month",
-        "YEAR": "year",
-    }[element._time_resolution]
-    return f"date_trunc('{res}', {compiler.process(element.clauses)})"
-
-
-@compiles(date_trunc, "mysql")
-def mysql_date_trunc(element, compiler, **kw):
-    pattern = {
-        "SECOND": "%Y-%m-%d %H:%i:%S",
-        "MINUTE": "%Y-%m-%d %H:%i",
-        "HOUR": "%Y-%m-%d %H",
-        "DAY": "%Y-%m-%d",
-        "MONTH": "%Y-%m",
-        "YEAR": "%Y",
-    }[element._time_resolution]
-
-    (dt_col,) = list(element.clauses)
-    return compiler.process(func.date_format(dt_col, pattern))
-
-
-@compiles(date_trunc, "sqlite")
-def sqlite_date_trunc(element, compiler, **kw):
-    pattern = {
-        "SECOND": "%Y-%m-%d %H:%M:%S",
-        "MINUTE": "%Y-%m-%d %H:%M",
-        "HOUR": "%Y-%m-%d %H",
-        "DAY": "%Y-%m-%d",
-        "MONTH": "%Y-%m",
-        "YEAR": "%Y",
-    }[element._time_resolution]
-    (dt_col,) = list(element.clauses)
-    return compiler.process(
-        func.strftime(
-            pattern,
-            dt_col,
-        )
-    )
 
 
 class days_since(expression.FunctionElement):  # noqa: N801


### PR DESCRIPTION
- `apply_search_filters` previously used `date_trunc()` to wrap datetime columns in `date_format()` (MySQL) / `strftime()` (SQLite), which prevents the database from using indexes on those columns
- Replaced with range-based comparisons on the raw column (e.g., `col >= start AND col < end` instead of `date_format(col, '%Y-%m-%d') = '2025-08-25'`)
- All precision levels (YEAR through SECOND) and all comparison operators (eq, neq, gt, lt, in, not in) are handled with index-friendly range predicates

```sql
-- Direct comparison (uses index): 0.649s
SELECT count(*) FROM Jobs
WHERE Status = 'Done' AND Site = 'LCG.CERN.cern'
  AND LastUpdateTime > '2025-08-25 15:35:31';

-- date_format() wrapper (full table scan): 12.806s
SELECT count(*) FROM Jobs
WHERE Status = 'Done' AND Site = 'LCG.CERN.cern'
  AND date_format(LastUpdateTime, '%Y-%m-%d %H:%i:%S') > '2025-08-25 15:35:31';
```

Closes https://github.com/DIRACGrid/diracx/issues/642