### PR TITLE
chore: add a badge for diracx-cert update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![DiracX tests](https://github.com/DIRACGrid/diracx/actions/workflows/main.yml/badge.svg?branch=main)
 ![Legacy tests](https://github.com/DIRACGrid/diracx/actions/workflows/integration.yml/badge.svg?branch=main)
 ![DiracX deployment](https://github.com/DIRACGrid/diracx/actions/workflows/deployment.yml/badge.svg?branch=main)
+![DiracX certification setup](http://lbcertifdirac70.cern.ch/pilot/last_diracx_update.svg)
 
 # DiracX
 


### PR DESCRIPTION
This reads a badge generated on the dirac certification machine, stating the deployment status of diracx cert