### PR TITLE
refactor: remove abstract execute method from BaseTask

### DIFF
--- a/diracx-tasks/src/diracx/tasks/plumbing/base_task.py
+++ b/diracx-tasks/src/diracx/tasks/plumbing/base_task.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 __all__ = ["BaseTask", "PeriodicBaseTask", "PeriodicVoAwareBaseTask"]
 
 import dataclasses
-from abc import ABC, abstractmethod
 from contextvars import ContextVar
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, ClassVar
@@ -18,8 +17,13 @@ if TYPE_CHECKING:
     from .broker.models import TaskBinding
 
 
-class BaseTask(ABC):
-    """Base class for all DiracX tasks."""
+class BaseTask:
+    """Base class for all DiracX tasks.
+
+    Implementations must define an "async def execute(self, ...)" method, where
+    the signature of "execute" determines what dependencies are injected by
+    the worker.
+    """
 
     priority: ClassVar[Priority] = Priority.NORMAL
     size: ClassVar[Size] = Size.MEDIUM
@@ -55,11 +59,6 @@ class BaseTask(ABC):
             RateLimiter(TASK, self.__class__.__name__),
             ConcurrencyLimiter(TASK, self.__class__.__name__),
         ]
-
-    @abstractmethod
-    async def execute(self, **kwargs: Any) -> Any:
-        """Run the task logic."""
-        ...
 
     def serialize(self) -> tuple[Any, ...]:
         """Serialize the task to a tuple of arguments for reconstruction."""

--- a/diracx-tasks/src/diracx/tasks/plumbing/factory.py
+++ b/diracx-tasks/src/diracx/tasks/plumbing/factory.py
@@ -112,7 +112,9 @@ async def task_wrapper(  # noqa: D417
         if held_locks:
             watchdog_task = asyncio.create_task(_lock_watchdog(held_locks, stop_event))
 
-        result = await task.execute(**kwargs)
+        # Subclasses define execute() with varying signatures for dependency
+        # injection, so it can't be declared on BaseTask without LSP violations.
+        result = await task.execute(**kwargs)  # type: ignore[attr-defined]
         return result
     finally:
         if watchdog_task is not None:
@@ -135,7 +137,9 @@ def wrap_task(cls: type[BaseTask]) -> Callable[..., Any]:
 
     Also attaches ``_dependant`` for FastAPI dependency resolution.
     """
-    execute_sig = signature(cls.execute, eval_str=True)
+    # Subclasses define execute() with varying signatures for dependency
+    # injection, so it can't be declared on BaseTask without LSP violations.
+    execute_sig = signature(cls.execute, eval_str=True)  # type: ignore[attr-defined]
     execute_params = list(execute_sig.parameters.values())
     if execute_params and execute_params[0].name == "self":
         execute_params = execute_params[1:]


### PR DESCRIPTION
The variable signature used for dependency injection violates the [Liskov Substiution Principle](https://en.wikipedia.org/wiki/Liskov_substitution_principle) and makes it impossible to run type checkers without ignore comments.