### PR TITLE
fix: stop using UPGRADE_REQUIRED for client version check

### DIFF
--- a/diracx-routers/src/diracx/routers/factory.py
+++ b/diracx-routers/src/diracx/routers/factory.py
@@ -508,10 +508,9 @@ class ClientMinVersionCheckMiddleware(BaseHTTPMiddleware):
                 # This is not managed here.
 
                 raise HTTPException(
-                    status_code=HTTPStatus.UPGRADE_REQUIRED,
-                    detail=f"Client version ({client_version})"
-                    f"not recent enough (>= {self.min_client_version})."
-                    "Upgrade.",
+                    status_code=HTTPStatus.PRECONDITION_FAILED,
+                    detail=f"Client version {client_version} is not compatible with the server. "
+                    f"Upgrade to a version >= {self.min_client_version}.",
                 )
         except HTTPException as exc:
             # Return a JSONResponse because the HTTPException

--- a/diracx-routers/src/diracx/routers/factory.py
+++ b/diracx-routers/src/diracx/routers/factory.py
@@ -508,7 +508,7 @@ class ClientMinVersionCheckMiddleware(BaseHTTPMiddleware):
                 # This is not managed here.
 
                 raise HTTPException(
-                    status_code=HTTPStatus.PRECONDITION_FAILED,
+                    status_code=HTTPStatus.BAD_REQUEST,
                     detail=f"Client version {client_version} is not compatible with the server. "
                     f"Upgrade to a version >= {self.min_client_version}.",
                 )

--- a/diracx-routers/tests/test_generic.py
+++ b/diracx-routers/tests/test_generic.py
@@ -62,7 +62,7 @@ def test_min_client_version_lower_than_expected(test_client):
     )
 
     r = test_client.get("/", headers={"DiracX-Client-Version": lower_version_than_min})
-    assert r.status_code == HTTPStatus.PRECONDITION_FAILED
+    assert r.status_code == HTTPStatus.BAD_REQUEST
     assert str(min_client_version) in r.json()["detail"]
 
 

--- a/diracx-routers/tests/test_generic.py
+++ b/diracx-routers/tests/test_generic.py
@@ -62,7 +62,7 @@ def test_min_client_version_lower_than_expected(test_client):
     )
 
     r = test_client.get("/", headers={"DiracX-Client-Version": lower_version_than_min})
-    assert r.status_code == HTTPStatus.UPGRADE_REQUIRED
+    assert r.status_code == HTTPStatus.PRECONDITION_FAILED
     assert str(min_client_version) in r.json()["detail"]
 
 


### PR DESCRIPTION
Closes #542 

Change:
Replace UPGRADE_REQUIRED (426) with PRECONDITION_FAILED (412)