### PR TITLE
feat(core): add AsyncCacheableSource and cacheable-source wiring

### DIFF
--- a/diracx-core/src/diracx/core/config/__init__.py
+++ b/diracx-core/src/diracx/core/config/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 __all__ = [
+    "CacheableSource",
     "Config",
     "ConfigSource",
     "ConfigSourceUrl",
@@ -31,6 +32,7 @@ from .schema import (
     UserConfig,
 )
 from .sources import (
+    CacheableSource,
     ConfigSource,
     ConfigSourceUrl,
     LocalGitConfigSource,

--- a/diracx-core/src/diracx/core/config/sources.py
+++ b/diracx-core/src/diracx/core/config/sources.py
@@ -8,29 +8,24 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from abc import ABCMeta, abstractmethod
 from datetime import datetime, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Annotated, Generic, TypeVar
+from typing import Annotated
 from urllib.parse import urlparse, urlunparse
 
 import sh
 import yaml
-from cachetools import Cache, LRUCache
 from pydantic import AnyUrl, BeforeValidator, TypeAdapter, UrlConstraints
 
 from diracx.core.exceptions import BadConfigurationVersionError
 from diracx.core.extensions import DiracEntryPoint, select_from_extension
-from diracx.core.utils import TwoLevelCache
+from diracx.core.sources import CacheableSource
 
 from .schema import Config
 
 DEFAULT_CONFIG_FILE = "default.yml"
 DEFAULT_GIT_BRANCH = "master"
-DEFAULT_CS_REV_CACHE_SOFT_TTL = 5
-# TODO: Reduce the hard TTL when we have more redundancy around the source of truth
-DEFAULT_CS_REV_CACHE_HARD_TTL = 60 * 60
 DEFAULT_CS_CONTENT_HARD_TTL = 15
 
 logger = logging.getLogger(__name__)
@@ -56,87 +51,6 @@ class AnyUrlWithoutHost(AnyUrl):
 
 
 ConfigSourceUrl = Annotated[AnyUrlWithoutHost, BeforeValidator(_apply_default_scheme)]
-
-T = TypeVar("T")
-
-
-class CacheableSource(Generic[T], metaclass=ABCMeta):
-    """Abstract base class for sources that can be cached.
-
-    Handles the caching of the latest revision and its content using a two-level cache.
-    """
-
-    def __init__(self):
-        # Revision cache is used to store the latest revision and its
-        # modification date. This cache has two TTLs, one which triggers the
-        # background refresh and the other which is results in a hard failure.
-        # This allows us to avoid blocking while the refresh is done, while
-        # maintaining strong guarantees on the data freshness.
-        self._revision_cache = TwoLevelCache(
-            soft_ttl=DEFAULT_CS_REV_CACHE_SOFT_TTL,
-            hard_ttl=DEFAULT_CS_REV_CACHE_HARD_TTL,
-            max_workers=1,
-            max_items=1,
-        )
-        # The content of a given revision can be stored in a simple LRU cache
-        # We keep the last two versions in memory to avoid any potential to flip
-        # flop between two versions when it changes.
-        self._content_cache: Cache = LRUCache(maxsize=2)
-
-    @abstractmethod
-    def latest_revision(self) -> tuple[str, datetime]:
-        """Abstract method.
-
-        Must return:
-        * a unique hash as a string, representing the last version
-        * a datetime object corresponding to when the version dates.
-        """
-
-    @abstractmethod
-    def read_raw(self, hexsha: str, modified: datetime) -> T:
-        """Abstract method.
-
-        Return the Source object that corresponds to the specific hash
-        The `modified` parameter is just added as a attribute to the source.
-        """
-
-    def read(self) -> T:
-        """Load the source from the backend with appropriate caching.
-
-        :raises: diracx.core.exceptions.NotReadyError if the source is being loaded still
-        :raises: git.exc.BadName if version does not exist
-        """
-        hexsha = self._revision_cache.get(
-            "latest_revision", self._read_work, blocking=True
-        )
-        return self._content_cache[hexsha]
-
-    async def read_non_blocking(self) -> T:
-        """Load the source from the backend with appropriate caching.
-
-        :raises: diracx.core.exceptions.NotReadyError if the source is being loaded still
-        :raises: git.exc.BadName if version does not exist
-        """
-        hexsha = self._revision_cache.get(
-            "latest_revision", self._read_work, blocking=False
-        )
-        return self._content_cache[hexsha]
-
-    def _read_work(self) -> str:
-        """Work function for the thread pool of `self._revision_cache`.
-
-        This function ensures that the latest revision is loaded into the
-        content cache before it is admitted into the revision cache.
-        """
-        hexsha, modified = self.latest_revision()
-        if hexsha not in self._content_cache:
-            self._content_cache[hexsha] = self.read_raw(hexsha, modified)
-        return hexsha
-
-    def clear_caches(self):
-        """Clear the caches."""
-        self._revision_cache.clear()
-        self._content_cache.clear()
 
 
 class ConfigSource(CacheableSource[Config]):

--- a/diracx-core/src/diracx/core/extensions.py
+++ b/diracx-core/src/diracx/core/extensions.py
@@ -23,6 +23,7 @@ class DiracEntryPoint(StrEnum):
 
     CORE = "diracx"
     ACCESS_POLICY = "diracx.access_policies"
+    CACHEABLE_SOURCES = "diracx.cacheable_sources"
     CLI = "diracx.cli"
     HIDDEN_CLI = "diracx.cli.hidden"
     OS_DB = "diracx.dbs.os"

--- a/diracx-core/src/diracx/core/sources.py
+++ b/diracx-core/src/diracx/core/sources.py
@@ -1,0 +1,105 @@
+"""Generic caching source abstractions.
+
+Sources wrap a backend (database, git repository, ...) whose content changes
+rarely compared to how often it is read, caching a revision identifier and the
+content it points to. Concrete implementations live next to the backend they
+read from (e.g. the resource status sources in diracx-logic).
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "AsyncCacheableSource",
+    "Snapshot",
+]
+
+from abc import ABCMeta, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime
+from typing import ClassVar, Generic, TypeVar
+
+from cachetools import Cache, LRUCache
+
+from diracx.core.utils import AsyncTwoLevelCache
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class Snapshot(Generic[T]):
+    """Wraps a cached data payload with its cache metadata."""
+
+    data: T
+    hexsha: str
+    modified: datetime
+
+
+class AsyncCacheableSource(Generic[T], metaclass=ABCMeta):
+    """Abstract base class for async sources that can be cached.
+
+    Async equivalent of CacheableSource. Uses AsyncTwoLevelCache so populate
+    functions are native coroutines.
+    """
+
+    #: The database class this source reads from. Used by the application
+    #: factory to instantiate the source with the matching database instance.
+    db_class: ClassVar[type]
+
+    #: TTLs for the revision cache: past the soft TTL a background refresh is
+    #: triggered while the cached value is still served; past the hard TTL the
+    #: data is considered too stale to serve. Subclasses can override these.
+    rev_cache_soft_ttl: ClassVar[int] = 5
+    # TODO: Reduce the hard TTL when we have more redundancy around the source of truth
+    rev_cache_hard_ttl: ClassVar[int] = 60 * 60
+
+    def __init__(self):
+        self._revision_cache = AsyncTwoLevelCache(
+            soft_ttl=self.rev_cache_soft_ttl,
+            hard_ttl=self.rev_cache_hard_ttl,
+            max_items=1,
+        )
+        self._content_cache: Cache = LRUCache(maxsize=2)
+
+    @abstractmethod
+    async def latest_revision(self) -> tuple[str, datetime]:
+        """Return (revision_str, modified) identifying the current revision."""
+
+    @abstractmethod
+    async def read_raw(self, hexsha: str, modified: datetime) -> T:
+        """Fetch and return the data for the given revision."""
+
+    async def _read_work(self) -> str:
+        hexsha, modified = await self.latest_revision()
+        if hexsha not in self._content_cache:
+            self._content_cache[hexsha] = await self.read_raw(hexsha, modified)
+        return hexsha
+
+    async def read(self) -> T:
+        """Blocking read — awaits refresh on a hard cache miss."""
+        hexsha = await self._revision_cache.get(
+            "latest_revision", self._read_work, blocking=True
+        )
+        return self._content_cache[hexsha]
+
+    async def read_non_blocking(self) -> T:
+        """Non-blocking read — raises NotReadyError on a hard cache miss."""
+        hexsha = await self._revision_cache.get(
+            "latest_revision", self._read_work, blocking=False
+        )
+        return self._content_cache[hexsha]
+
+    async def clear_caches(self):
+        """Clear the caches."""
+        await self._revision_cache.clear()
+        self._content_cache.clear()
+
+    @classmethod
+    async def create(cls) -> T:
+        """Dependency injection stub.
+
+        The application factory instantiates each concrete source and
+        overrides ``cls.create`` with the instance's ``read`` method, so this
+        should never actually be called. Each subclass's bound ``create``
+        classmethod is a distinct dependency key.
+        """
+        raise NotImplementedError(f"{cls.__name__} was not wired by the factory")

--- a/diracx-core/src/diracx/core/sources.py
+++ b/diracx-core/src/diracx/core/sources.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 __all__ = [
     "AsyncCacheableSource",
+    "CacheableSource",
     "Snapshot",
 ]
 
@@ -20,9 +21,13 @@ from typing import ClassVar, Generic, TypeVar
 
 from cachetools import Cache, LRUCache
 
-from diracx.core.utils import AsyncTwoLevelCache
+from diracx.core.utils import AsyncTwoLevelCache, TwoLevelCache
 
 T = TypeVar("T")
+
+DEFAULT_CS_REV_CACHE_SOFT_TTL = 5
+# TODO: Reduce the hard TTL when we have more redundancy around the source of truth
+DEFAULT_CS_REV_CACHE_HARD_TTL = 60 * 60
 
 
 @dataclass(frozen=True)
@@ -32,6 +37,85 @@ class Snapshot(Generic[T]):
     data: T
     hexsha: str
     modified: datetime
+
+
+class CacheableSource(Generic[T], metaclass=ABCMeta):
+    """Abstract base class for sources that can be cached.
+
+    Handles the caching of the latest revision and its content using a two-level cache.
+    """
+
+    def __init__(self):
+        # Revision cache is used to store the latest revision and its
+        # modification date. This cache has two TTLs, one which triggers the
+        # background refresh and the other which is results in a hard failure.
+        # This allows us to avoid blocking while the refresh is done, while
+        # maintaining strong guarantees on the data freshness.
+        self._revision_cache = TwoLevelCache(
+            soft_ttl=DEFAULT_CS_REV_CACHE_SOFT_TTL,
+            hard_ttl=DEFAULT_CS_REV_CACHE_HARD_TTL,
+            max_workers=1,
+            max_items=1,
+        )
+        # The content of a given revision can be stored in a simple LRU cache
+        # We keep the last two versions in memory to avoid any potential to flip
+        # flop between two versions when it changes.
+        self._content_cache: Cache = LRUCache(maxsize=2)
+
+    @abstractmethod
+    def latest_revision(self) -> tuple[str, datetime]:
+        """Abstract method.
+
+        Must return:
+        * a unique hash as a string, representing the last version
+        * a datetime object corresponding to when the version dates.
+        """
+
+    @abstractmethod
+    def read_raw(self, hexsha: str, modified: datetime) -> T:
+        """Abstract method.
+
+        Return the Source object that corresponds to the specific hash
+        The `modified` parameter is just added as a attribute to the source.
+        """
+
+    def read(self) -> T:
+        """Load the source from the backend with appropriate caching.
+
+        :raises: diracx.core.exceptions.NotReadyError if the source is being loaded still
+        :raises: git.exc.BadName if version does not exist
+        """
+        hexsha = self._revision_cache.get(
+            "latest_revision", self._read_work, blocking=True
+        )
+        return self._content_cache[hexsha]
+
+    async def read_non_blocking(self) -> T:
+        """Load the source from the backend with appropriate caching.
+
+        :raises: diracx.core.exceptions.NotReadyError if the source is being loaded still
+        :raises: git.exc.BadName if version does not exist
+        """
+        hexsha = self._revision_cache.get(
+            "latest_revision", self._read_work, blocking=False
+        )
+        return self._content_cache[hexsha]
+
+    def _read_work(self) -> str:
+        """Work function for the thread pool of `self._revision_cache`.
+
+        This function ensures that the latest revision is loaded into the
+        content cache before it is admitted into the revision cache.
+        """
+        hexsha, modified = self.latest_revision()
+        if hexsha not in self._content_cache:
+            self._content_cache[hexsha] = self.read_raw(hexsha, modified)
+        return hexsha
+
+    def clear_caches(self):
+        """Clear the caches."""
+        self._revision_cache.clear()
+        self._content_cache.clear()
 
 
 class AsyncCacheableSource(Generic[T], metaclass=ABCMeta):

--- a/diracx-routers/src/diracx/routers/factory.py
+++ b/diracx-routers/src/diracx/routers/factory.py
@@ -32,6 +32,7 @@ from diracx.core.config import ConfigSource
 from diracx.core.exceptions import DiracError, DiracHttpResponseError, NotReadyError
 from diracx.core.extensions import DiracEntryPoint, select_from_extension
 from diracx.core.settings import ServiceSettingsBase
+from diracx.core.sources import AsyncCacheableSource
 from diracx.core.utils import dotenv_files_from_environment
 from diracx.db.exceptions import DBUnavailableError
 from diracx.db.os.utils import BaseOSDB
@@ -185,6 +186,7 @@ def create_app_inner(
     fail_startup = True
     # Add the SQL DBs to the application
     available_sql_db_classes: set[type[BaseSQLDB]] = set()
+    sql_db_instances: dict[type[BaseSQLDB], BaseSQLDB] = {}
 
     for db_name, db_url in database_urls.items():
         try:
@@ -199,6 +201,7 @@ def create_app_inner(
             for sql_db_class in sql_db_classes:
                 assert sql_db_class.transaction not in app.dependency_overrides
                 available_sql_db_classes.add(sql_db_class)
+                sql_db_instances[sql_db_class] = sql_db
 
                 app.dependency_overrides[sql_db_class.transaction] = partial(
                     db_transaction, sql_db
@@ -214,6 +217,34 @@ def create_app_inner(
 
     if fail_startup:
         raise Exception("No SQL database could be initialized, aborting")
+
+    # Instantiate the cacheable sources and override their create methods,
+    # mirroring the SQL DB wiring above. A single instance is used for each
+    # source name so that its caches persist across requests. The instance is
+    # made from the highest priority class but, as for the DBs, the override
+    # is registered for every implementation class so that vanilla DiracX
+    # routers get an instance of the extension's source.
+    source_classes_by_name: dict[str, list[type[AsyncCacheableSource]]] = {}
+    for entry_point in select_from_extension(group=DiracEntryPoint.CACHEABLE_SOURCES):
+        # Entry points are yielded in priority order, highest first
+        source_classes_by_name.setdefault(entry_point.name, []).append(
+            entry_point.load()
+        )
+    for source_name, source_classes in source_classes_by_name.items():
+        source_db = sql_db_instances.get(source_classes[0].db_class)
+        if source_db is None:
+            logger.warning(
+                "Cannot wire cacheable source %s: %s is not available",
+                source_name,
+                source_classes[0].db_class.__name__,
+            )
+            continue
+        # The base class does not declare the ``db`` argument as it is only
+        # part of the contract between the factory and the concrete sources
+        source = source_classes[0](db=source_db)  # type: ignore[call-arg]
+        for source_cls in source_classes:
+            assert source_cls.create not in app.dependency_overrides
+            app.dependency_overrides[source_cls.create] = source.read
 
     # Add the OpenSearch DBs to the application
     available_os_db_classes: set[type[BaseOSDB]] = set()
@@ -271,6 +302,17 @@ def create_app_inner(
             raise NotImplementedError(
                 f"Cannot enable {system_name=} as it requires {missing_os_dbs=}"
             )
+
+        # Ensure required cacheable sources have been wired, i.e. that the
+        # database they read from is available
+        for source_cls in find_dependents(
+            router,
+            AsyncCacheableSource,  # type: ignore[type-abstract]
+        ):
+            if source_cls.create not in app.dependency_overrides:
+                raise NotImplementedError(
+                    f"Cannot enable {system_name=} as it requires {source_cls=}"
+                )
 
         # Add the router to the application
         dependencies = []

--- a/diracx-testing/src/diracx/testing/utils.py
+++ b/diracx-testing/src/diracx/testing/utils.py
@@ -171,6 +171,7 @@ class ClientFactory:
         from diracx.core.config import ConfigSource
         from diracx.core.extensions import select_from_extension
         from diracx.core.settings import ServiceSettingsBase
+        from diracx.core.sources import AsyncCacheableSource
         from diracx.db.os.utils import BaseOSDB
         from diracx.db.sql.utils import BaseSQLDB
         from diracx.routers.access_policies import BaseAccessPolicy
@@ -252,6 +253,7 @@ class ClientFactory:
                     BaseSQLDB,
                     BaseOSDB,
                     ConfigSource,
+                    AsyncCacheableSource,
                     BaseAccessPolicy,
                 ),
             ), obj


### PR DESCRIPTION
Adds a generic `diracx.core.sources` module with `AsyncCacheableSource` and
`Snapshot`, a `diracx.cacheable_sources` entry-point group, and application
factory support: each source is instantiated once per app (so its caches
persist across requests) with the database instance matching its
`db_class`, and its read method overrides the create dependency for every
implementation class so extensions can substitute their own sources.
Routers depending on a source whose database is not available fail at
startup, consistent with the handling of missing databases.

Replaces #910
Part of #839

Blocked by https://github.com/DIRACGrid/diracx/pull/936