### PR TITLE
chore: token policies persisted in DB

### DIFF
--- a/diracx-client/tests/test_auth.py
+++ b/diracx-client/tests/test_auth.py
@@ -17,7 +17,6 @@ REFRESH_CONTENT = {
     "jti": "f0706e0a-af1e-4538-9f1f-7b9620783cba",
     "exp": int((datetime.now(tz=timezone.utc) + timedelta(days=1)).timestamp()),
     "legacy_exchange": False,
-    "dirac_policies": {},
 }
 
 TOKEN_RESPONSE_DICT = {

--- a/diracx-core/src/diracx/core/models/auth.py
+++ b/diracx-core/src/diracx/core/models/auth.py
@@ -82,7 +82,7 @@ class AccessTokenPayload(TokenPayload):
 class RefreshTokenPayload(TokenPayload):
     legacy_exchange: bool
     # TODO: this should be removed later (https://github.com/DIRACGrid/diracx/issues/524#issuecomment-4395561176)
-    dirac_policies: dict | None
+    dirac_policies: dict | None = None
 
 
 class SupportInfo(TypedDict):

--- a/diracx-core/src/diracx/core/models/auth.py
+++ b/diracx-core/src/diracx/core/models/auth.py
@@ -59,7 +59,6 @@ class OpenIDConfiguration(TypedDict):
 class TokenPayload(BaseModel):
     jti: str
     exp: UTCDatetime
-    dirac_policies: dict
 
 
 class TokenResponse(BaseModel):
@@ -77,10 +76,13 @@ class AccessTokenPayload(TokenPayload):
     dirac_properties: list[str]
     preferred_username: str
     dirac_group: str
+    dirac_policies: dict
 
 
 class RefreshTokenPayload(TokenPayload):
     legacy_exchange: bool
+    # TODO: this should be removed later (https://github.com/DIRACGrid/diracx/issues/524#issuecomment-4395561176)
+    dirac_policies: dict | None
 
 
 class SupportInfo(TypedDict):

--- a/diracx-db/src/diracx/db/sql/auth/db.py
+++ b/diracx-db/src/diracx/db/sql/auth/db.py
@@ -5,6 +5,7 @@ import re
 import secrets
 from datetime import UTC, datetime
 from itertools import pairwise
+from typing import Any
 
 from dateutil.relativedelta import relativedelta
 from dateutil.rrule import MONTHLY, rrule
@@ -324,10 +325,7 @@ class AuthDB(BaseSQLDB):
         )
 
     async def insert_refresh_token(
-        self,
-        jti: UUID,
-        subject: str,
-        scope: str,
+        self, jti: UUID, subject: str, scope: str, policies: dict[str, Any]
     ) -> None:
         """Insert a refresh token in the DB.
 
@@ -335,9 +333,7 @@ class AuthDB(BaseSQLDB):
         """
         # Insert values into the DB
         stmt = insert(RefreshTokens).values(
-            jti=str(jti),
-            sub=subject,
-            scope=scope,
+            jti=str(jti), sub=subject, scope=scope, policies=policies
         )
         await self.conn.execute(stmt)
 

--- a/diracx-db/src/diracx/db/sql/auth/schema.py
+++ b/diracx-db/src/diracx/db/sql/auth/schema.py
@@ -119,5 +119,8 @@ class RefreshTokens(Base):
 
     # User attributes bound to the refresh token
     sub: Mapped[str] = mapped_column("Sub", String(256), index=True)
+    policies: Mapped[dict[str, Any] | None] = mapped_column(
+        "Policies", nullable=True, default=None
+    )
 
     __table_args__ = (Index("index_status_sub", status, sub),)

--- a/diracx-db/tests/auth/test_refresh_token.py
+++ b/diracx-db/tests/auth/test_refresh_token.py
@@ -25,7 +25,7 @@ async def test_insert(auth_db: AuthDB):
             jti1,
             "subject",
             "vo:lhcb property:NormalUser",
-            {"PolicySpecific": "OpenRefreshForTest"},
+            {"PolicySpecific": "OpenAccessForTest"},
         )
 
     # Insert a second refresh token
@@ -35,7 +35,7 @@ async def test_insert(auth_db: AuthDB):
             jti2,
             "subject",
             "vo:lhcb property:NormalUser",
-            {"PolicySpecific": "OpenRefreshForTest"},
+            {"PolicySpecific": "OpenAccessForTest"},
         )
 
     # Make sure they don't have the same JWT ID
@@ -48,7 +48,7 @@ async def test_get(auth_db: AuthDB):
     refresh_token_details = {
         "sub": "12345",
         "scope": "vo:lhcb property:NormalUser",
-        "policies": {"PolicySpecific": "OpenRefreshForTest"},
+        "policies": {"PolicySpecific": "OpenAccessForTest"},
     }
 
     # Insert refresh token details
@@ -95,7 +95,7 @@ async def test_get_user_refresh_tokens(auth_db: AuthDB):
     async with auth_db as auth_db:
         for sub in subjects:
             await auth_db.insert_refresh_token(
-                uuid7(), sub, "scope", {"PolicySpecific": "OpenRefreshForTest"}
+                uuid7(), sub, "scope", {"PolicySpecific": "OpenAccessForTest"}
             )
 
     # Get the refresh tokens of each user
@@ -120,7 +120,7 @@ async def test_revoke(auth_db: AuthDB):
     async with auth_db as auth_db:
         jti = uuid7()
         await auth_db.insert_refresh_token(
-            jti, "subject", "scope", {"PolicySpecific": "OpenRefreshForTest"}
+            jti, "subject", "scope", {"PolicySpecific": "OpenAccessForTest"}
         )
 
     # Revoke the token
@@ -147,7 +147,7 @@ async def test_revoke_user_refresh_tokens(auth_db: AuthDB):
     async with auth_db as auth_db:
         for sub in subjects:
             await auth_db.insert_refresh_token(
-                uuid7(), sub, "scope", {"PolicySpecific": "OpenRefreshForTest"}
+                uuid7(), sub, "scope", {"PolicySpecific": "OpenAccessForTest"}
             )
 
     # Revoke the tokens of sub1
@@ -190,7 +190,7 @@ async def test_revoke_and_get_user_refresh_tokens(auth_db: AuthDB):
         for _ in range(nb_tokens):
             jti = uuid7()
             await auth_db.insert_refresh_token(
-                jti, sub, "scope", {"PolicySpecific": "OpenRefreshForTest"}
+                jti, sub, "scope", {"PolicySpecific": "OpenAccessForTest"}
             )
             jtis.append(jti)
 
@@ -236,7 +236,7 @@ async def test_get_refresh_tokens(auth_db: AuthDB):
     async with auth_db as auth_db:
         for sub in subjects:
             await auth_db.insert_refresh_token(
-                uuid7(), sub, "scope", {"PolicySpecific": "OpenRefreshForTest"}
+                uuid7(), sub, "scope", {"PolicySpecific": "OpenAccessForTest"}
             )
 
     # Get all refresh tokens (Admin)

--- a/diracx-db/tests/auth/test_refresh_token.py
+++ b/diracx-db/tests/auth/test_refresh_token.py
@@ -25,6 +25,7 @@ async def test_insert(auth_db: AuthDB):
             jti1,
             "subject",
             "vo:lhcb property:NormalUser",
+            {"PolicySpecific": "OpenRefreshForTest"},
         )
 
     # Insert a second refresh token
@@ -34,6 +35,7 @@ async def test_insert(auth_db: AuthDB):
             jti2,
             "subject",
             "vo:lhcb property:NormalUser",
+            {"PolicySpecific": "OpenRefreshForTest"},
         )
 
     # Make sure they don't have the same JWT ID
@@ -46,6 +48,7 @@ async def test_get(auth_db: AuthDB):
     refresh_token_details = {
         "sub": "12345",
         "scope": "vo:lhcb property:NormalUser",
+        "policies": {"PolicySpecific": "OpenRefreshForTest"},
     }
 
     # Insert refresh token details
@@ -55,6 +58,7 @@ async def test_get(auth_db: AuthDB):
             jti,
             refresh_token_details["sub"],
             refresh_token_details["scope"],
+            refresh_token_details["policies"],
         )
 
     # Enrich the dict with the generated refresh token attributes
@@ -63,6 +67,7 @@ async def test_get(auth_db: AuthDB):
         "Scope": refresh_token_details["scope"],
         "JTI": jti,
         "Status": RefreshTokenStatus.CREATED,
+        "Policies": refresh_token_details["policies"],
     }
 
     # Get refresh token details
@@ -90,9 +95,7 @@ async def test_get_user_refresh_tokens(auth_db: AuthDB):
     async with auth_db as auth_db:
         for sub in subjects:
             await auth_db.insert_refresh_token(
-                uuid7(),
-                sub,
-                "scope",
+                uuid7(), sub, "scope", {"PolicySpecific": "OpenRefreshForTest"}
             )
 
     # Get the refresh tokens of each user
@@ -117,9 +120,7 @@ async def test_revoke(auth_db: AuthDB):
     async with auth_db as auth_db:
         jti = uuid7()
         await auth_db.insert_refresh_token(
-            jti,
-            "subject",
-            "scope",
+            jti, "subject", "scope", {"PolicySpecific": "OpenRefreshForTest"}
         )
 
     # Revoke the token
@@ -146,9 +147,7 @@ async def test_revoke_user_refresh_tokens(auth_db: AuthDB):
     async with auth_db as auth_db:
         for sub in subjects:
             await auth_db.insert_refresh_token(
-                uuid7(),
-                sub,
-                "scope",
+                uuid7(), sub, "scope", {"PolicySpecific": "OpenRefreshForTest"}
             )
 
     # Revoke the tokens of sub1
@@ -191,9 +190,7 @@ async def test_revoke_and_get_user_refresh_tokens(auth_db: AuthDB):
         for _ in range(nb_tokens):
             jti = uuid7()
             await auth_db.insert_refresh_token(
-                jti,
-                sub,
-                "scope",
+                jti, sub, "scope", {"PolicySpecific": "OpenRefreshForTest"}
             )
             jtis.append(jti)
 
@@ -239,9 +236,7 @@ async def test_get_refresh_tokens(auth_db: AuthDB):
     async with auth_db as auth_db:
         for sub in subjects:
             await auth_db.insert_refresh_token(
-                uuid7(),
-                sub,
-                "scope",
+                uuid7(), sub, "scope", {"PolicySpecific": "OpenRefreshForTest"}
             )
 
     # Get all refresh tokens (Admin)

--- a/diracx-logic/src/diracx/logic/auth/token.py
+++ b/diracx-logic/src/diracx/logic/auth/token.py
@@ -30,7 +30,6 @@ from diracx.db.sql import AuthDB
 from diracx.db.sql.auth.schema import FlowStatus, RefreshTokenStatus
 from diracx.db.sql.utils import uuid7_to_datetime
 from diracx.db.sql.utils.functions import substract_date
-from diracx.routers.access_policies import BaseAccessPolicy
 
 from .utils import (
     get_allowed_user_properties,
@@ -46,7 +45,7 @@ async def get_oidc_token(
     config: Config,
     settings: AuthSettings,
     available_properties: set[SecurityProperty],
-    all_access_policies: dict[str, BaseAccessPolicy],
+    all_access_policies: dict[str, Any],
     device_code: str | None = None,
     code: str | None = None,
     redirect_uri: str | None = None,
@@ -248,7 +247,7 @@ async def perform_legacy_exchange(
     available_properties: set[SecurityProperty],
     settings: AuthSettings,
     config: Config,
-    all_access_policies: dict[str, BaseAccessPolicy],
+    all_access_policies: dict[str, Any],
     expires_minutes: float | None = None,
 ) -> tuple[AccessTokenPayload, RefreshTokenPayload | None]:
     """Endpoint used by legacy DIRAC to mint tokens for proxy -> token exchange."""
@@ -288,7 +287,7 @@ async def exchange_token(
     config: Config,
     settings: AuthSettings,
     available_properties: set[SecurityProperty],
-    all_access_policies: dict[str, BaseAccessPolicy],
+    all_access_policies: dict[str, Any],
     *,
     refresh_token_expire_minutes: float | None = None,
     legacy_exchange: bool = False,

--- a/diracx-logic/src/diracx/logic/auth/token.py
+++ b/diracx-logic/src/diracx/logic/auth/token.py
@@ -329,31 +329,6 @@ async def exchange_token(
     # Merge the VO with the subject to get a unique DIRAC sub
     sub = f"{vo}:{sub}"
 
-    refresh_payload: RefreshTokenPayload | None = None
-    if include_refresh_token:
-        # Insert the refresh token with user details into the RefreshTokens table
-        # User details are needed to regenerate access tokens later
-        refresh_jti = await insert_refresh_token(
-            auth_db=auth_db,
-            subject=sub,
-            scope=scope,
-            policies=policies or {},
-        )
-
-        # Generate refresh token payload
-        if refresh_token_expire_minutes is None:
-            refresh_token_expire_minutes = settings.refresh_token_expire_minutes
-        refresh_exp = uuid7_to_datetime(refresh_jti) + timedelta(
-            minutes=refresh_token_expire_minutes
-        )
-        refresh_payload = RefreshTokenPayload(
-            jti=str(refresh_jti),
-            exp=refresh_exp,
-            # legacy_exchange is used to indicate that the original refresh token
-            # was obtained from the legacy_exchange endpoint
-            legacy_exchange=legacy_exchange,
-        )
-
     # Generate access token payload
     # For now, the access token is only used to access DIRAC services,
     # therefore, the audience is not set and checked
@@ -380,6 +355,31 @@ async def exchange_token(
         for policy_name, policy in all_access_policies.items():
             if access_extra := policy.enrich_tokens(access_payload):
                 access_payload.dirac_policies[policy_name] = access_extra
+
+    refresh_payload: RefreshTokenPayload | None = None
+    if include_refresh_token:
+        # Insert the refresh token with user details into the RefreshTokens table
+        # User details are needed to regenerate access tokens later
+        refresh_jti = await insert_refresh_token(
+            auth_db=auth_db,
+            subject=sub,
+            scope=scope,
+            policies=access_payload.dirac_policies,
+        )
+
+        # Generate refresh token payload
+        if refresh_token_expire_minutes is None:
+            refresh_token_expire_minutes = settings.refresh_token_expire_minutes
+        refresh_exp = uuid7_to_datetime(refresh_jti) + timedelta(
+            minutes=refresh_token_expire_minutes
+        )
+        refresh_payload = RefreshTokenPayload(
+            jti=str(refresh_jti),
+            exp=refresh_exp,
+            # legacy_exchange is used to indicate that the original refresh token
+            # was obtained from the legacy_exchange endpoint
+            legacy_exchange=legacy_exchange,
+        )
 
     return access_payload, refresh_payload
 

--- a/diracx-logic/src/diracx/logic/auth/token.py
+++ b/diracx-logic/src/diracx/logic/auth/token.py
@@ -6,7 +6,7 @@ import base64
 import hashlib
 import re
 from datetime import datetime, timedelta, timezone
-from typing import cast
+from typing import Any, cast
 
 from joserfc import jwt
 from joserfc.jwt import Claims
@@ -324,6 +324,7 @@ async def exchange_token(
             auth_db=auth_db,
             subject=sub,
             scope=scope,
+            policies={},  # TODO
         )
 
         # Generate refresh token payload
@@ -390,9 +391,7 @@ def _sign_token_payload(claims: dict, settings: AuthSettings) -> str:
 
 
 async def insert_refresh_token(
-    auth_db: AuthDB,
-    subject: str,
-    scope: str,
+    auth_db: AuthDB, subject: str, scope: str, policies: dict[str, Any]
 ) -> UUID:
     """Insert a refresh token into the database and return the JWT ID."""
     # Generate a JWT ID
@@ -400,9 +399,7 @@ async def insert_refresh_token(
 
     # Insert the refresh token into the DB
     await auth_db.insert_refresh_token(
-        jti=jti,
-        subject=subject,
-        scope=scope,
+        jti=jti, subject=subject, scope=scope, policies=policies
     )
     return jti
 

--- a/diracx-logic/src/diracx/logic/auth/token.py
+++ b/diracx-logic/src/diracx/logic/auth/token.py
@@ -55,6 +55,7 @@ async def get_oidc_token(
     legacy_exchange = False
     include_refresh_token = True
     refresh_token_expire_minutes = None
+    policies = None
 
     if grant_type == GrantType.device_code:
         assert device_code is not None
@@ -77,6 +78,7 @@ async def get_oidc_token(
             legacy_exchange,
             refresh_token_expire_minutes,
             include_refresh_token,
+            policies,
         ) = await get_oidc_token_info_from_refresh_flow(
             refresh_token, auth_db, settings
         )
@@ -94,6 +96,7 @@ async def get_oidc_token(
         legacy_exchange=legacy_exchange,
         refresh_token_expire_minutes=refresh_token_expire_minutes,
         include_refresh_token=include_refresh_token,
+        policies=policies,
     )
 
 
@@ -163,7 +166,7 @@ async def get_oidc_token_info_from_authorization_flow(
 
 async def get_oidc_token_info_from_refresh_flow(
     refresh_token: str, auth_db: AuthDB, settings: AuthSettings
-) -> tuple[dict, str, bool, float, bool]:
+) -> tuple[dict, str, bool, float, bool, dict]:
     """Get OIDC token information from the refresh token DB and check few parameters before returning it."""
     # Decode the refresh token to get the JWT ID
     jti, exp, legacy_exchange = await verify_dirac_refresh_token(
@@ -216,12 +219,14 @@ async def get_oidc_token_info_from_refresh_flow(
         "sub": sub.split(":", 1)[1],
     }
     scope = refresh_token_attributes["Scope"]
+    policies = refresh_token_attributes["Policies"]
     return (
         oidc_token_info,
         scope,
         legacy_exchange,
         remaining_minutes,
         include_refresh_token,
+        policies,
     )
 
 
@@ -267,6 +272,7 @@ async def perform_legacy_exchange(
         available_properties,
         refresh_token_expire_minutes=expires_minutes,
         legacy_exchange=True,
+        policies=None,
     )
 
 
@@ -281,6 +287,7 @@ async def exchange_token(
     refresh_token_expire_minutes: float | None = None,
     legacy_exchange: bool = False,
     include_refresh_token: bool = True,
+    policies: dict[str, Any] | None = None,
 ) -> tuple[AccessTokenPayload, RefreshTokenPayload | None]:
     """Exchange the OIDC token for a DIRAC generated access token."""
     # Extract dirac attributes from the OIDC scope
@@ -324,7 +331,7 @@ async def exchange_token(
             auth_db=auth_db,
             subject=sub,
             scope=scope,
-            policies={},  # TODO
+            policies=policies or {},
         )
 
         # Generate refresh token payload
@@ -357,7 +364,7 @@ async def exchange_token(
         preferred_username=preferred_username,
         dirac_group=dirac_group,
         exp=access_exp,
-        dirac_policies={},
+        dirac_policies=policies or {},
     )
 
     return access_payload, refresh_payload

--- a/diracx-logic/src/diracx/logic/auth/token.py
+++ b/diracx-logic/src/diracx/logic/auth/token.py
@@ -30,6 +30,7 @@ from diracx.db.sql import AuthDB
 from diracx.db.sql.auth.schema import FlowStatus, RefreshTokenStatus
 from diracx.db.sql.utils import uuid7_to_datetime
 from diracx.db.sql.utils.functions import substract_date
+from diracx.routers.access_policies import BaseAccessPolicy
 
 from .utils import (
     get_allowed_user_properties,
@@ -45,6 +46,7 @@ async def get_oidc_token(
     config: Config,
     settings: AuthSettings,
     available_properties: set[SecurityProperty],
+    all_access_policies: dict[str, BaseAccessPolicy],
     device_code: str | None = None,
     code: str | None = None,
     redirect_uri: str | None = None,
@@ -93,6 +95,7 @@ async def get_oidc_token(
         config,
         settings,
         available_properties,
+        all_access_policies,
         legacy_exchange=legacy_exchange,
         refresh_token_expire_minutes=refresh_token_expire_minutes,
         include_refresh_token=include_refresh_token,
@@ -245,6 +248,7 @@ async def perform_legacy_exchange(
     available_properties: set[SecurityProperty],
     settings: AuthSettings,
     config: Config,
+    all_access_policies: dict[str, BaseAccessPolicy],
     expires_minutes: float | None = None,
 ) -> tuple[AccessTokenPayload, RefreshTokenPayload | None]:
     """Endpoint used by legacy DIRAC to mint tokens for proxy -> token exchange."""
@@ -270,6 +274,7 @@ async def perform_legacy_exchange(
         config,
         settings,
         available_properties,
+        all_access_policies,
         refresh_token_expire_minutes=expires_minutes,
         legacy_exchange=True,
         policies=None,
@@ -283,6 +288,7 @@ async def exchange_token(
     config: Config,
     settings: AuthSettings,
     available_properties: set[SecurityProperty],
+    all_access_policies: dict[str, BaseAccessPolicy],
     *,
     refresh_token_expire_minutes: float | None = None,
     legacy_exchange: bool = False,
@@ -364,8 +370,16 @@ async def exchange_token(
         preferred_username=preferred_username,
         dirac_group=dirac_group,
         exp=access_exp,
-        dirac_policies=policies or {},
+        dirac_policies={},
     )
+
+    # Enrich the token with policy specific content
+    if policies is not None:
+        access_payload.dirac_policies = policies
+    else:
+        for policy_name, policy in all_access_policies.items():
+            if access_extra := policy.enrich_tokens(access_payload):
+                access_payload.dirac_policies[policy_name] = access_extra
 
     return access_payload, refresh_payload
 

--- a/diracx-logic/src/diracx/logic/auth/token.py
+++ b/diracx-logic/src/diracx/logic/auth/token.py
@@ -338,7 +338,6 @@ async def exchange_token(
             # legacy_exchange is used to indicate that the original refresh token
             # was obtained from the legacy_exchange endpoint
             legacy_exchange=legacy_exchange,
-            dirac_policies={},
         )
 
     # Generate access token payload

--- a/diracx-routers/src/diracx/routers/access_policies.py
+++ b/diracx-routers/src/diracx/routers/access_policies.py
@@ -33,7 +33,6 @@ from fastapi import Depends
 from diracx.core.extensions import DiracEntryPoint, select_from_extension
 from diracx.core.models import (
     AccessTokenPayload,
-    RefreshTokenPayload,
 )
 from diracx.core.settings import DevelopmentSettings
 from diracx.routers.dependencies import auto_inject
@@ -90,18 +89,15 @@ class BaseAccessPolicy(metaclass=ABCMeta):
         return
 
     @staticmethod
-    def enrich_tokens(
-        access_payload: AccessTokenPayload, refresh_payload: RefreshTokenPayload | None
-    ) -> tuple[dict, dict]:
-        """Add content to access or refresh payload when issuing a token.
+    def enrich_tokens(access_payload: AccessTokenPayload) -> dict:
+        """Add content to access payload when issuing a token.
 
-        Content can be whatever is desired inside the access or refresh payload.
+        Content can be whatever is desired inside the access payload.
 
         :param access_payload: access token payload
-        :param refresh_payload: refresh token payload
-        :returns: extra content for both payload
+        :returns: extra content for the access payload
         """
-        return {}, {}
+        return {}
 
 
 @auto_inject

--- a/diracx-routers/src/diracx/routers/auth/token.py
+++ b/diracx-routers/src/diracx/routers/auth/token.py
@@ -53,13 +53,10 @@ async def mint_token(
 
     # Enrich the token with policy specific content
     dirac_access_policies = {}
-    dirac_refresh_policies = {}
     for policy_name, policy in all_access_policies.items():
-        access_extra, refresh_extra = policy.enrich_tokens(access_payload)
+        access_extra = policy.enrich_tokens(access_payload)
         if access_extra:
             dirac_access_policies[policy_name] = access_extra
-        if refresh_extra:
-            dirac_refresh_policies[policy_name] = refresh_extra
 
     # Create the access token
     access_payload.dirac_policies = dirac_access_policies
@@ -67,7 +64,6 @@ async def mint_token(
 
     # Create the refresh token
     if refresh_payload:
-        refresh_payload.dirac_policies = dirac_refresh_policies
         refresh_token = create_token(refresh_payload, settings)
     elif existing_refresh_token:
         refresh_token = existing_refresh_token

--- a/diracx-routers/src/diracx/routers/auth/token.py
+++ b/diracx-routers/src/diracx/routers/auth/token.py
@@ -41,25 +41,15 @@ async def mint_token(
     access_payload: AccessTokenPayload,
     refresh_payload: RefreshTokenPayload | None,
     existing_refresh_token: str | None,
-    all_access_policies: dict[str, BaseAccessPolicy],
     settings: AuthSettings,
 ) -> TokenResponse:
-    """Enrich the token with policy specific content and mint it."""
+    """Mint the token."""
     if not refresh_payload and not existing_refresh_token:
         raise HTTPException(
             status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
             detail="Refresh token is not set and no refresh token was provided",
         )
 
-    # Enrich the token with policy specific content
-    dirac_access_policies = {}
-    for policy_name, policy in all_access_policies.items():
-        access_extra = policy.enrich_tokens(access_payload)
-        if access_extra:
-            dirac_access_policies[policy_name] = access_extra
-
-    # Create the access token
-    access_payload.dirac_policies = dirac_access_policies
     access_token = create_token(access_payload, settings)
 
     # Create the refresh token
@@ -126,6 +116,7 @@ async def get_oidc_token(
             config,
             settings,
             available_properties,
+            all_access_policies,
             device_code=device_code,
             code=code,
             redirect_uri=redirect_uri,
@@ -156,9 +147,7 @@ async def get_oidc_token(
             status_code=HTTPStatus.FORBIDDEN,
             detail=str(e),
         ) from e
-    return await mint_token(
-        access_payload, refresh_payload, refresh_token, all_access_policies, settings
-    )
+    return await mint_token(access_payload, refresh_payload, refresh_token, settings)
 
 
 BASE_64_URL_SAFE_PATTERN = (
@@ -203,6 +192,7 @@ async def perform_legacy_exchange(
             available_properties=available_properties,
             settings=settings,
             config=config,
+            all_access_policies=all_access_policies,
             expires_minutes=expires_minutes,
         )
     except ValueError as e:
@@ -221,6 +211,4 @@ async def perform_legacy_exchange(
             status_code=HTTPStatus.FORBIDDEN,
             detail=str(e),
         ) from e
-    return await mint_token(
-        access_payload, refresh_payload, None, all_access_policies, settings
-    )
+    return await mint_token(access_payload, refresh_payload, None, settings)

--- a/diracx-routers/src/diracx/routers/auth/token.py
+++ b/diracx-routers/src/diracx/routers/auth/token.py
@@ -55,9 +55,7 @@ async def mint_token(
     dirac_access_policies = {}
     dirac_refresh_policies = {}
     for policy_name, policy in all_access_policies.items():
-        access_extra, refresh_extra = policy.enrich_tokens(
-            access_payload, refresh_payload
-        )
+        access_extra, refresh_extra = policy.enrich_tokens(access_payload)
         if access_extra:
             dirac_access_policies[policy_name] = access_extra
         if refresh_extra:

--- a/diracx-routers/tests/auth/test_legacy_exchange.py
+++ b/diracx-routers/tests/auth/test_legacy_exchange.py
@@ -101,12 +101,14 @@ async def test_valid(test_client, legacy_credentials, expires_seconds):
     )
     assert r.status_code == 200
     user_info = r.json()
+
     assert user_info["sub"] == "lhcb:b824d4dc-1f9d-4ee8-8df5-c0ae55d46041"
     assert user_info["vo"] == "lhcb"
     assert user_info["dirac_group"] == "lhcb_user"
     assert sorted(user_info["properties"]) == sorted(
         ["PrivateLimitedDelegation", "NormalUser"]
     )
+    assert user_info["policies"]
 
 
 async def test_refresh_token(test_client, legacy_credentials):

--- a/diracx-routers/tests/auth/test_standard.py
+++ b/diracx-routers/tests/auth/test_standard.py
@@ -1490,3 +1490,54 @@ async def test_do_device_flow_iam_server_error(test_client, monkeypatch):
     r = test_client.get("/api/auth/device", params={"user_code": user_code})
     assert r.status_code == 502
     assert r.json()["detail"] == "IAM error"
+
+
+async def test_access_token_contains_policies(test_client, auth_httpx_mock: HTTPXMock):
+    """Test that dirac_policies exists in the access token after login."""
+    # Get access token
+    access_token = _get_tokens(test_client)["access_token"]
+
+    # Get user infos
+    r = test_client.get(
+        "/api/auth/userinfo", headers={"Authorization": f"Bearer {access_token}"}
+    )
+    assert r.status_code == 200
+    assert r.json()["policies"]
+
+
+async def test_access_token_contains_policies_after_refresh(
+    test_client, auth_httpx_mock: HTTPXMock
+):
+    """Test that dirac_policies are persisted in the access token after refreshing the token."""
+    # Get tokens
+    tokens = _get_tokens(test_client)
+    initial_access_token = tokens["access_token"]
+    initial_refresh_token = tokens["refresh_token"]
+
+    # Retrieve policies
+    r = test_client.get(
+        "/api/auth/userinfo",
+        headers={"Authorization": f"Bearer {initial_access_token}"},
+    )
+    assert r.status_code == 200
+    initial_policies = r.json()["policies"]
+    assert initial_policies
+
+    # Refresh the token
+    r = test_client.post(
+        "/api/auth/token",
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": initial_refresh_token,
+            "client_id": DIRAC_CLIENT_ID,
+        },
+    )
+    assert r.status_code == 200
+    new_access_token = r.json()["access_token"]
+
+    # Check if policies are the same
+    r = test_client.get(
+        "/api/auth/userinfo", headers={"Authorization": f"Bearer {new_access_token}"}
+    )
+    assert r.status_code == 200
+    assert r.json()["policies"] == initial_policies

--- a/diracx-testing/src/diracx/testing/utils.py
+++ b/diracx-testing/src/diracx/testing/utils.py
@@ -46,8 +46,8 @@ from joserfc.jwk import KeySet, OKPKey
 from uuid_utils import uuid7
 
 from diracx.core.extensions import DiracEntryPoint
-from diracx.core.settings import FactorySettings
 from diracx.core.models import AccessTokenPayload
+from diracx.core.settings import FactorySettings
 
 if TYPE_CHECKING:
     from diracx.core.settings import (

--- a/diracx-testing/src/diracx/testing/utils.py
+++ b/diracx-testing/src/diracx/testing/utils.py
@@ -46,8 +46,8 @@ from joserfc.jwk import KeySet, OKPKey
 from uuid_utils import uuid7
 
 from diracx.core.extensions import DiracEntryPoint
-from diracx.core.models import AccessTokenPayload, RefreshTokenPayload
 from diracx.core.settings import FactorySettings
+from diracx.core.models import AccessTokenPayload
 
 if TYPE_CHECKING:
     from diracx.core.settings import (
@@ -199,11 +199,8 @@ class ClientFactory:
                 pass
 
             @staticmethod
-            def enrich_tokens(
-                access_payload: AccessTokenPayload,
-                refresh_payload: RefreshTokenPayload | None,
-            ):
-                return {"PolicySpecific": "OpenAccessForTest"}, {}
+            def enrich_tokens(access_payload: AccessTokenPayload):
+                return {"PolicySpecific": "OpenAccessForTest"}
 
         enabled_systems = {
             e.name for e in select_from_extension(group=DiracEntryPoint.SERVICES)


### PR DESCRIPTION
## Closes: #524 

### Changes:

- Moved the `dirac_policies` from `TokenPayload` to `RefreshTokensPayload` and  `AccessTokenPayload`. 
**Later, this should be removed from `RefreshTokensPayload`**.

- `RefreshTokens` now has a `policies` column. 
**Manual updates to the already existing DBTable is needed: `ALTER TABLE RefreshTokens ADD COLUMN Policies JSON`. It should add NULL by default for existing values.**

- `Policies` are added from `all_access_policies` in the `exchange_token` function if no policies were found in the DB (e.g, new `RefreshToken`). Otherwise, they are taken from the DB to create a new `AccessTokenPayload`.

- `mint_token` function doesn't need to enrich the token anymore since the payloads already have the policies inside them, from `exchange_token` function.

- `enrich_token` function now takes only the `AccessTokenPayload` and returns one dict with the policies values.