### PR TITLE
docs/tests: document job commands and add heartbeat command tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,5 +101,8 @@ pixi.lock
 *.egg-info
 docs/templates/_builtin_markdown.jinja
 
+# virtualenv
+.venv
+
 # docs site
 site

--- a/diracx-routers/tests/jobs/test_heartbeat_commands.py
+++ b/diracx-routers/tests/jobs/test_heartbeat_commands.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from time import sleep
+
+import pytest
+from fastapi.testclient import TestClient
+
+from diracx.core.models.job import JobStatus
+
+pytestmark = pytest.mark.enabled_dependencies(
+    [
+        "AuthSettings",
+        "JobDB",
+        "JobLoggingDB",
+        "ConfigSource",
+        "TaskQueueDB",
+        "SandboxMetadataDB",
+        "WMSAccessPolicy",
+        "DevelopmentSettings",
+        "JobParametersDB",
+    ]
+)
+
+
+def test_heartbeat(normal_user_client: TestClient, valid_job_id: int):
+    search_body = {
+        "search": [{"parameter": "JobID", "operator": "eq", "value": valid_job_id}]
+    }
+    r = normal_user_client.post("/api/jobs/search", json=search_body)
+    r.raise_for_status()
+    old_data = r.json()[0]
+    assert old_data["HeartBeatTime"] is None
+
+    payload = {valid_job_id: {"Vsize": 1234}}
+    r = normal_user_client.patch("/api/jobs/heartbeat", json=payload)
+    r.raise_for_status()
+
+    r = normal_user_client.post("/api/jobs/search", json=search_body)
+    r.raise_for_status()
+    new_data = r.json()[0]
+
+    hbt = datetime.fromisoformat(new_data["HeartBeatTime"])
+    # This should be timezone aware due to the enforced tzinfo from
+    # the SQLAlchemy type used for datetime fields in JobDB
+    assert hbt.tzinfo is not None
+    assert hbt >= datetime.now(tz=timezone.utc) - timedelta(seconds=15)
+
+    # Kill the job by setting the status on it
+    r = normal_user_client.patch(
+        "/api/jobs/status",
+        json={
+            valid_job_id: {
+                str(datetime.now(timezone.utc)): {
+                    "Status": JobStatus.KILLED,
+                    "MinorStatus": "Marked for termination",
+                }
+            }
+        },
+    )
+    r.raise_for_status()
+
+    sleep(1)
+    # Send another heartbeat and check that a Kill job command was set
+    payload = {valid_job_id: {"Vsize": 1235}}
+    r = normal_user_client.patch("/api/jobs/heartbeat", json=payload)
+    r.raise_for_status()
+
+    commands = r.json()
+    assert len(commands) == 1, "Exactly one job command should be returned"
+    assert commands[0]["job_id"] == valid_job_id, (
+        f"Wrong job id, should be '{valid_job_id}' but got {commands[0]['job_id']=}"
+    )
+    assert commands[0]["command"] == "Kill", (
+        f"Wrong job command received, should be 'Kill' but got {commands[0]=}"
+    )
+    sleep(1)
+
+    # Send another heartbeat and check the job commands are empty
+    payload = {valid_job_id: {"Vsize": 1234}}
+    r = normal_user_client.patch("/api/jobs/heartbeat", json=payload)
+    r.raise_for_status()
+    commands = r.json()
+    assert len(commands) == 0, (
+        "Exactly zero job commands should be returned after heartbeat commands are sent"
+    )
+
+
+def test_multiple_jobs_receive_independent_kill_commands(
+    normal_user_client: TestClient,
+    valid_job_ids: list[int],
+):
+    """Verify that multiple jobs each receive exactly one Kill command."""
+    r = normal_user_client.patch(
+        "/api/jobs/status",
+        json={
+            job_id: {
+                datetime.now(timezone.utc).isoformat(): {
+                    "Status": JobStatus.KILLED,
+                    "MinorStatus": "Marked for termination",
+                }
+            }
+            for job_id in valid_job_ids
+        },
+    )
+    r.raise_for_status()
+
+    sleep(1)
+
+    r = normal_user_client.patch(
+        "/api/jobs/heartbeat",
+        json={job_id: {"Vsize": 2000} for job_id in valid_job_ids},
+    )
+    r.raise_for_status()
+
+    commands = r.json()
+    assert len(commands) == len(valid_job_ids)
+    assert {cmd["job_id"] for cmd in commands} == set(valid_job_ids)
+    assert {cmd["command"] for cmd in commands} == {"Kill"}
+
+    sleep(1)
+
+    r = normal_user_client.patch(
+        "/api/jobs/heartbeat",
+        json={job_id: {"Vsize": 2001} for job_id in valid_job_ids},
+    )
+    r.raise_for_status()
+
+    assert r.json() == []
+
+
+def test_non_killed_status_does_not_create_command(
+    normal_user_client: TestClient,
+    valid_job_id: int,
+):
+    """Verify statuses different from KILLED do not enqueue job commands."""
+    r = normal_user_client.patch(
+        "/api/jobs/status",
+        json={
+            valid_job_id: {
+                datetime.now(timezone.utc).isoformat(): {
+                    "Status": JobStatus.RUNNING,
+                    "MinorStatus": "Normal transition",
+                }
+            }
+        },
+    )
+    r.raise_for_status()
+
+    sleep(1)
+
+    r = normal_user_client.patch(
+        "/api/jobs/heartbeat",
+        json={valid_job_id: {"Vsize": 500}},
+    )
+    r.raise_for_status()
+
+    assert r.json() == []
+
+
+def test_deleted_creates_kill_command(
+    normal_user_client: TestClient,
+    valid_job_id: int,
+):
+    """Verify DELETED follows the same command path as KILLED."""
+    r = normal_user_client.patch(
+        "/api/jobs/status",
+        json={
+            valid_job_id: {
+                datetime.now(timezone.utc).isoformat(): {
+                    "Status": JobStatus.DELETED,
+                    "MinorStatus": "User removed job",
+                }
+            }
+        },
+    )
+    r.raise_for_status()
+
+    sleep(1)
+
+    r = normal_user_client.patch(
+        "/api/jobs/heartbeat",
+        json={valid_job_id: {"Vsize": 123}},
+    )
+    r.raise_for_status()
+
+    commands = r.json()
+    assert len(commands) == 1
+    assert commands[0]["job_id"] == valid_job_id
+    assert commands[0]["command"] == "Kill"
+
+    sleep(1)
+
+    r = normal_user_client.patch(
+        "/api/jobs/heartbeat",
+        json={valid_job_id: {"Vsize": 124}},
+    )
+    r.raise_for_status()
+
+    assert r.json() == []

--- a/diracx-routers/tests/jobs/test_status.py
+++ b/diracx-routers/tests/jobs/test_status.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
-from time import sleep
 
 import pytest
 from fastapi.testclient import TestClient
@@ -920,69 +919,6 @@ def test_diracx_476(normal_user_client: TestClient, valid_job_id: int):
     payload = {valid_job_id: {(time - timedelta(minutes=2)).isoformat(): inner_payload}}
     r = normal_user_client.patch("/api/jobs/status", json={valid_job_id: payload})
     assert r.status_code == 200, r.json()
-
-
-def test_heartbeat(normal_user_client: TestClient, valid_job_id: int):
-    search_body = {
-        "search": [{"parameter": "JobID", "operator": "eq", "value": valid_job_id}]
-    }
-    r = normal_user_client.post("/api/jobs/search", json=search_body)
-    r.raise_for_status()
-    old_data = r.json()[0]
-    assert old_data["HeartBeatTime"] is None
-
-    payload = {valid_job_id: {"Vsize": 1234}}
-    r = normal_user_client.patch("/api/jobs/heartbeat", json=payload)
-    r.raise_for_status()
-
-    r = normal_user_client.post("/api/jobs/search", json=search_body)
-    r.raise_for_status()
-    new_data = r.json()[0]
-
-    hbt = datetime.fromisoformat(new_data["HeartBeatTime"])
-    # This should be timezone aware due to the enforced tzinfo from
-    # the SQLAlchemy type used for datetime fields in JobDB
-    assert hbt.tzinfo is not None
-    assert hbt >= datetime.now(tz=timezone.utc) - timedelta(seconds=15)
-
-    # Kill the job by setting the status on it
-    r = normal_user_client.patch(
-        "/api/jobs/status",
-        json={
-            valid_job_id: {
-                str(datetime.now(timezone.utc)): {
-                    "Status": JobStatus.KILLED,
-                    "MinorStatus": "Marked for termination",
-                }
-            }
-        },
-    )
-    r.raise_for_status()
-
-    sleep(1)
-    # Send another heartbeat and check that a Kill job command was set
-    payload = {valid_job_id: {"Vsize": 1235}}
-    r = normal_user_client.patch("/api/jobs/heartbeat", json=payload)
-    r.raise_for_status()
-
-    commands = r.json()
-    assert len(commands) == 1, "Exactly one job command should be returned"
-    assert commands[0]["job_id"] == valid_job_id, (
-        f"Wrong job id, should be '{valid_job_id}' but got {commands[0]['job_id']=}"
-    )
-    assert commands[0]["command"] == "Kill", (
-        f"Wrong job command received, should be 'Kill' but got {commands[0]=}"
-    )
-    sleep(1)
-
-    # Send another heartbeat and check the job commands are empty
-    payload = {valid_job_id: {"Vsize": 1234}}
-    r = normal_user_client.patch("/api/jobs/heartbeat", json=payload)
-    r.raise_for_status()
-    commands = r.json()
-    assert len(commands) == 0, (
-        "Exactly zero job commands should be returned after heartbeat commands are sent"
-    )
 
 
 def test_patch_metadata_doc_example(normal_user_client: TestClient, valid_job_id: int):

--- a/docs/dev/explanations/job_commands.md
+++ b/docs/dev/explanations/job_commands.md
@@ -1,0 +1,82 @@
+## What Are Job Commands?
+
+Job commands implement a **per-job control queue** between the WMS and the pilot (JobAgent).
+
+They allow the WMS to send control instructions to running jobs via the heartbeat mechanism.
+
+Currently used for:
+
+- Remote job termination (`Kill` command)
+
+The mechanism is generic and could support additional commands in the future (e.g. debug actions, core dump requests, etc.).
+
+______________________________________________________________________
+
+## Behaviour Summary
+
+### Command Creation
+
+When a job transitions to a terminal state (`KILLED` or `DELETED`),
+`set_job_statuses()` enqueues a `Kill` command in the JobDB.
+
+### Command Delivery
+
+Commands are delivered during:
+
+```text
+PATCH /api/jobs/heartbeat
+```
+
+Flow:
+
+1. Heartbeat updates job state.
+2. `get_job_commands()` retrieves pending commands.
+3. Commands are marked as sent.
+4. Commands are returned to the pilot.
+
+This guarantees **one-shot delivery semantics**:
+
+- A command is delivered exactly once.
+- It is not re-delivered on subsequent heartbeats.
+
+______________________________________________________________________
+
+## Sequence Diagram (Kill Command Lifecycle)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant User
+    participant Router
+    participant JobDB
+    participant WatchDog
+
+    User->>Router: PATCH /api/jobs/status (Killed)
+    Router->>JobDB: update status → KILLED
+    Router->>JobDB: enqueue "Kill"
+    Router-->>User: 200 OK
+
+    WatchDog->>Router: PATCH /api/jobs/heartbeat
+    Router->>JobDB: fetch + mark sent
+    Router-->>WatchDog: [Kill]
+
+    WatchDog->>Router: PATCH /api/jobs/heartbeat
+    Router-->>WatchDog: []
+```
+
+______________________________________________________________________
+
+## Activity View
+
+```mermaid
+flowchart TD
+    A[Status change → KILLED] --> B[Enqueue Kill command]
+    B --> C[Stored in JobDB]
+
+    D[Heartbeat] --> E[Fetch commands]
+    E --> F[Mark as sent]
+    F --> G[Return to pilot]
+    G --> D
+```
+
+______________________________________________________________________

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -171,6 +171,7 @@ nav:
           - Components:
               - Databases: dev/explanations/components/db.md
               - Routes: dev/explanations/components/routes.md
+              - Job commands: dev/explanations/job_commands.md
           - Testing: dev/explanations/testing.md
           - Extensions: dev/explanations/extensions.md
           - Designing functionality: dev/explanations/designing-functionality.md


### PR DESCRIPTION
This PR adds focused router‑level coverage for heartbeat command delivery and documents the job‑command lifecycle. The new tests verify:

- KILLED/DELETED transitions enqueue a Kill command.

- one-shot delivery via heartbeat (no redelivery)

- Multiple jobs are handled independently.

The docs include a concise overview plus sequence/activity diagrams.

Changes

- Add diracx-routers/tests/jobs/test_heartbeat_commands.py with router‑level Kill/heartbeat coverage.

-  Add docs/dev/explanations/job_commands.md describing command creation/delivery and diagrams.

- Ignore local virtualenv (.venv) in .gitignore.

Tests

-  pytest diracx-routers/tests/jobs/test_heartbeat_commands.py
