### PR TITLE
refactor: use read() instead of ConfigSource's read_config()

### DIFF
--- a/diracx-cli/src/diracx/cli/internal/config.py
+++ b/diracx-cli/src/diracx/cli/internal/config.py
@@ -35,7 +35,7 @@ def get_repo_path(config_repo_str: str) -> Path:
 
 
 def get_config_from_repo_path(repo_path: Path) -> Config:
-    return ConfigSource.create_from_url(backend_url=repo_path).read_config()
+    return ConfigSource.create_from_url(backend_url=repo_path).read()
 
 
 @app.command()

--- a/diracx-cli/tests/test_internal.py
+++ b/diracx-cli/tests/test_internal.py
@@ -72,7 +72,7 @@ def test_generate_cs(tmp_path, protocol):
 
 
 def test_add_vo(cs_repo):
-    config = ConfigSource.create_from_url(backend_url=cs_repo).read_config()
+    config = ConfigSource.create_from_url(backend_url=cs_repo).read()
 
     assert TEST_VO in config.Registry
     assert config.Registry[TEST_VO].DefaultGroup == "user"
@@ -95,7 +95,7 @@ def test_add_vo(cs_repo):
         ],
     )
 
-    config = ConfigSource.create_from_url(backend_url=cs_repo).read_config()
+    config = ConfigSource.create_from_url(backend_url=cs_repo).read()
     assert result.exit_code == 0, result.output
 
     assert vo2 in config.Registry
@@ -121,7 +121,7 @@ def test_add_vo(cs_repo):
 def test_add_group(cs_repo):
     new_group = "testgroup2"
 
-    config = ConfigSource.create_from_url(backend_url=cs_repo).read_config()
+    config = ConfigSource.create_from_url(backend_url=cs_repo).read()
 
     assert TEST_USER_GROUP in config.Registry[TEST_VO].Groups
     assert config.Registry[TEST_VO].Groups[TEST_USER_GROUP].JobShare == 1000
@@ -143,7 +143,7 @@ def test_add_group(cs_repo):
             "AdminUser",
         ],
     )
-    config = ConfigSource.create_from_url(backend_url=cs_repo).read_config()
+    config = ConfigSource.create_from_url(backend_url=cs_repo).read()
     assert result.exit_code == 0, result.output
 
     assert new_group in config.Registry[TEST_VO].Groups
@@ -190,7 +190,7 @@ def test_add_user(cs_repo, vo, user_group):
     sub = "lhcb:chaen"
     preferred_username = "dontCallMeShirley"
 
-    config = ConfigSource.create_from_url(backend_url=cs_repo).read_config()
+    config = ConfigSource.create_from_url(backend_url=cs_repo).read()
 
     # Check the user isn't in it
     if vo in config.Registry:
@@ -216,7 +216,7 @@ def test_add_user(cs_repo, vo, user_group):
 
     assert result.exit_code == 0, result.output
 
-    config = ConfigSource.create_from_url(backend_url=cs_repo).read_config()
+    config = ConfigSource.create_from_url(backend_url=cs_repo).read()
     # check the user is defined
     assert vo in config.Registry
     assert sub in config.Registry[vo].Users

--- a/diracx-core/src/diracx/core/config/sources.py
+++ b/diracx-core/src/diracx/core/config/sources.py
@@ -171,30 +171,6 @@ class ConfigSource(CacheableSource[Config]):
         url = TypeAdapter(ConfigSourceUrl).validate_python(str(backend_url))
         return cls.__registry[url.scheme](backend_url=url)
 
-    @abstractmethod
-    def read_raw(self, hexsha: str, modified: datetime) -> Config:
-        """Abstract method.
-
-        Return the Config object that corresponds to the specific hash
-        The `modified` parameter is just added as a attribute to the config.
-        """
-
-    def read_config(self) -> Config:
-        """Load the configuration from the backend with appropriate caching.
-
-        :raises: diracx.core.exceptions.NotReadyError if the config is being loaded still
-        :raises: git.exc.BadName if version does not exist
-        """
-        return super().read()
-
-    async def read_config_non_blocking(self) -> Config:
-        """Load the configuration from the backend with appropriate caching.
-
-        :raises: diracx.core.exceptions.NotReadyError if the config is being loaded still
-        :raises: git.exc.BadName if version does not exist
-        """
-        return await super().read_non_blocking()
-
 
 class BaseGitConfigSource(ConfigSource):
     """Base class for the git based config source."""

--- a/diracx-routers/src/diracx/routers/factory.py
+++ b/diracx-routers/src/diracx/routers/factory.py
@@ -152,9 +152,7 @@ def create_app_inner(
 
     # Override the ConfigSource.create by the actual reading of the config
     # Mark it as non-blocking so we can serve 503 errors while waiting for the config
-    app.dependency_overrides[ConfigSource.create] = (
-        config_source.read_config_non_blocking
-    )
+    app.dependency_overrides[ConfigSource.create] = config_source.read_non_blocking
 
     all_access_policies_used = {}
 

--- a/diracx-routers/tests/health/test_probes.py
+++ b/diracx-routers/tests/health/test_probes.py
@@ -21,14 +21,14 @@ async def test_live(client_factory):
         r = await _test_after_clear(config_source, probe_fcn)
         assert r.json() == {"status": "live"}
 
-        old_config = await config_source.read_config_non_blocking()
+        old_config = await config_source.read_non_blocking()
         repo = Repo(config_source.repo_location)
         commit = repo.index.commit("Test commit")
         assert commit.hexsha not in old_config._hexsha
 
         # This will trigger a config update but still return the old config
         config_source._revision_cache.soft_cache.clear()
-        new_config = await config_source.read_config_non_blocking()
+        new_config = await config_source.read_non_blocking()
         assert commit.hexsha not in old_config._hexsha
 
         # If we wait long enough, the new config should be returned
@@ -37,7 +37,7 @@ async def test_live(client_factory):
 
             r = probe_fcn()
             assert r.status_code == 200, r.text
-            new_config = await config_source.read_config_non_blocking()
+            new_config = await config_source.read_non_blocking()
             if commit.hexsha in new_config._hexsha:
                 break
         else:

--- a/diracx-testing/src/diracx/testing/utils.py
+++ b/diracx-testing/src/diracx/testing/utils.py
@@ -206,7 +206,7 @@ class ClientFactory:
             backend_url=f"git+file://{with_config_repo}"
         )
         # Warm the cache to avoid 503 errors
-        config_source.read_config()
+        config_source.read()
 
         self.app = create_app_inner(
             enabled_systems=enabled_systems,


### PR DESCRIPTION
Closes #838. Needs https://github.com/DIRACGrid/diracx-charts/pull/248 to be merged first for compatibility purposes.

- Deletes `ConfigSource.read_config()`, `ConfigSource.read_raw()` and `ConfigSource.read_config_non_blocking()`
- Those are replaced by the new CacheableSource methods `read`, `read_non_blocking`, `read_raw`