### PR TITLE
refactor: simplify defintion of dependencies

### DIFF
--- a/diracx-db/src/diracx/db/sql/utils/base.py
+++ b/diracx-db/src/diracx/db/sql/utils/base.py
@@ -165,6 +165,12 @@ class BaseSQLDB(metaclass=ABCMeta):
 
     @classmethod
     def transaction(cls) -> Self:
+        """Dependency injection sentinel: overridden at startup to yield a DB inside a transaction."""
+        raise NotImplementedError("This should never be called")
+
+    @classmethod
+    def no_transaction(cls) -> Self:
+        """Dependency injection sentinel: overridden at startup to yield a DB without a transaction."""
         raise NotImplementedError("This should never be called")
 
     @property

--- a/diracx-logic/src/diracx/logic/auth/token.py
+++ b/diracx-logic/src/diracx/logic/auth/token.py
@@ -193,7 +193,7 @@ async def get_oidc_token_info_from_refresh_flow(
             # Revoke all the user tokens from the subject
             await auth_db.revoke_user_refresh_tokens(sub)
 
-            # Commit here, otherwise the revokation operation will not be taken into account
+            # Commit here, otherwise the revocation operation will not be taken into account
             # as we return an error to the user
             await auth_db.conn.commit()
 

--- a/diracx-logic/src/diracx/logic/jobs/sandboxes.py
+++ b/diracx-logic/src/diracx/logic/jobs/sandboxes.py
@@ -210,7 +210,7 @@ async def clean_sandboxes(
     3. Deletes from DB
 
     Args:
-        sandbox_metadata_db: Database connection (not yet entered).
+        sandbox_metadata_db: Database connection (not in a transaction).
         settings: Sandbox store settings with S3 client.
 
     Returns:

--- a/diracx-routers/src/diracx/routers/access_policies.py
+++ b/diracx-routers/src/diracx/routers/access_policies.py
@@ -31,7 +31,8 @@ from diracx.core.models.auth import (
     AccessTokenPayload,
     RefreshTokenPayload,
 )
-from diracx.routers.dependencies import DevelopmentSettings
+from diracx.core.settings import DevelopmentSettings
+from diracx.routers.dependencies import auto_inject
 from diracx.routers.utils.users import AuthorizedUserInfo, verify_dirac_access_token
 
 if "annotations" in globals():
@@ -107,6 +108,7 @@ class BaseAccessPolicy(metaclass=ABCMeta):
         return {}, {}
 
 
+@auto_inject
 def check_permissions(
     policy: Callable,
     policy_name: str,

--- a/diracx-routers/src/diracx/routers/auth/authorize_code_flow.py
+++ b/diracx-routers/src/diracx/routers/auth/authorize_code_flow.py
@@ -16,19 +16,17 @@ from fastapi import (
 )
 
 from diracx.core.exceptions import AuthorizationError, IAMClientError, IAMServerError
+from diracx.core.settings import AuthSettings
+from diracx.db.sql import AuthDB
 from diracx.logic.auth.authorize_code_flow import (
     complete_authorization_flow as complete_authorization_flow_bl,
 )
 from diracx.logic.auth.authorize_code_flow import (
     initiate_authorization_flow as initiate_authorization_flow_bl,
 )
+from diracx.routers.dependencies import Config
 
-from ..dependencies import (
-    AuthDB,
-    AuthSettings,
-    AvailableSecurityProperties,
-    Config,
-)
+from ..dependencies import AvailableSecurityProperties
 from ..fastapi_classes import DiracxRouter
 
 logger = logging.getLogger(__name__)

--- a/diracx-routers/src/diracx/routers/auth/device_flow.py
+++ b/diracx-routers/src/diracx/routers/auth/device_flow.py
@@ -18,6 +18,8 @@ from fastapi.responses import RedirectResponse
 
 from diracx.core.exceptions import IAMClientError, IAMServerError
 from diracx.core.models.auth import InitiateDeviceFlowResponse
+from diracx.core.settings import AuthSettings
+from diracx.db.sql import AuthDB
 from diracx.logic.auth.device_flow import do_device_flow as do_device_flow_bl
 from diracx.logic.auth.device_flow import (
     finish_device_flow as finish_device_flow_bl,
@@ -25,13 +27,9 @@ from diracx.logic.auth.device_flow import (
 from diracx.logic.auth.device_flow import (
     initiate_device_flow as initiate_device_flow_bl,
 )
+from diracx.routers.dependencies import Config
 
-from ..dependencies import (
-    AuthDB,
-    AuthSettings,
-    AvailableSecurityProperties,
-    Config,
-)
+from ..dependencies import AvailableSecurityProperties
 from ..fastapi_classes import DiracxRouter
 
 logger = logging.getLogger(__name__)

--- a/diracx-routers/src/diracx/routers/auth/management.py
+++ b/diracx-routers/src/diracx/routers/auth/management.py
@@ -16,6 +16,8 @@ from uuid_utils import UUID
 
 from diracx.core.exceptions import InvalidCredentialsError, TokenNotFoundError
 from diracx.core.properties import PROXY_MANAGEMENT, SecurityProperty
+from diracx.core.settings import AuthSettings
+from diracx.db.sql import AuthDB
 from diracx.logic.auth.management import (
     get_refresh_tokens as get_refresh_tokens_bl,
 )
@@ -26,7 +28,6 @@ from diracx.logic.auth.management import (
     revoke_refresh_token_by_refresh_token as revoke_refresh_token_by_refresh_token_bl,
 )
 
-from ..dependencies import AuthDB, AuthSettings
 from ..fastapi_classes import DiracxRouter
 from ..utils.users import AuthorizedUserInfo, verify_dirac_access_token
 

--- a/diracx-routers/src/diracx/routers/auth/token.py
+++ b/diracx-routers/src/diracx/routers/auth/token.py
@@ -20,14 +20,17 @@ from diracx.core.models.auth import (
     RefreshTokenPayload,
     TokenResponse,
 )
+from diracx.core.settings import AuthSettings
+from diracx.db.sql import AuthDB
 from diracx.logic.auth.token import create_token
 from diracx.logic.auth.token import get_oidc_token as get_oidc_token_bl
 from diracx.logic.auth.token import (
     perform_legacy_exchange as perform_legacy_exchange_bl,
 )
 from diracx.routers.access_policies import BaseAccessPolicy
+from diracx.routers.dependencies import Config
 
-from ..dependencies import AuthDB, AuthSettings, AvailableSecurityProperties, Config
+from ..dependencies import AvailableSecurityProperties
 from ..fastapi_classes import DiracxRouter
 
 router = DiracxRouter(require_auth=False)

--- a/diracx-routers/src/diracx/routers/auth/well_known.py
+++ b/diracx-routers/src/diracx/routers/auth/well_known.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from fastapi import Request
 
 from diracx.core.models.auth import Metadata, OpenIDConfiguration
+from diracx.core.settings import AuthSettings
 from diracx.logic.auth.well_known import (
     get_installation_metadata as get_installation_metadata_bl,
 )
@@ -12,8 +13,8 @@ from diracx.logic.auth.well_known import (
 from diracx.logic.auth.well_known import (
     get_openid_configuration as get_openid_configuration_bl,
 )
+from diracx.routers.dependencies import Config
 
-from ..dependencies import AuthSettings, Config
 from ..fastapi_classes import DiracxRouter
 
 router = DiracxRouter(require_auth=False, path_root="")

--- a/diracx-routers/src/diracx/routers/configuration.py
+++ b/diracx-routers/src/diracx/routers/configuration.py
@@ -11,8 +11,9 @@ from fastapi import (
     status,
 )
 
+from diracx.routers.dependencies import Config
+
 from .access_policies import open_access
-from .dependencies import Config
 from .fastapi_classes import DiracxRouter
 
 logger = logging.getLogger(__name__)

--- a/diracx-routers/src/diracx/routers/dependencies.py
+++ b/diracx-routers/src/diracx/routers/dependencies.py
@@ -1,4 +1,4 @@
-"""Router DI types — re-exported from the canonical definitions in diracx-tasks."""
+"""Router dependency injection types — re-exported from the canonical definitions in diracx-tasks."""
 
 from __future__ import annotations
 

--- a/diracx-routers/src/diracx/routers/factory.py
+++ b/diracx-routers/src/diracx/routers/factory.py
@@ -201,6 +201,9 @@ def create_app_inner(
                 app.dependency_overrides[sql_db_class.transaction] = partial(
                     db_transaction, sql_db
                 )
+                app.dependency_overrides[sql_db_class.no_transaction] = partial(
+                    db_no_transaction, sql_db
+                )
 
             # At least one DB works, so we do not fail the startup
             fail_startup = False
@@ -481,6 +484,11 @@ async def db_transaction(db: T2) -> AsyncGenerator[T2]:
         if reason := await is_db_unavailable(db):
             raise DBUnavailableError(reason)
         yield db
+
+
+async def db_no_transaction(db: T2) -> AsyncGenerator[T2]:
+    """Yield a DB instance without entering a transaction."""
+    yield db
 
 
 class ClientMinVersionCheckMiddleware(BaseHTTPMiddleware):

--- a/diracx-routers/src/diracx/routers/fastapi_classes.py
+++ b/diracx-routers/src/diracx/routers/fastapi_classes.py
@@ -7,6 +7,8 @@ from typing import Any, Callable, TypeVar, cast
 from fastapi import APIRouter, FastAPI
 from starlette.routing import Route
 
+from diracx.tasks.plumbing.depends import auto_inject
+
 T = TypeVar("T")
 
 
@@ -94,6 +96,8 @@ class DiracxRouter(APIRouter):
     # https://github.com/tiangolo/fastapi/discussions/8489
 
     def add_api_route(self, path: str, endpoint: Callable[..., Any], **kwargs):
+        endpoint = auto_inject(endpoint)
+
         route_index = self._get_route_index_by_path_and_methods(
             path, set(kwargs.get("methods", []))
         )

--- a/diracx-routers/src/diracx/routers/health/probes.py
+++ b/diracx-routers/src/diracx/routers/health/probes.py
@@ -9,7 +9,9 @@ import logging
 from fastapi import HTTPException
 from starlette.responses import JSONResponse
 
-from ..dependencies import AuthDB, Config
+from diracx.db.sql import AuthDB
+from diracx.routers.dependencies import Config
+
 from ..fastapi_classes import DiracxRouter
 
 logger = logging.getLogger(__name__)

--- a/diracx-routers/src/diracx/routers/jobs/query.py
+++ b/diracx-routers/src/diracx/routers/jobs/query.py
@@ -10,16 +10,13 @@ from diracx.core.models.search import (
     SummaryParams,
 )
 from diracx.core.properties import JOB_ADMINISTRATOR
+from diracx.db.os import JobParametersDB
+from diracx.db.sql import JobDB, JobLoggingDB
 from diracx.logic.jobs.query import MAX_PER_PAGE
 from diracx.logic.jobs.query import search as search_bl
 from diracx.logic.jobs.query import summary as summary_bl
+from diracx.routers.dependencies import Config
 
-from ..dependencies import (
-    Config,
-    JobDB,
-    JobLoggingDB,
-    JobParametersDB,
-)
 from ..fastapi_classes import DiracxRouter
 from ..utils.users import AuthorizedUserInfo, verify_dirac_access_token
 from .access_policies import ActionType, CheckWMSPolicyCallable

--- a/diracx-routers/src/diracx/routers/jobs/sandboxes.py
+++ b/diracx-routers/src/diracx/routers/jobs/sandboxes.py
@@ -11,6 +11,8 @@ from diracx.core.models.sandbox import (
     SandboxInfo,
     SandboxUploadResponse,
 )
+from diracx.core.settings import SandboxStoreSettings
+from diracx.db.sql import JobDB, SandboxMetadataDB
 from diracx.logic.jobs.sandboxes import SANDBOX_PFN_REGEX
 from diracx.logic.jobs.sandboxes import (
     assign_sandbox_to_job as assign_sandbox_to_job_bl,
@@ -25,7 +27,6 @@ from diracx.logic.jobs.sandboxes import (
     unassign_jobs_sandboxes as unassign_jobs_sandboxes_bl,
 )
 
-from ..dependencies import JobDB, SandboxMetadataDB, SandboxStoreSettings
 from ..fastapi_classes import DiracxRouter
 from ..utils.users import AuthorizedUserInfo, verify_dirac_access_token
 from .access_policies import (

--- a/diracx-routers/src/diracx/routers/jobs/status.py
+++ b/diracx-routers/src/diracx/routers/jobs/status.py
@@ -13,6 +13,8 @@ from diracx.core.models.job import (
     JobStatusUpdate,
     SetJobStatusReturn,
 )
+from diracx.db.os import JobParametersDB
+from diracx.db.sql import JobDB, JobLoggingDB, TaskQueueDB
 from diracx.logic.jobs.status import add_heartbeat as add_heartbeat_bl
 from diracx.logic.jobs.status import get_job_commands as get_job_commands_bl
 from diracx.logic.jobs.status import reschedule_jobs as reschedule_jobs_bl
@@ -20,14 +22,8 @@ from diracx.logic.jobs.status import (
     set_job_parameters_or_attributes as set_job_parameters_or_attributes_bl,
 )
 from diracx.logic.jobs.status import set_job_statuses as set_job_statuses_bl
+from diracx.routers.dependencies import Config
 
-from ..dependencies import (
-    Config,
-    JobDB,
-    JobLoggingDB,
-    JobParametersDB,
-    TaskQueueDB,
-)
 from ..fastapi_classes import DiracxRouter
 from .access_policies import ActionType, CheckWMSPolicyCallable
 

--- a/diracx-routers/src/diracx/routers/jobs/submission.py
+++ b/diracx-routers/src/diracx/routers/jobs/submission.py
@@ -7,13 +7,10 @@ from fastapi import Body, Depends, HTTPException
 from pydantic import BaseModel
 
 from diracx.core.models.job import InsertedJob
+from diracx.db.sql import JobDB, JobLoggingDB
 from diracx.logic.jobs.submission import submit_jdl_jobs as submit_jdl_jobs_bl
+from diracx.routers.dependencies import Config
 
-from ..dependencies import (
-    Config,
-    JobDB,
-    JobLoggingDB,
-)
 from ..fastapi_classes import DiracxRouter
 from ..utils.users import AuthorizedUserInfo, verify_dirac_access_token
 from .access_policies import ActionType, CheckWMSPolicyCallable

--- a/diracx-routers/src/diracx/routers/utils/users.py
+++ b/diracx-routers/src/diracx/routers/utils/users.py
@@ -15,8 +15,9 @@ from uuid_utils import UUID as _UUID
 
 from diracx.core.models.auth import UserInfo
 from diracx.core.properties import SecurityProperty
+from diracx.core.settings import AuthSettings
 from diracx.logic.auth.utils import read_token
-from diracx.routers.dependencies import AuthSettings
+from diracx.routers.dependencies import auto_inject
 
 logger = logging.getLogger(__name__)
 
@@ -71,6 +72,7 @@ class AuthorizedUserInfo(AuthInfo, UserInfo):
     pass
 
 
+@auto_inject
 async def verify_dirac_access_token(
     authorization: Annotated[str, Depends(oidc_scheme)],
     settings: AuthSettings,

--- a/diracx-tasks/src/diracx/tasks/plumbing/depends.py
+++ b/diracx-tasks/src/diracx/tasks/plumbing/depends.py
@@ -1,52 +1,42 @@
-"""Canonical dependency injection type definitions for tasks.
+"""Canonical dependency injection type definitions.
 
-These are the same Annotated types used in ``diracx.routers.dependencies``
-but defined here so that the task worker can resolve them without importing
-the router machinery.
+``diracx.routers.dependencies`` re-exports from this module so that both
+routers and the task worker resolve the same names.
 
-``diracx.routers.dependencies`` should re-export from this module.
+DB classes, OS DB classes, and ``ServiceSettingsBase`` subclasses are
+**auto-detected** by ``auto_inject_depends``:
+
+- In tasks: called by ``wrap_task``
+- In routers: called by ``DiracxRouter.add_api_route``
+- In sub-dependency functions: applied via the ``@auto_inject`` decorator
 """
 
 from __future__ import annotations
 
 __all__ = (
     "Config",
-    "AuthDB",
-    "JobDB",
-    "JobLoggingDB",
-    "SandboxMetadataDB",
-    "TaskQueueDB",
-    "PilotAgentsDB",
-    "JobParametersDB",
-    "DBDepends",
-    "add_settings_annotation",
+    "NoTransaction",
+    "auto_inject",
+    "auto_inject_depends",
     "AvailableSecurityProperties",
-    "AuthSettings",
-    "DevelopmentSettings",
-    "SandboxStoreSettings",
     "CallbackSpawner",
     "_CallbackSpawner",
     "_callback_spawner_placeholder",
 )
 
-from functools import partial
-from typing import TYPE_CHECKING, Annotated, TypeVar
+import dataclasses
+from inspect import Parameter, signature
+from typing import TYPE_CHECKING, Annotated, TypeVar, get_args, get_origin
 
 from fastapi import Depends
+from fastapi.params import Depends as DependsClass
 
 from diracx.core.config import Config as _Config
 from diracx.core.config import ConfigSource
 from diracx.core.properties import SecurityProperty
-from diracx.core.settings import AuthSettings as _AuthSettings
-from diracx.core.settings import DevelopmentSettings as _DevelopmentSettings
-from diracx.core.settings import SandboxStoreSettings as _SandboxStoreSettings
-from diracx.db.os import JobParametersDB as _JobParametersDB
-from diracx.db.sql import AuthDB as _AuthDB
-from diracx.db.sql import JobDB as _JobDB
-from diracx.db.sql import JobLoggingDB as _JobLoggingDB
-from diracx.db.sql import PilotAgentsDB as _PilotAgentsDB
-from diracx.db.sql import SandboxMetadataDB as _SandboxMetadataDB
-from diracx.db.sql import TaskQueueDB as _TaskQueueDB
+from diracx.core.settings import ServiceSettingsBase
+from diracx.db.os.utils import BaseOSDB
+from diracx.db.sql.utils import BaseSQLDB
 
 from ._redis_types import CallbackRegistry
 
@@ -55,42 +45,120 @@ if TYPE_CHECKING:
 
 T = TypeVar("T")
 
-# Use scope="function" to ensure DB commits happen before sending HTTP responses
-# This prevents race conditions when DIRAC immediately queries data after DiracX writes it
-DBDepends = partial(Depends, scope="function")
+
+@dataclasses.dataclass(frozen=True)
+class NoTransaction:
+    """Annotated marker: inject DB without auto-wrapping in a transaction.
+
+    Usage::
+
+        async def execute(
+            self,
+            db: Annotated[SandboxMetadataDB, NoTransaction()],
+        ) -> int:
+            async with db:  # caller manages transactions
+                ...
+    """
 
 
-def add_settings_annotation(cls: T) -> T:
-    """Add a ``Depends`` annotation to a class that has a ``create`` classmethod."""
-    return Annotated[cls, Depends(cls.create)]  # type: ignore[return-value, attr-defined]
+def auto_inject_depends(params: list[Parameter]) -> list[Parameter]:
+    """Auto-wrap DB and Settings parameters with ``Depends``.
+
+    Detects:
+    - ``BaseSQLDB`` subclasses -> ``Depends(cls.transaction, scope="function")``
+      (or ``cls.no_transaction`` when ``NoTransaction()`` marker is present)
+    - ``BaseOSDB`` subclasses -> ``Depends(cls.session, scope="function")``
+    - ``ServiceSettingsBase`` subclasses -> ``Depends(cls.create)``
+    Already-wrapped ``Annotated[..., Depends(...)]`` types pass through
+    unchanged.  Combining ``NoTransaction()`` with an explicit ``Depends``
+    raises ``TypeError`` — use one or the other, not both.
+    """
+    result = []
+    for p in params:
+        annotation = p.annotation
+        if annotation is Parameter.empty:
+            result.append(p)
+            continue
+
+        base_type = annotation
+        no_tx = False
+        has_depends = False
+
+        if get_origin(annotation) is Annotated:
+            args = get_args(annotation)
+            base_type = args[0]
+            no_tx = any(isinstance(a, NoTransaction) for a in args[1:])
+            has_depends = any(isinstance(a, DependsClass) for a in args[1:])
+
+        if not isinstance(base_type, type):
+            result.append(p)
+            continue
+
+        if issubclass(base_type, BaseSQLDB):
+            if has_depends and no_tx:
+                raise TypeError(
+                    f"Parameter {p.name!r}: NoTransaction() cannot be combined "
+                    f"with an explicit Depends() annotation"
+                )
+            if has_depends:
+                result.append(p)
+            else:
+                dep = base_type.no_transaction if no_tx else base_type.transaction
+                result.append(
+                    p.replace(
+                        annotation=Annotated[base_type, Depends(dep, scope="function")]
+                    )
+                )
+        elif issubclass(base_type, BaseOSDB):
+            if no_tx:
+                raise TypeError(
+                    f"Parameter {p.name!r}: NoTransaction() is not supported "
+                    f"for BaseOSDB subclasses (they have no transaction semantics)"
+                )
+            if has_depends:
+                result.append(p)
+            else:
+                result.append(
+                    p.replace(
+                        annotation=Annotated[
+                            base_type,
+                            Depends(base_type.session, scope="function"),
+                        ]
+                    )
+                )
+        elif issubclass(base_type, ServiceSettingsBase):
+            if has_depends:
+                result.append(p)
+            else:
+                result.append(
+                    p.replace(
+                        annotation=Annotated[base_type, Depends(base_type.create)]
+                    )
+                )
+        else:
+            result.append(p)
+
+    return result
 
 
-# Databases
-AuthDB = Annotated[_AuthDB, DBDepends(_AuthDB.transaction)]
-JobDB = Annotated[_JobDB, DBDepends(_JobDB.transaction)]
-JobLoggingDB = Annotated[_JobLoggingDB, DBDepends(_JobLoggingDB.transaction)]
-PilotAgentsDB = Annotated[_PilotAgentsDB, DBDepends(_PilotAgentsDB.transaction)]
-SandboxMetadataDB = Annotated[
-    _SandboxMetadataDB, DBDepends(_SandboxMetadataDB.transaction)
-]
-TaskQueueDB = Annotated[_TaskQueueDB, DBDepends(_TaskQueueDB.transaction)]
+def auto_inject(func):
+    """Adjust annotations to auto-inject ``Depends`` for DB and Settings parameters.
 
-# Opensearch databases
-JobParametersDB = Annotated[_JobParametersDB, DBDepends(_JobParametersDB.session)]
+    Apply to functions used as FastAPI sub-dependencies that take
+    DB or Settings classes as parameters.
+    """
+    sig = signature(func, eval_str=True)
+    for p in auto_inject_depends(list(sig.parameters.values())):
+        if p.annotation is not Parameter.empty:
+            func.__annotations__[p.name] = p.annotation
+    return func
 
 
-# Miscellaneous
+# --- Types that cannot be auto-detected (no common base class pattern) ---
+
 Config = Annotated[_Config, Depends(ConfigSource.create)]
 AvailableSecurityProperties = Annotated[
     set[SecurityProperty], Depends(SecurityProperty.available_properties)
-]
-
-AuthSettings = Annotated[_AuthSettings, Depends(_AuthSettings.create)]
-DevelopmentSettings = Annotated[
-    _DevelopmentSettings, Depends(_DevelopmentSettings.create)
-]
-SandboxStoreSettings = Annotated[
-    _SandboxStoreSettings, Depends(_SandboxStoreSettings.create)
 ]
 
 

--- a/diracx-tasks/src/diracx/tasks/plumbing/factory.py
+++ b/diracx-tasks/src/diracx/tasks/plumbing/factory.py
@@ -27,6 +27,7 @@ from diracx.core.extensions import select_from_extension
 from ._redis_types import LockCoordinator
 from .base_task import BaseTask
 from .broker.models import TaskBinding
+from .depends import auto_inject_depends
 from .locks import BaseLimiter, BaseLock
 
 T = TypeVar("T")
@@ -146,6 +147,7 @@ def wrap_task(cls: type[BaseTask]) -> Callable[..., Any]:
         for p in execute_params
         if p.kind not in (Parameter.VAR_KEYWORD, Parameter.VAR_POSITIONAL)
     ]
+    execute_params = auto_inject_depends(execute_params)
 
     parameters = [
         Parameter("args", Parameter.POSITIONAL_ONLY, default=()),
@@ -272,6 +274,11 @@ async def _db_context(db: _T_DB) -> AsyncIterator[_T_DB]:
         yield db
 
 
+async def _db_no_transaction(db: _T_DB) -> AsyncIterator[_T_DB]:
+    """Yield a DB instance without entering a transaction."""
+    yield db
+
+
 @asynccontextmanager
 async def setup_dependency_overrides(
     task_dependants: Iterable[Dependant] = (),
@@ -297,6 +304,9 @@ async def setup_dependency_overrides(
             await stack.enter_async_context(sql_db.engine_context())
             for sql_db_class in sql_db_classes:
                 overrides[sql_db_class.transaction] = partial(_db_context, sql_db)
+                overrides[sql_db_class.no_transaction] = partial(
+                    _db_no_transaction, sql_db
+                )
 
         # --- OS databases ---
         for db_name, conn_kwargs in BaseOSDB.available_urls().items():

--- a/diracx-testing/src/diracx/testing/utils.py
+++ b/diracx-testing/src/diracx/testing/utils.py
@@ -239,7 +239,7 @@ class ClientFactory:
         self.app.lifetime_functions = []
         for obj in self.all_lifetime_functions:
             assert isinstance(
-                obj.__self__, (ServiceSettingsBase, BaseSQLDB, BaseOSDB, ConfigSource)
+                obj.__self__, (ServiceSettingsBase, BaseSQLDB, BaseOSDB)
             ), obj
 
     @contextlib.contextmanager
@@ -284,9 +284,10 @@ class ClientFactory:
         from diracx.testing.mock_osdb import MockOSDBMixin
 
         for k, v in self.app.dependency_overrides.items():
-            # Ignore dependency overrides which aren't BaseSQLDB.transaction or BaseOSDB.session
+            # Ignore dependency overrides which aren't BaseSQLDB.transaction/no_transaction or BaseOSDB.session
             if isinstance(v, UnavailableDependency) or k.__func__ not in (
                 BaseSQLDB.transaction.__func__,
+                BaseSQLDB.no_transaction.__func__,
                 BaseOSDB.session.__func__,
             ):
                 continue

--- a/docs/adr/DX-ADR-001_tasks.md
+++ b/docs/adr/DX-ADR-001_tasks.md
@@ -84,10 +84,12 @@ class AnotherExampleTask(BaseTask, BaseModel):
 #### Dependency Injection
 
 Subclasses of `BaseTask` can define additional arguments which are passed at task-execution time in a similar way to FastAPI's dependency injection system used in `diracx-routers`.
-These are defined as arguments to `BaseTask.execute` and are expected to be type annotated with a class which is registered in the dependency injection system.
+These are defined as arguments to `BaseTask.execute` and are expected to be type annotated with a DB class or settings class.
+The `auto_inject_depends` function in `diracx.tasks.plumbing.depends` automatically detects `BaseSQLDB` subclasses, `BaseOSDB` subclasses, and `ServiceSettingsBase` subclasses and wraps them with the appropriate `Depends` annotation.
 
 ```python
-from diracx.tasks.depends import AuthSettings, JobDB
+from diracx.core.settings import AuthSettings
+from diracx.db.sql import JobDB
 
 
 class ExampleTask(BaseTask):
@@ -96,7 +98,11 @@ class ExampleTask(BaseTask):
         pass
 ```
 
-The classes which have been annotated for dependency injection are re-exported in `diracx.routers.depends`.
+This auto-detection is applied in three places:
+
+- In tasks: called by `wrap_task` in `diracx.tasks.plumbing.factory`
+- In routers: called by `DiracxRouter.add_api_route`
+- In sub-dependency functions: applied via the `@auto_inject` decorator
 
 #### Locking
 
@@ -387,7 +393,9 @@ The three size classes (`SMALL`, `MEDIUM`, `LARGE`) exist to allow independent w
 
 ### Dependency Injection
 
-`diracx.routers.depends` re-exports `diracx.tasks.depends` due to the following reasoning:
+DB classes, OS DB classes, and `ServiceSettingsBase` subclasses are auto-detected by `auto_inject_depends` in `diracx.tasks.plumbing.depends`. This means route handlers, task `execute()` methods, and sub-dependency functions can simply type-annotate their parameters with the bare class (e.g. `job_db: JobDB`) and the framework wraps them with the appropriate `Depends` call automatically.
+
+`diracx.routers.dependencies` re-exports from `diracx.tasks.plumbing.depends` due to the following reasoning:
 
 - We don't want `diracx-logic`/`diracx-db` to depend on `fastapi`
 - `diracx-tasks` shouldn't depend on `diracx-routers`

--- a/docs/dev/explanations/components/routes.md
+++ b/docs/dev/explanations/components/routes.md
@@ -40,12 +40,11 @@ DiracX extensively utilizes FastAPI's dependency injection. For detailed informa
 
 ### Settings
 
-- **Settings classes** are Pydantic models that load service configuration from the environment and are wrapped with `add_settings_annotation` for FastAPI to handle them.
+- **Settings classes** are Pydantic models that load service configuration from the environment. Subclasses of `ServiceSettingsBase` are auto-detected by the dependency injection system — simply use the class as a type annotation and it will be wrapped with `Depends(cls.create)` automatically.
 
 Example:
 
 ```python
-@add_settings_annotation
 class AuthSettings(ServiceSettingsBase):
     """Settings for the authentication service."""
 
@@ -67,6 +66,9 @@ Available environment variables:
 Usage example:
 
 ```python
+from diracx.core.settings import AuthSettings
+
+
 @router.get("/openid-configuration")
 async def get_openid_configuration(settings: AuthSettings):
     ...
@@ -106,12 +108,12 @@ The `Config` object is cached efficiently between requests and automatically ref
 
 ### SQL Databases
 
-To depend on a SQL-backed database, use the classes in `diracx.routers.dependencies`. The connection is managed through a central pool, with transactions opened for the duration of a request. Successful requests commit the transaction, while requests with HTTP status code `>=400` roll back the transaction. Connections are returned to the pool for reuse.
+To depend on a SQL-backed database, import the DB class directly from its package. The dependency injection system auto-detects `BaseSQLDB` subclasses and wraps them with `Depends(cls.transaction, scope="function")`. The connection is managed through a central pool, with transactions opened for the duration of a request. Successful requests commit the transaction, while requests with HTTP status code `>=400` roll back the transaction. Connections are returned to the pool for reuse.
 
 Example:
 
 ```python
-from diracx.routers.dependencies import JobDB, JobLoggingDB
+from diracx.db.sql import JobDB, JobLoggingDB
 
 
 @router.delete("/{job_id}")
@@ -122,7 +124,7 @@ async def delete_single_job(job_db: JobDB, job_logging_db: JobLoggingDB):
 There are advanced and uncommon scenarios where committing a transaction is necessary even when returning an error response (e.g., revoking tokens in the database and returning an error to a potentially malicious user). In such cases, explicitly committing the transaction before raising an exception is crucial. Without this explicit commit, the intended changes would be rolled back along with the transaction, leading to unintended consequences:
 
 ```python
-from diracx.routers.dependencies import AuthDB
+from diracx.db.sql import AuthDB
 
 
 @router.post("/token")
@@ -143,12 +145,12 @@ Refer to the [SQLAlchemy documentation](https://docs.sqlalchemy.org/en/20/core/p
 
 ### OpenSearch Databases
 
-Connecting to an OpenSearch database is similar to an SQL database, with connections being pooled automatically. However, there is no automatic transaction/rollback behavior.
+Connecting to an OpenSearch database is similar to an SQL database, with connections being pooled automatically. `BaseOSDB` subclasses are auto-detected and wrapped with `Depends(cls.session, scope="function")`. There is no automatic transaction/rollback behavior.
 
 Example:
 
 ```python
-from diracx.routers.dependencies import JobParametersDB
+from diracx.db.os import JobParametersDB
 
 
 @router.post("/search", responses=EXAMPLE_RESPONSES)

--- a/docs/dev/explanations/tasks/index.md
+++ b/docs/dev/explanations/tasks/index.md
@@ -141,7 +141,7 @@ The framework lives in `diracx-tasks` under `diracx.tasks.plumbing`. Domain-spec
 | `plumbing/persistence/dlq.py`      | `TaskDB` — SQL-backed dead-letter queue for tasks marked `dlq_eligible`                                 |
 | `plumbing/base_task.py`            | `BaseTask`, `PeriodicBaseTask`, `PeriodicVoAwareBaseTask` base classes                                  |
 | `plumbing/lock_registry.py`        | `LockedObjectType` registry and `register_locked_object_type()`                                         |
-| `plumbing/depends.py`              | Dependency injection type annotations shared between tasks and routers                                  |
+| `plumbing/depends.py`              | Auto-detection of DB/Settings dependencies (`auto_inject_depends`) shared between tasks and routers     |
 
 ### Environment variables
 
@@ -167,6 +167,6 @@ Extensions define tasks in their own packages and register them via entry points
 
 - **Tasks** are registered under `diracx.tasks.<category>` (e.g. `diracx.tasks.lollygag`).
 - **Custom lock types** are registered under `diracx.lock_object_types` by calling `register_locked_object_type()` at module level.
-- **Dependency injection types** for new databases are defined in a `depends.py` using `DBDepends` from `diracx.tasks.plumbing.depends`.
+- **Dependency injection** for databases and settings is handled automatically — `auto_inject_depends` in `diracx.tasks.plumbing.depends` detects `BaseSQLDB`, `BaseOSDB`, and `ServiceSettingsBase` subclasses and wraps them with the appropriate `Depends` annotation. Task code should import DB classes directly from their defining packages (e.g. `from gubbins.db.sql import LollygagDB`).
 
 See the [how-to guide](../../how-to/add-a-task.md) for a step-by-step walkthrough.

--- a/docs/dev/how-to/add-a-task.md
+++ b/docs/dev/how-to/add-a-task.md
@@ -12,7 +12,7 @@ from diracx.tasks.plumbing.base_task import BaseTask
 from diracx.tasks.plumbing.enums import Priority, Size
 from diracx.tasks.plumbing.retry_policies import ExponentialBackoff
 
-from .depends import LollygagDB
+from gubbins.db.sql import LollygagDB
 
 
 @dataclasses.dataclass
@@ -44,20 +44,6 @@ Add the task to a `diracx.tasks.<category>` entry point group in your package's 
 [project.entry-points."diracx.tasks.lollygag"]
 SyncOwnersTask = "gubbins.tasks.lollygag:SyncOwnersTask"
 ```
-
-### Add dependency injection types
-
-If the task depends on a database that doesn't already have a dependency injection annotation, add one in a `depends.py` module:
-
-```python
-from typing import Annotated
-from diracx.tasks.plumbing.depends import DBDepends
-from gubbins.db.sql import LollygagDB as _LollygagDB
-
-LollygagDB = Annotated[_LollygagDB, DBDepends(_LollygagDB.transaction)]
-```
-
-The `DBDepends` helper wraps the database class so the worker can resolve it at execution time, matching the same pattern used in `diracx.routers`.
 
 ### Custom locks
 

--- a/docs/dev/reference/dependency-injection.md
+++ b/docs/dev/reference/dependency-injection.md
@@ -1,17 +1,21 @@
 # Dependency injection
 
-DiracX uses [FastAPI's dependency injection system](https://fastapi.tiangolo.com/tutorial/dependencies/) to provide dependencies to API route handlers. Dependencies are injected as function parameters using Python's `Annotated` type hints.
+DiracX uses [FastAPI's dependency injection system](https://fastapi.tiangolo.com/tutorial/dependencies/) to provide dependencies to API route handlers. Dependencies are injected as function parameters using Python's type hints.
+
+DB classes, OS DB classes, and `ServiceSettingsBase` subclasses are **auto-detected** by `auto_inject_depends` in `diracx.tasks.plumbing.depends`. This means you can simply type-annotate parameters with the bare class and the framework wraps them with the appropriate `Depends` call automatically. This auto-detection is applied:
+
+- In routers: by `DiracxRouter.add_api_route`
+- In tasks: by `wrap_task` in `diracx.tasks.plumbing.factory`
+- In sub-dependency functions: via the `@auto_inject` decorator
 
 ## Available dependencies
 
-DiracX provides several types of dependencies that can be injected into route handlers:
-
 ### Database connections
 
-Database connections are automatically managed through dependency injection with automatic transaction handling:
+Database connections are automatically managed through dependency injection with automatic transaction handling. Import DB classes directly from their defining packages:
 
 ```python
-from diracx.routers.dependencies import JobDB, AuthDB, JobLoggingDB
+from diracx.db.sql import JobDB, JobLoggingDB
 
 
 @router.get("/jobs/{job_id}")
@@ -27,15 +31,15 @@ async def get_job(
 
 Available database dependencies:
 
-| Dependency          | Underlying Class                  | Description                          |
-| ------------------- | --------------------------------- | ------------------------------------ |
-| `JobDB`             | `diracx.db.sql.JobDB`             | Job management database              |
-| `AuthDB`            | `diracx.db.sql.AuthDB`            | Authentication database              |
-| `JobLoggingDB`      | `diracx.db.sql.JobLoggingDB`      | Job logging database                 |
-| `PilotAgentsDB`     | `diracx.db.sql.PilotAgentsDB`     | Pilot agents database                |
-| `SandboxMetadataDB` | `diracx.db.sql.SandboxMetadataDB` | Sandbox metadata database            |
-| `TaskQueueDB`       | `diracx.db.sql.TaskQueueDB`       | Task queue database                  |
-| `JobParametersDB`   | `diracx.db.os.JobParametersDB`    | Job parameters (OpenSearch) database |
+| Class               | Package         | Description                          |
+| ------------------- | --------------- | ------------------------------------ |
+| `JobDB`             | `diracx.db.sql` | Job management database              |
+| `AuthDB`            | `diracx.db.sql` | Authentication database              |
+| `JobLoggingDB`      | `diracx.db.sql` | Job logging database                 |
+| `PilotAgentsDB`     | `diracx.db.sql` | Pilot agents database                |
+| `SandboxMetadataDB` | `diracx.db.sql` | Sandbox metadata database            |
+| `TaskQueueDB`       | `diracx.db.sql` | Task queue database                  |
+| `JobParametersDB`   | `diracx.db.os`  | Job parameters (OpenSearch) database |
 
 #### Connection Pool Management
 
@@ -67,19 +71,20 @@ SQL database connections have automatic transaction handling:
 - **Failed requests** (HTTP status >= 400) automatically roll back the transaction
 - **Connections** are returned to the pool for reuse
 
-Each database dependency is defined as:
+The auto-detection applies the following rules:
 
 ```python
-# SQL databases use .transaction() for automatic transaction handling
-JobDB = Annotated[_JobDB, Depends(_JobDB.transaction)]
-
-# OpenSearch databases use .session() (no automatic transactions)
-JobParametersDB = Annotated[_JobParametersDB, Depends(_JobParametersDB.session)]
+# SQL databases -> Depends(cls.transaction, scope="function")
+# OpenSearch databases -> Depends(cls.session, scope="function")
+# Settings classes -> Depends(cls.create)
 ```
 
 For advanced scenarios requiring explicit transaction commits (e.g., revoking tokens before returning an error):
 
 ```python
+from diracx.db.sql import AuthDB
+
+
 @router.post("/token")
 async def token(auth_db: AuthDB):
     if refresh_token_attributes["status"] == RefreshTokenStatus.REVOKED:
@@ -93,14 +98,32 @@ async def token(auth_db: AuthDB):
         raise HTTPException(status_code=401)
 ```
 
+For cases where a database connection is needed without a transaction (e.g., a task that manages its own transactions in batches), use the `NoTransaction` marker:
+
+```python
+from typing import Annotated
+
+from diracx.db.sql import SandboxMetadataDB
+from diracx.tasks.plumbing.depends import NoTransaction
+
+
+async def execute(
+    self,
+    sandbox_metadata_db: Annotated[SandboxMetadataDB, NoTransaction()],
+) -> int:
+    # Caller manages transactions manually
+    ...
+```
+
 For more details on the underlying database classes, see the [Database Components](../explanations/components/db.md) documentation.
 
 ### Configuration and settings
 
-Configuration and application settings are injected using dedicated dependencies:
+Configuration and application settings are injected using dedicated dependencies. Settings classes that inherit from `ServiceSettingsBase` are auto-detected. `Config` must be imported from `diracx.routers.dependencies`:
 
 ```python
-from diracx.routers.dependencies import Config, AuthSettings
+from diracx.core.settings import AuthSettings
+from diracx.routers.dependencies import Config
 
 
 @router.get("/config-info")
@@ -116,22 +139,14 @@ async def get_config_info(
 
 Available configuration dependencies:
 
-| Dependency             | Underlying Class                            | Description                   |
-| ---------------------- | ------------------------------------------- | ----------------------------- |
-| `Config`               | `diracx.core.config.Config`                 | DiracX configuration          |
-| `AuthSettings`         | `diracx.core.settings.AuthSettings`         | Authentication settings       |
-| `DevelopmentSettings`  | `diracx.core.settings.DevelopmentSettings`  | Development-specific settings |
-| `SandboxStoreSettings` | `diracx.core.settings.SandboxStoreSettings` | Sandbox storage settings      |
+| Class                  | Package                       | Description                   |
+| ---------------------- | ----------------------------- | ----------------------------- |
+| `Config`               | `diracx.routers.dependencies` | DiracX configuration          |
+| `AuthSettings`         | `diracx.core.settings`        | Authentication settings       |
+| `DevelopmentSettings`  | `diracx.core.settings`        | Development-specific settings |
+| `SandboxStoreSettings` | `diracx.core.settings`        | Sandbox storage settings      |
 
-Each configuration dependency is defined as:
-
-```python
-# Configuration uses ConfigSource.create
-Config = Annotated[_Config, Depends(ConfigSource.create)]
-
-# Settings use the .create() class method
-AuthSettings = Annotated[_AuthSettings, Depends(_AuthSettings.create)]
-```
+`Config` is special because it doesn't inherit from `ServiceSettingsBase` and uses `ConfigSource.create` as its dependency factory. It is the only dependency that requires importing a pre-wrapped `Annotated` type.
 
 For more details on configuration and settings classes, see the [Configuration](configuration.md) documentation.
 
@@ -182,6 +197,7 @@ async def get_properties(
 Access policies provide fine-grained authorization control:
 
 ```python
+from diracx.db.sql import JobDB
 from diracx.routers.jobs.access_policies import CheckWMSPolicyCallable, ActionType
 
 
@@ -201,10 +217,9 @@ async def create_job(
 
 ### Settings dependencies
 
-For custom settings classes that inherit from `BaseSettings`, use the `add_settings_annotation` helper from `diracx.routers.dependencies`:
+Custom settings classes that inherit from `ServiceSettingsBase` are auto-detected. Simply define the class and use it as a type annotation:
 
 ```python
-from diracx.routers.dependencies import add_settings_annotation
 from diracx.core.settings import ServiceSettingsBase
 
 
@@ -216,25 +231,22 @@ class MyCustomSettings(ServiceSettingsBase):
         return cls()
 
 
-# Create the dependency
-MySettings = add_settings_annotation(MyCustomSettings)
-
-
 @router.get("/my-endpoint")
-async def my_endpoint(settings: MySettings) -> dict:
+async def my_endpoint(settings: MyCustomSettings) -> dict:
     return {"custom_option": settings.custom_option}
 ```
 
 ### Database dependencies
 
-Database dependencies follow the pattern of using the `.transaction()` class method:
+Database dependencies are also auto-detected. Any `BaseSQLDB` subclass used as a type annotation will automatically get wrapped with `Depends(cls.transaction, scope="function")`:
 
 ```python
-from typing import Annotated
-from fastapi import Depends
+from my_extension.db.sql import MyCustomDB
 
-# Database classes should have a .transaction() class method
-MyCustomDB = Annotated[MyCustomDBClass, Depends(MyCustomDBClass.transaction)]
+
+@router.get("/my-data")
+async def get_data(db: MyCustomDB) -> dict:
+    ...
 ```
 
 ## Complete example
@@ -242,9 +254,9 @@ MyCustomDB = Annotated[MyCustomDBClass, Depends(MyCustomDBClass.transaction)]
 Here's a complete example showing multiple dependency types:
 
 ```python
-from typing import Annotated
-from fastapi import Depends
-from diracx.routers.dependencies import Config, JobDB, AuthSettings
+from diracx.core.settings import AuthSettings
+from diracx.db.sql import JobDB
+from diracx.routers.dependencies import Config
 from diracx.routers.utils.users import AuthorizedUserInfo, verify_dirac_access_token
 from diracx.routers.auth.utils import has_properties
 from diracx.core.properties import NORMAL_USER

--- a/docs/dev/tutorials/advanced-tutorial/database.md
+++ b/docs/dev/tutorials/advanced-tutorial/database.md
@@ -84,12 +84,11 @@ covers the broader architecture.
 
 Create an empty `my_pilot_db/__init__.py` file in the same directory.
 
-## Register the entry point, export, and dependency
+## Register the entry point and export
 
-The next three steps connect your database to the rest of DiracX. Each
-step serves a different purpose in the registration pipeline.
+The next two steps connect your database to the rest of DiracX.
 
-!!! note "Why three registration steps?"
+!!! note "Why two registration steps?"
 
     1. **Entry point** (in `pyproject.toml`) — Tells DiracX's plugin
         system that this DB exists. The entry point name becomes the DB's
@@ -97,9 +96,10 @@ step serves a different purpose in the registration pipeline.
     2. **Package export** (in `__init__.py`) — Makes the DB class
         importable from the top-level package so other code (routers,
         tasks) can reference it.
-    3. **Dependency injection** (in `depends.py`) — Creates an
-        `Annotated` type that FastAPI and the task worker can resolve
-        automatically, wrapping the DB in a transaction context.
+
+    Dependency injection is handled automatically — `auto_inject_depends`
+    detects `BaseSQLDB` subclasses and wraps them with the appropriate
+    `Depends` annotation. No manual `Annotated` wrapper is needed.
 
     See [Entrypoints](../../reference/entrypoints.md) and
     [Dependency injection](../../reference/dependency-injection.md)
@@ -122,20 +122,6 @@ Add under `[project.entry-points."diracx.dbs.sql"]`:
 ```
 
 <!-- blacken-docs:on -->
-
-### Dependency injection
-
-<!-- blacken-docs:off -->
-
-```python title="gubbins-tasks/src/gubbins/tasks/depends.py"
---8<-- "extensions/gubbins/gubbins-tasks/src/gubbins/tasks/depends.py:my_pilots_depends"
-```
-
-<!-- blacken-docs:on -->
-
-The `DBDepends` wrapper ensures the transaction commits before the HTTP
-response is sent. When used in task code, the same type annotation lets
-the task worker inject a database connection automatically.
 
 ### Helm chart
 

--- a/docs/dev/tutorials/advanced-tutorial/logic.md
+++ b/docs/dev/tutorials/advanced-tutorial/logic.md
@@ -49,9 +49,8 @@ Key points:
     scheduling concerns.
 - **Custom exception** — `PilotSubmissionError` replaces a generic
     `RuntimeError`, making error handling more precise in callers.
-- **DB type hints** — Functions use the raw `MyPilotDB` class (not the
-    DI-annotated type from `depends.py`). At runtime, the injected
-    instance is the same object either way.
+- **DB type hints** — Functions use the raw `MyPilotDB` class directly.
+    The dependency injection system auto-detects DB classes at runtime.
 
 ## Update dependencies
 

--- a/docs/dev/tutorials/advanced-tutorial/router.md
+++ b/docs/dev/tutorials/advanced-tutorial/router.md
@@ -42,13 +42,14 @@ Here we allow all authenticated users — in a real system you'd check
 
 ### DB dependency
 
-!!! tip "The `Annotated[DB, Depends(DB.transaction)]` pattern"
+!!! tip "Auto-injected database dependencies"
 
-    This is the standard way to inject a database connection in DiracX
-    routers. `Depends(DB.transaction)` opens a transaction when the request
-    starts and commits it on success (or rolls back on error). The
-    `Annotated` type alias makes the dependency reusable across multiple
-    endpoint signatures.
+    Database classes (`BaseSQLDB` subclasses) are auto-detected by
+    `DiracxRouter.add_api_route`. Simply type-annotate a parameter with
+    the DB class and it will be wrapped with
+    `Depends(cls.transaction, scope="function")` automatically, which
+    opens a transaction when the request starts and commits on success
+    (or rolls back on error).
 
 ### Endpoints
 
@@ -73,18 +74,6 @@ Access policy entry point:
 ```toml title="gubbins-routers/pyproject.toml"
 --8<-- "extensions/gubbins/gubbins-routers/pyproject.toml:my_pilots_access_policy_entry_point"
 ```
-
-## Update package exports
-
-Re-export the DB dependency:
-
-<!-- blacken-docs:off -->
-
-```python title="gubbins-routers/src/gubbins/routers/dependencies.py"
---8<-- "extensions/gubbins/gubbins-routers/src/gubbins/routers/dependencies.py:my_pilots_router_depends"
-```
-
-<!-- blacken-docs:on -->
 
 ## Checkpoint
 

--- a/docs/dev/tutorials/advanced-tutorial/tasks.md
+++ b/docs/dev/tutorials/advanced-tutorial/tasks.md
@@ -54,8 +54,8 @@ The key imports to note:
 - **`gubbins.logic.my_pilots`** — Business logic functions from the
     [logic layer](logic.md). Tasks delegate to these rather than
     implementing logic inline.
-- **`MyPilotDB`** (from `depends`) — The dependency-injected database
-    type from Part 2
+- **`MyPilotDB`** (from `gubbins.db.sql`) — The database class from
+    Part 2, auto-detected by the dependency injection system
 
 ## MyPilotTask — one-shot submission
 

--- a/extensions/gubbins/gubbins-routers/src/gubbins/routers/dependencies.py
+++ b/extensions/gubbins/gubbins-routers/src/gubbins/routers/dependencies.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__all__ = ("Config", "LollygagDB")
+__all__ = ("Config",)
 
 from typing import Annotated
 
@@ -8,15 +8,6 @@ from diracx.core.config import ConfigSource
 from fastapi import Depends
 
 from gubbins.core.config.schema import Config as _Config
-
-# Re-export DI types from gubbins-tasks (mirrors diracx.routers.dependencies)
-from gubbins.tasks.depends import LollygagDB as LollygagDB  # noqa: F401
-
-# --8<-- [start:my_pilots_router_depends]
-from gubbins.tasks.depends import MyPilotDB as MyPilotDB  # noqa: F401, E402
-
-__all__ += ("MyPilotDB",)  # type: ignore[assignment]
-# --8<-- [end:my_pilots_router_depends]
 
 # Overwrite the Config dependency such that gubbins routers
 # can use it

--- a/extensions/gubbins/gubbins-routers/src/gubbins/routers/lollygag/lollygag.py
+++ b/extensions/gubbins/gubbins-routers/src/gubbins/routers/lollygag/lollygag.py
@@ -5,12 +5,9 @@ It uses the the Lollygag AccessPolicy (which itself requires the Gubbins propert
 
 from __future__ import annotations
 
-from typing import Annotated
-
 from diracx.routers.fastapi_classes import DiracxRouter
-from fastapi import Depends
 
-from gubbins.db.sql import LollygagDB as _LollygagDB
+from gubbins.db.sql import LollygagDB
 from gubbins.logic.lollygag.lollygag import (
     get_gubbins_secrets as get_gubbins_secrets_bl,
 )
@@ -20,10 +17,6 @@ from gubbins.logic.lollygag.lollygag import (
 )
 
 from .access_policy import ActionType, CheckLollygagPolicyCallable
-
-# Define the dependency at the top, so you don't have to
-# be so verbose in your routes
-LollygagDB = Annotated[_LollygagDB, Depends(_LollygagDB.transaction)]
 
 router = DiracxRouter()
 

--- a/extensions/gubbins/gubbins-routers/src/gubbins/routers/my_pilots.py
+++ b/extensions/gubbins/gubbins-routers/src/gubbins/routers/my_pilots.py
@@ -17,7 +17,7 @@ from diracx.routers.fastapi_classes import DiracxRouter
 from diracx.routers.utils.users import AuthorizedUserInfo
 from fastapi import Depends
 
-from gubbins.db.sql import MyPilotDB as _MyPilotDB
+from gubbins.db.sql import MyPilotDB
 
 
 class ActionType(StrEnum):
@@ -38,8 +38,6 @@ class MyPilotsAccessPolicy(BaseAccessPolicy):
 
 
 CheckMyPilotsPolicyCallable = Annotated[Callable, Depends(MyPilotsAccessPolicy.check)]
-
-MyPilotDB = Annotated[_MyPilotDB, Depends(_MyPilotDB.transaction)]
 
 router = DiracxRouter()
 

--- a/extensions/gubbins/gubbins-tasks/src/gubbins/tasks/depends.py
+++ b/extensions/gubbins/gubbins-tasks/src/gubbins/tasks/depends.py
@@ -1,25 +1,7 @@
 """Dependency injection type definitions for gubbins tasks.
 
-Re-exported by ``gubbins.routers.dependencies`` so that both routers
-and the task worker can resolve them.
+DB classes are auto-detected by ``auto_inject_depends`` — no wrappers needed.
+Task code should import DB classes directly from ``gubbins.db.sql``.
 """
 
 from __future__ import annotations
-
-__all__ = ("LollygagDB",)
-
-from typing import Annotated
-
-from diracx.tasks.plumbing.depends import DBDepends
-
-from gubbins.db.sql import LollygagDB as _LollygagDB
-
-LollygagDB = Annotated[_LollygagDB, DBDepends(_LollygagDB.transaction)]
-# --8<-- [start:my_pilots_depends]
-
-from gubbins.db.sql import MyPilotDB as _MyPilotDB  # noqa: E402
-
-MyPilotDB = Annotated[_MyPilotDB, DBDepends(_MyPilotDB.transaction)]
-
-__all__ += ("MyPilotDB",)  # type: ignore[assignment]
-# --8<-- [end:my_pilots_depends]

--- a/extensions/gubbins/gubbins-tasks/src/gubbins/tasks/lollygag.py
+++ b/extensions/gubbins/gubbins-tasks/src/gubbins/tasks/lollygag.py
@@ -24,9 +24,9 @@ from diracx.tasks.plumbing.locks import BaseLock, MutexLock
 from diracx.tasks.plumbing.retry_policies import ExponentialBackoff
 from diracx.tasks.plumbing.schedules import CronSchedule, IntervalSeconds
 
+from gubbins.db.sql import LollygagDB
 from gubbins.logic.lollygag.lollygag import get_owner_object, insert_owner_object
 
-from .depends import LollygagDB
 from .lock_types import LOLLYGAG
 
 logger = logging.getLogger(__name__)

--- a/extensions/gubbins/gubbins-tasks/src/gubbins/tasks/my_pilots.py
+++ b/extensions/gubbins/gubbins-tasks/src/gubbins/tasks/my_pilots.py
@@ -27,6 +27,7 @@ from diracx.tasks.plumbing.locks import BaseLock, MutexLock
 from diracx.tasks.plumbing.retry_policies import NoRetry
 from diracx.tasks.plumbing.schedules import CronSchedule, IntervalSeconds
 
+from gubbins.db.sql import MyPilotDB
 from gubbins.logic.my_pilots import (
     get_available_ces,
     get_pilot_summary,
@@ -34,7 +35,6 @@ from gubbins.logic.my_pilots import (
     transition_pilot_states,
 )
 
-from .depends import MyPilotDB
 from .my_pilot_lock_types import MY_PILOT
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
When using diracx tasks I've run into a few annoying issues (this was written before #842 was merged but we decided to make it a separate PR).

* Some tasks need to manage their own DB transactions, e.g. clean up jobs which need to clean up in batches.
* Re-exporting every database and settings class through `diracx.tasks` is tedious and error prone.
* The re-exports of databases and settings classes in `diracx.tasks` ends up coupling us quite tightly to FastAPI and means any changes in FastAPI need to be followed in both DiracX and in extensions.

This PR makes two notable changes to improve this, first you can now do:

```python
    async def execute(
        self,
        sandbox_metadata_db: Annotated[SandboxMetadataDB, NoTransaction()],
        settings: SandboxStoreSettings,
    ) -> int:
```

i.e. use an explicit annotation to override the DB transaction behaviour. We could think about adding similar annotations in other contexts but that's an exercise for later.

In order to be able to implement this nicely, and to be able to solve the other points above we now depend on `from diracx.db.sql import SandboxMetadataDB`. DiracX tasks/routers then inspects the function signature for tasks/routes and automatically injects the `Depends` annotations.