### PR TITLE
ci: harden github actions

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -12,6 +12,8 @@ on:
   schedule:
     - cron: '0 10 * * *'
 
+permissions: {}
+
 jobs:
   deploy-pypi:
     name: PyPI deployment

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -66,11 +66,13 @@ jobs:
           python -m readme_renderer README.md -o /tmp/README.html
       - name: Extract version from tag
         id: check-tag
+        env:
+          GITHUB_REF: ${{ github.ref }}
         run: |
           set -xeuo pipefail
           IFS=$'\n\t'
           # Check if this is a tag push
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             # Extract version from the tag
             export NEW_VERSION="${GITHUB_REF#refs/tags/}"
             echo "Deploying release $NEW_VERSION"
@@ -240,9 +242,11 @@ jobs:
 
       - name: Update chart versions
         id: update-versions
+        env:
+          NEW_CHART_VERSION: ${{ needs.deploy-pypi.outputs.new-version }}
         run: |
           cd diracx-charts
-          VERSION="${{ needs.deploy-pypi.outputs.new-version }}"
+          VERSION="${NEW_CHART_VERSION}"
 
           # Get current chart version before updating
           CURRENT_CHART_VERSION=$(grep '^version:' diracx/Chart.yaml | sed 's/version: //' | tr -d '"')
@@ -268,6 +272,10 @@ jobs:
 
       - name: Commit and push changes
         if: success()
+        env:
+          CURRENT_CHART_VERSION: ${{ steps.update-versions.outputs.current_chart_version }}
+          NEW_CHART_VERSION: ${{ steps.update-versions.outputs.new_chart_version }}
+          DIRACX_VERSION: ${{ steps.update-versions.outputs.diracx_version }}
         run: |
           cd diracx-charts
 
@@ -280,15 +288,15 @@ jobs:
           # Check if there are changes to commit
           if ! git diff --cached --quiet; then
             # Commit the changes
-            git commit -m "chore: bump chart to ${{ steps.update-versions.outputs.new_chart_version }} for DiracX ${{ steps.update-versions.outputs.diracx_version }}
+            git commit -m "chore: bump chart to ${NEW_CHART_VERSION} for DiracX ${DIRACX_VERSION}
 
-            - Update appVersion to ${{ steps.update-versions.outputs.diracx_version }}
-            - Update image tag to ${{ steps.update-versions.outputs.diracx_version }}
-            - Bump chart version from ${{ steps.update-versions.outputs.current_chart_version }} to ${{ steps.update-versions.outputs.new_chart_version }}"
+            - Update appVersion to ${DIRACX_VERSION}
+            - Update image tag to ${DIRACX_VERSION}
+            - Bump chart version from ${CURRENT_CHART_VERSION} to ${NEW_CHART_VERSION}"
 
             git push origin master
 
-            echo "✅ Successfully pushed chart version ${{ steps.update-versions.outputs.new_chart_version }} and tag ${TAG_NAME}"
+            echo "✅ Successfully pushed chart version ${NEW_CHART_VERSION} and tag ${TAG_NAME}"
           else
             echo "No changes to commit"
           fi

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -42,6 +42,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           token: ${{ github.token }}
+          persist-credentials: false
       - run: |
           git fetch --prune --unshallow
           git config --global user.email "ci@diracgrid.org"
@@ -112,6 +113,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
       - name: Set up Docker Buildx
@@ -218,13 +221,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           path: diracx
-
+          persist-credentials: false
       - name: Checkout diracx-charts
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: DIRACGrid/diracx-charts
           token: ${{ secrets.CHARTS_UPDATE_TOKEN }}
           path: diracx-charts
+          persist-credentials: true
 
       - name: Configure Git
         run: |

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -41,7 +41,7 @@ jobs:
         # We need extglob for REFERENCE_BRANCH substitution
         shell: bash -l -O extglob {0}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ github.token }}
           persist-credentials: false
@@ -49,7 +49,7 @@ jobs:
           git fetch --prune --unshallow
           git config --global user.email "ci@diracgrid.org"
           git config --global user.name "DIRACGrid CI"
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.14'
       - name: Installing dependencies
@@ -91,7 +91,7 @@ jobs:
           # Also build the diracx metapackage
           python -m build --outdir $PWD/dist .
       - name: 'Upload Artifact'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: diracx-whl
           path: dist/diracx*.whl
@@ -100,7 +100,7 @@ jobs:
       # https://docs.pypi.org/trusted-publishers/
       - name: Publish package on PyPI
         if: steps.check-tag.outputs.create-release == 'true'
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           # Generate and upload PEP 740 attestations (build provenance) for the wheels.
           attestations: true
@@ -116,15 +116,15 @@ jobs:
       attestations: write      # write build-provenance attestations
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Login to GitHub container registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -132,7 +132,7 @@ jobs:
 
       - name: Build and push services (release)
         id: build-services-release
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         if: ${{ needs.deploy-pypi.outputs.create-release == 'true' }}
         with:
           context: .
@@ -150,7 +150,7 @@ jobs:
           push-to-registry: true
       - name: Build and push tasks (release)
         id: build-tasks-release
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         if: ${{ needs.deploy-pypi.outputs.create-release == 'true' }}
         with:
           context: .
@@ -168,7 +168,7 @@ jobs:
           push-to-registry: true
       - name: Build and push client (release)
         id: build-client-release
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         if: ${{ needs.deploy-pypi.outputs.create-release == 'true' }}
         with:
           context: .
@@ -186,7 +186,7 @@ jobs:
           push-to-registry: true
 
       - name: Build and push services (dev)
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           file: containers/Dockerfile
@@ -195,7 +195,7 @@ jobs:
           tags: ghcr.io/diracgrid/diracx/services:dev
           platforms: linux/amd64,linux/arm64
       - name: Build and push tasks (dev)
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           file: containers/Dockerfile
@@ -204,7 +204,7 @@ jobs:
           tags: ghcr.io/diracgrid/diracx/tasks:dev
           platforms: linux/amd64,linux/arm64
       - name: Build and push client (dev)
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           file: containers/Dockerfile
@@ -222,12 +222,12 @@ jobs:
     if: ${{ needs.deploy-pypi.outputs.create-release == 'true' }}
     steps:
       - name: Checkout diracx
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: diracx
           persist-credentials: false
       - name: Checkout diracx-charts
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: DIRACGrid/diracx-charts
           token: ${{ secrets.CHARTS_UPDATE_TOKEN }}

--- a/.github/workflows/draft-on-changes-requested.yml
+++ b/.github/workflows/draft-on-changes-requested.yml
@@ -1,7 +1,7 @@
 name: Draft on Changes Requested
 
 on:
-  workflow_run:
+  workflow_run: # zizmor: ignore[dangerous-triggers] workflow is safe.
     workflows: ["Record Changes Requested"]
     types: [completed]
 

--- a/.github/workflows/draft-on-changes-requested.yml
+++ b/.github/workflows/draft-on-changes-requested.yml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       pr_number: ${{ steps.pr.outputs.number }}
     steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pr-info
           run-id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,6 +16,8 @@ on:
       - 'docs/**'
       - 'mkdocs.yml'
 
+permissions: {}
+
 defaults:
   run:
     shell: bash -el {0}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -32,6 +32,8 @@ jobs:
           - integration
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.14'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,10 +33,10 @@ jobs:
         dirac-branch:
           - integration
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.14'
       - name: Clone DIRAC
@@ -95,7 +95,7 @@ jobs:
           echo "::group::DIRAC server logs"
           cd /tmp/DIRACRepo && ./integration_tests.py logs --no-follow --lines 1000 2>&1 | tee /tmp/service-logs/dirac.log || true
           echo "::endgroup::"
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: ${{ failure() }}
         with:
           name: service-logs-${{ github.job }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4
@@ -67,7 +67,7 @@ jobs:
           - gubbins-cli
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4
@@ -120,7 +120,7 @@ jobs:
           echo "After cleanup:"
           df -h
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4
@@ -139,9 +139,9 @@ jobs:
           cache: false
           environments: ${{ matrix.extension == 'diracx' && 'default' || 'default-gubbins' }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Build services image
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           file: containers/Dockerfile
@@ -150,7 +150,7 @@ jobs:
           tags: ghcr.io/${{ matrix.extension == 'diracx' && 'diracgrid/diracx' || 'gubbins' }}/services:dev
           outputs: type=docker,dest=/tmp/services_image.tar
       - name: Build tasks image
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           file: containers/Dockerfile
@@ -159,7 +159,7 @@ jobs:
           tags: ghcr.io/${{ matrix.extension == 'diracx' && 'diracgrid/diracx' || 'gubbins' }}/tasks:dev
           outputs: type=docker,dest=/tmp/tasks_image.tar
       - name: Build client image
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           file: containers/Dockerfile
@@ -244,7 +244,7 @@ jobs:
         package: [diracx, gubbins]
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4
@@ -267,7 +267,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4
         with:
           run-install: false
@@ -65,6 +67,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4
         with:
           run-install: false
@@ -116,6 +120,8 @@ jobs:
           df -h
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4
         with:
           run-install: false
@@ -238,6 +244,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4
         with:
           run-install: false
@@ -259,6 +267,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4
         with:
           run-install: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,6 @@ on:
       - '**.md'
       - 'docs/**'
       - 'mkdocs.yml'
-      -
 permissions: {}
 
 concurrency:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,8 @@ on:
       - '**.md'
       - 'docs/**'
       - 'mkdocs.yml'
+      -
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -12,7 +12,7 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         if: ${{ github.actor != 'pre-commit-ci[bot]' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,7 +1,7 @@
 name: PR Title
 
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] read-only so there's no danger.
     types: [opened, edited, synchronize]
 
 permissions:

--- a/.github/workflows/record-changes-requested.yml
+++ b/.github/workflows/record-changes-requested.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "${{ github.event.pull_request.number }}" > pr_number.txt
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: pr-info
           path: pr_number.txt

--- a/.github/workflows/record-changes-requested.yml
+++ b/.github/workflows/record-changes-requested.yml
@@ -4,6 +4,8 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions: {}
+
 jobs:
   record:
     if: github.event.review.state == 'changes_requested'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
           release-type: simple

--- a/.github/workflows/update_security_txt_expiry.yml
+++ b/.github/workflows/update_security_txt_expiry.yml
@@ -16,12 +16,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.x'
 
@@ -76,7 +76,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.update_script.outputs.changes_made == 'true'
-        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore(security): Update security.txt expiry date"

--- a/.github/workflows/update_security_txt_expiry.yml
+++ b/.github/workflows/update_security_txt_expiry.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6

--- a/.github/workflows/vulnerabilities.yml
+++ b/.github/workflows/vulnerabilities.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
           tags: true
-
+          persist-credentials: false
       - name: Run Trivy (client:dev)
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:

--- a/.github/workflows/vulnerabilities.yml
+++ b/.github/workflows/vulnerabilities.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           tags: true
@@ -29,7 +29,7 @@ jobs:
           output: "client-dev-vulnerability-report.sarif"
 
       - name: Upload SARIF to GitHub Security (client:dev)
-        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
         with:
           sarif_file: "client-dev-vulnerability-report.sarif"
           category: "client-dev"
@@ -43,7 +43,7 @@ jobs:
           skip-setup-trivy: true
 
       - name: Upload SARIF to GitHub Security (services:dev)
-        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
         with:
           sarif_file: "services-dev-vulnerability-report.sarif"
           category: "services-dev"
@@ -70,7 +70,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Security (client:rel)
         if: ${{ steps.get-latest-tag.outputs.latest_tag != '' }}
-        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
         with:
           sarif_file: "client-rel-vulnerability-report.sarif"
           category: "client-rel"
@@ -86,7 +86,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Security (services:rel)
         if: ${{ steps.get-latest-tag.outputs.latest_tag != '' }}
-        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
         with:
           sarif_file: "services-rel-vulnerability-report.sarif"
           category: "services-rel"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,7 +78,10 @@ repos:
       - id: blacken-docs
         additional_dependencies:
           - black==22.12.0
-
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.22.0
+    hooks:
+      - id: zizmor
   - repo: local
     hooks:
       - id: check-lollygag

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,10 +78,12 @@ repos:
       - id: blacken-docs
         additional_dependencies:
           - black==22.12.0
+
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
     rev: v1.22.0
     hooks:
       - id: zizmor
+
   - repo: local
     hooks:
       - id: check-lollygag

--- a/docs/dev/reference/pixi-tasks.md
+++ b/docs/dev/reference/pixi-tasks.md
@@ -36,6 +36,11 @@ This page documents the available pixi tasks.
 - `mkdocs`: mkdocs serve
 - `mkdocs-build`: mkdocs build --strict
 
+## Github Actions Tasks
+
+- `gha-pinact`: Run Pinact GHA versions update
+- `gha-zizmor`: Run Zizmor GHA analysis
+
 ## Gubbins Tasks
 
 - `pytest-gubbins`: Run the tests for gubbins

--- a/extensions/gubbins/.github/workflows/main.yml
+++ b/extensions/gubbins/.github/workflows/main.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   unittest:
     name: Unit test - ${{ matrix.package }}
@@ -26,6 +28,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
       - uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4
         with:
           run-install: false
@@ -50,6 +55,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
       - uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4
         with:
           run-install: false

--- a/pixi.lock
+++ b/pixi.lock
@@ -9532,6 +9532,25 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ff/43/a2319935fb84a116ea5e436a0ca3d58f586ef0b456034ab296491aed8b22/signurlarity-0.3.1-py3-none-any.whl
+  gha-lint:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pinact-4.0.0-hfc2019e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zizmor-1.25.2-hb17b654_0.conda
+      linux-aarch64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pinact-4.0.0-h22914b5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zizmor-1.25.2-h069e38c_0.conda
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pinact-4.0.0-hf76c51c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zizmor-1.25.2-h6fdd925_0.conda
   gubbins-api:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -18351,6 +18370,9 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls: []
+  run_exports:
+    strong:
+    - _openmp_mutex >=4.5
   size: 28948
   timestamp: 1770939786096
 - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
@@ -18831,6 +18853,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
+  run_exports: {}
   size: 1041084
   timestamp: 1778269013026
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
@@ -18892,6 +18915,9 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
+  run_exports:
+    strong:
+    - _openmp_mutex >=4.5
   size: 603817
   timestamp: 1778268942614
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
@@ -19292,6 +19318,14 @@ packages:
   purls: []
   size: 13344463
   timestamp: 1703310653947
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pinact-4.0.0-hfc2019e_0.conda
+  sha256: 149a2be9a714db0cfcc3490282d9f21860c3f0978fda7203526b575623800a80
+  md5: 40cdae7ed68bc99c92fb168dc7c1009b
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 5774505
+  timestamp: 1779807340488
 - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py311haee01d2_0.conda
   sha256: 8d9325af538a8f56013e42bbb91a4dc6935aece34476e20bafacf6007b571e86
   md5: 2ed8f6fe8b51d8e19f7621941f7bb95f
@@ -19605,6 +19639,19 @@ packages:
   purls: []
   size: 85189
   timestamp: 1753484064210
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zizmor-1.25.2-hb17b654_0.conda
+  sha256: 4886a9d6b6110d76cb986845a14fec92af8ae1447483f2c08a3e7e24180a0f86
+  md5: acd23eff438bd24feaa41b4cc95ffd1e
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 7009161
+  timestamp: 1778922170103
 - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda
   sha256: 245c9ee8d688e23661b95e3c6dd7272ca936fabc03d423cdb3cdee1bbcf9f2f2
   md5: c2a01a08fc991620a74b32420e97868a
@@ -19638,6 +19685,9 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls: []
+  run_exports:
+    strong:
+    - _openmp_mutex >=4.5
   size: 28926
   timestamp: 1770939656741
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
@@ -20093,6 +20143,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
+  run_exports: {}
   size: 622462
   timestamp: 1778268755949
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_19.conda
@@ -20150,6 +20201,9 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
+  run_exports:
+    strong:
+    - _openmp_mutex >=4.5
   size: 587387
   timestamp: 1778268674393
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.18-h90929bb_2.conda
@@ -20525,6 +20579,14 @@ packages:
   purls: []
   size: 13338804
   timestamp: 1703310557094
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pinact-4.0.0-h22914b5_0.conda
+  sha256: ed8f1b4602a6baa747afa9e2ae6526a104f2c4ac754cf7c65b5f015711e5e184
+  md5: d7a16861cfa99aca05ca98dc1c5fef29
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 5222127
+  timestamp: 1779807353519
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/psutil-7.2.2-py311h51cfe5d_0.conda
   sha256: b03dfb4dc12a3744f377d94bd267e1dc82dda4764b3d35d081cdb2482207565a
   md5: a1a2849301364b492841e875fcaaf1e4
@@ -20829,6 +20891,18 @@ packages:
   purls: []
   size: 88088
   timestamp: 1753484092643
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zizmor-1.25.2-h069e38c_0.conda
+  sha256: 87e2a5ea81b148f658e3cf14c1f62558e8c90853af0586e260d8aee5b6c8272f
+  md5: 56c3ff78fde96124776f40b2b71f7196
+  depends:
+  - libgcc >=14
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 6746973
+  timestamp: 1778922190302
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.3.2-hdc9db2a_2.conda
   sha256: d651731b45f2d84591881da3ce3e4107a9ba6709fe790dbd5f7b8d9c89a02ed7
   md5: 493587274c81b34d198b085b46a86eaa
@@ -22174,6 +22248,14 @@ packages:
   purls: []
   size: 14439531
   timestamp: 1703311335652
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pinact-4.0.0-hf76c51c_0.conda
+  sha256: 7e0e9dae4e45d3acf9561206aa38911c776df079b59c7c9492b3857184b9e1a8
+  md5: 42c8d7be17e68e7acb99dc12f87f1286
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 5067388
+  timestamp: 1779807570939
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.2.2-py311he363849_0.conda
   sha256: 2b774e8f4ccaac8783d1908f281e4bb20b7036d6708dc913ee7811b070f5b4b5
   md5: 7cff50265141513c960f00ba586780ea
@@ -22441,6 +22523,18 @@ packages:
   purls: []
   size: 83386
   timestamp: 1753484079473
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zizmor-1.25.2-h6fdd925_0.conda
+  sha256: accff2d5f1f272db521d1c3f1965720fdd096dbecad09b13cd391d289e706034
+  md5: a256ec17027f29d7ff6df5fee51d093c
+  depends:
+  - __osx >=11.0
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 6437874
+  timestamp: 1778922235301
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_2.conda
   sha256: 8dd2ac25f0ba714263aac5832d46985648f4bfb9b305b5021d702079badc08d2
   md5: f1c0bce276210bed45a04949cfe8dc20

--- a/pixi.toml
+++ b/pixi.toml
@@ -194,6 +194,14 @@ shellcheck = "*"
 cmd = "find . -not -wholename './.pixi/*' -name '*.sh' -print -exec shellcheck --exclude=SC1090,SC1091 --external-source '{}' ';'"
 description = "Run shellcheck on all shell scripts"
 
+# Features for running GHA lints
+[feature.gha-lint.dependencies]
+zizmor = "*"
+pinact = "*"
+[feature.gha-lint.tasks]
+gha-zizmor = {cmd = "zizmor .", description = "Run Zizmor GHA analysis"}
+gha-pinact = {cmd ="pinact run" , description = "Run Pinact GHA versions update"}
+
 # Settings documentation feature
 [feature.settings-doc.dependencies]
 python = "*"
@@ -253,6 +261,7 @@ mkdocs = {features = ["mkdocs"], no-default-feature = true}
 shellcheck = {features = ["shellcheck"], no-default-feature = true}
 pre-commit = {features = ["pre-commit"], no-default-feature = true}
 settings-doc = {features = ["settings-doc"], no-default-feature = true}
+gha-lint = {features = ["gha-lint"], no-default-feature = true}
 
 # Meta-tasks for running many tests at once
 [tasks.pytest-diracx-all-one-by-one]

--- a/scripts/generate_pixi_tasks_doc.py
+++ b/scripts/generate_pixi_tasks_doc.py
@@ -22,6 +22,8 @@ def get_task_group(task_name):
         return "Shellcheck"
     if task_name.startswith("generate-settings-"):
         return "Settings"
+    if task_name.startswith("gha-"):
+        return "Github Actions"
     return "Default"
 
 


### PR DESCRIPTION
## Closes: https://github.com/issues/assigned?issue=DIRACGrid%7Cdiracx%7C914

### Changes
- Applied [Zizmor](https://github.com/zizmorcore/zizmor) recommandations in GHA files
- Applied [Pinact](https://github.com/suzuki-shunsuke/pinact) to update checkout versions in GHA files, recommended by Zizmor (https://docs.zizmor.sh/audits/#ref-version-mismatch)
- Added Zizmor to pre-commit
- Added Zizmor and Pinact tasks in pixi: devs can use `pixi run zizmor --fix=safe` to auto-fix minor issues or `pixi run pinact` to auto-update checkout versions