### PR TITLE
ci: enforce conventional commit format for PR titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -12,7 +12,7 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v6
         if: ${{ github.actor != 'pre-commit-ci[bot]' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Add a GitHub Actions workflow using `amannn/action-semantic-pull-request@v5` to validate PR titles follow conventional commit format
- This ensures release-please can correctly parse squash-merged commit messages for version bumps and changelog generation
- Bot PRs (pre-commit.ci) are handled by skipping the validation step while still reporting a green check

## Notes

After merging, "Validate PR title" should be added as a required status check in branch protection settings for `main`.