### PR TITLE
fix(routers): parse If-Modified-Since as GMT and extract apply_cache_headers

### DIFF
--- a/diracx-routers/src/diracx/routers/configuration.py
+++ b/diracx-routers/src/diracx/routers/configuration.py
@@ -3,13 +3,10 @@ from __future__ import annotations
 __all__ = ["router"]
 
 import logging
-from datetime import datetime, timezone
-from http import HTTPStatus
 from typing import Annotated
 
 from fastapi import (
     Header,
-    HTTPException,
     Response,
 )
 
@@ -17,10 +14,9 @@ from diracx.routers.dependencies import Config
 
 from .access_policies import open_access
 from .fastapi_classes import DiracxRouter
+from .utils.http_cache import apply_cache_headers
 
 logger = logging.getLogger(__name__)
-
-LAST_MODIFIED_FORMAT = "%a, %d %b %Y %H:%M:%S GMT"
 
 router = DiracxRouter()
 
@@ -42,31 +38,12 @@ async def serve_config(
         return 304: this is to avoid flip/flopping
     """
     # await check_permissions()
-    headers = {
-        "ETag": config._hexsha,
-        "Last-Modified": config._modified.strftime(LAST_MODIFIED_FORMAT),
-    }
-
-    if if_none_match == config._hexsha:
-        raise HTTPException(status_code=HTTPStatus.NOT_MODIFIED, headers=headers)
-
-    # This is to prevent flip/flopping in case
-    # a server gets out of sync with disk
-    if if_modified_since:
-        try:
-            not_before = datetime.strptime(
-                if_modified_since, LAST_MODIFIED_FORMAT
-            ).astimezone(timezone.utc)
-        except ValueError:
-            logger.debug(
-                "Failed to parse If-Modified-Since header: %s", if_modified_since
-            )
-        else:
-            if not_before > config._modified:
-                raise HTTPException(
-                    status_code=HTTPStatus.NOT_MODIFIED, headers=headers
-                )
-
-    response.headers.update(headers)
+    apply_cache_headers(
+        response,
+        etag=config._hexsha,
+        modified=config._modified,
+        if_none_match=if_none_match,
+        if_modified_since=if_modified_since,
+    )
 
     return config

--- a/diracx-routers/src/diracx/routers/utils/__init__.py
+++ b/diracx-routers/src/diracx/routers/utils/__init__.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
-__all__ = ["AuthorizedUserInfo", "verify_dirac_access_token"]
+__all__ = [
+    "LAST_MODIFIED_FORMAT",
+    "AuthorizedUserInfo",
+    "apply_cache_headers",
+    "verify_dirac_access_token",
+]
 
+from .http_cache import LAST_MODIFIED_FORMAT, apply_cache_headers
 from .users import AuthorizedUserInfo, verify_dirac_access_token

--- a/diracx-routers/src/diracx/routers/utils/http_cache.py
+++ b/diracx-routers/src/diracx/routers/utils/http_cache.py
@@ -1,0 +1,72 @@
+"""Helpers for HTTP conditional-request caching (ETag / Last-Modified / 304)."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from http import HTTPStatus
+
+from fastapi import HTTPException, Response
+
+logger = logging.getLogger(__name__)
+
+LAST_MODIFIED_FORMAT = "%a, %d %b %Y %H:%M:%S GMT"
+
+
+def apply_cache_headers(
+    response: Response,
+    *,
+    etag: str,
+    modified: datetime,
+    if_none_match: str | None,
+    if_modified_since: str | None,
+    vary: str | None = None,
+) -> None:
+    """Set ETag / Last-Modified headers and raise 304 when appropriate.
+
+    If If-None-Match matches the current ETag, return 304.
+
+    If If-Modified-Since is given and is newer than the current Last-Modified,
+    return 304: this is to avoid flip/flopping in case a server gets out of
+    sync with the source of truth.
+
+    Args:
+        response: The response whose headers should be updated.
+        etag: The current entity tag.
+        modified: The current modification time (timezone-aware).
+        if_none_match: Value of the If-None-Match request header, if any.
+        if_modified_since: Value of the If-Modified-Since request header, if any.
+        vary: Optional value for the Vary header, for responses whose content
+              depends on more than the URL (e.g. the caller's identity).
+
+    Raises:
+        HTTPException(304): when the client's cached copy is still current.
+
+    """
+    headers = {
+        "ETag": etag,
+        "Last-Modified": modified.strftime(LAST_MODIFIED_FORMAT),
+    }
+    if vary is not None:
+        headers["Vary"] = vary
+
+    if if_none_match == etag:
+        raise HTTPException(status_code=HTTPStatus.NOT_MODIFIED, headers=headers)
+
+    if if_modified_since:
+        try:
+            # The If-Modified-Since header is always GMT (RFC 9110)
+            not_before = datetime.strptime(
+                if_modified_since, LAST_MODIFIED_FORMAT
+            ).replace(tzinfo=timezone.utc)
+        except ValueError:
+            logger.debug(
+                "Failed to parse If-Modified-Since header: %s", if_modified_since
+            )
+        else:
+            if not_before > modified:
+                raise HTTPException(
+                    status_code=HTTPStatus.NOT_MODIFIED, headers=headers
+                )
+
+    response.headers.update(headers)


### PR DESCRIPTION
The `If-Modified-Since` header is always GMT (RFC 9110) but it was parsed with `astimezone()`, which interprets the naive datetime as server-local time. Use `replace(tzinfo=timezone.utc)` instead.

The conditional-request logic (ETag / Last-Modified / 304) is moved out of the configuration router into a reusable `apply_cache_headers` helper.

Replaces #910
Part of #839