### PR TITLE
ci: pin GitHub Actions by SHA digest via Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
   "minimumReleaseAge": "7 days",
   "packageRules": [
     {


### PR DESCRIPTION
Add the helpers:pinGitHubActionDigests preset to protect against tag-replacement supply-chain attacks on GitHub Actions.