### PR TITLE
chore: regenerate Helm diagram when updating the version

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -235,6 +235,9 @@ jobs:
         run: |
           cd diracx-charts
 
+          # Update the diagram to reflect the updated version number
+          pixi run generate-diagram
+
           # Stage all changes
           git add -A
 


### PR DESCRIPTION
The automatic pushes to the charts are failing the CI because the version is part of the mermaid diagram. 

https://github.com/DIRACGrid/diracx-charts/actions/runs/24500801671/job/71606798020

```
Run if ! git diff --exit-code docs/admin/explanations/architecture_diagram.md; then
diff --git a/docs/admin/explanations/architecture_diagram.md b/docs/admin/explanations/architecture_diagram.md
index 98286a6..1d08398 100644
--- a/docs/admin/explanations/architecture_diagram.md
+++ b/docs/admin/explanations/architecture_diagram.md
@@ -5,7 +5,7 @@ config:
 flowchart TD
 
     subgraph k8s_instance ["K8s Instance: diracx"]
-        subgraph helm_chart ["Helm Chart: diracx 1.0.22"]
+        subgraph helm_chart ["Helm Chart: diracx 1.0.24"]
             subgraph k8s_app ["K8s Application: diracx"]
                 ing_diracx{{"ing: diracx"}}
                 svc_diracx(("svc: diracx"))
Error: architecture_diagram.md is out of date. Run 'pixi run generate-diagram' and commit the result.
Error: Process completed with exit code 1.
```

This PR forces the diagram regeneration