### PR TITLE
chore: add gubbins/tasks to gubbins-charts

### DIFF
--- a/extensions/gubbins-charts/values.yaml
+++ b/extensions/gubbins-charts/values.yaml
@@ -14,5 +14,7 @@ diracx:
       tag: "dev"
       services:
         repository: gubbins/services
+      tasks:
+        repository: gubbins/tasks
       client:
         repository: gubbins/client


### PR DESCRIPTION
I think we are missing `gubbins/tasks` in `gubbins-charts`, which might cause failures such as https://github.com/DIRACGrid/diracx/actions/runs/26713204907/job/78840172112#step:15:30 where, IIUC, `gubbins/tasks` is not found so `diracx/tasks:dev` (not the local one but the released one) is used instead and still contains the `pilot_agents` directory which was renamed in the pilot PR.