### PR TITLE
fix: from minio to seaweedfs

### DIFF
--- a/diracx-cli/src/diracx/cli/internal/legacy.py
+++ b/diracx-cli/src/diracx/cli/internal/legacy.py
@@ -197,7 +197,7 @@ def generate_helm_values(
         "initSql": {"enabled": False},
         "cert-manager": {"enabled": False},
         "cert-manager-issuer": {"enabled": False},
-        "minio": {"enabled": False},
+        "seaweedfs": {"enabled": False},
         "dex": {"enabled": False},
         "opensearch": {"enabled": False},
         # This is Openshift specific, change it maybe

--- a/diracx-core/tests/test_s3.py
+++ b/diracx-core/tests/test_s3.py
@@ -73,7 +73,7 @@ async def test_s3_object_exists(moto_s3):
 async def test_presigned_upload_moto(moto_s3):
     """Test the presigned upload with moto.
 
-    This doesn't actually test the signature, see test_presigned_upload_minio
+    This doesn't actually test the signature, see test_presigned_upload_seaweedfs
     """
     file_content, checksum = _random_file(128)
     key = f"{checksum}.dat"
@@ -104,10 +104,10 @@ async def test_presigned_upload_moto(moto_s3):
 
 
 @pytest.fixture(scope="function")
-async def minio_client(demo_urls):
-    """Create a S3 client that uses minio from the demo as backend."""
+async def seaweedfs_client(demo_urls):
+    """Create a S3 client that uses seaweedfs from the demo as backend."""
     async with AsyncClient(
-        endpoint_url=demo_urls["minio"],
+        endpoint_url=demo_urls["seaweedfs"],
         aws_access_key_id="console",
         aws_secret_access_key="console123",
     ) as client:
@@ -115,20 +115,20 @@ async def minio_client(demo_urls):
 
 
 @pytest.fixture(scope="function")
-async def test_bucket(minio_client):
+async def test_bucket(seaweedfs_client):
     """Create a test bucket that is cleaned up after the test session."""
     bucket_name = f"dirac-test-{secrets.token_hex(8)}"
-    await minio_client.create_bucket(Bucket=bucket_name)
+    await seaweedfs_client.create_bucket(Bucket=bucket_name)
     yield bucket_name
-    objects = await minio_client.list_objects(Bucket=bucket_name)
+    objects = await seaweedfs_client.list_objects(Bucket=bucket_name)
     contents = objects.get("Contents", [])
     if contents:
-        await minio_client.delete_objects(
+        await seaweedfs_client.delete_objects(
             Bucket=bucket_name,
             Delete={"Objects": [{"Key": obj["Key"]} for obj in contents]},
         )
 
-    await minio_client.delete_bucket(Bucket=bucket_name)
+    await seaweedfs_client.delete_bucket(Bucket=bucket_name)
 
 
 @pytest.mark.parametrize(
@@ -140,28 +140,29 @@ async def test_bucket(minio_client):
         pytest.param(*_random_file(128), 127, "exceeds the maximum", id="maximum"),
         pytest.param(*_random_file(128), 129, "smaller than the minimum", id="minimum"),
         # Check with invalid checksum
+        # Warning: each s3 software has its own mismatch message!
         pytest.param(
             _random_file(128)[0],
             _random_file(128)[1],
             128,
-            "ContentChecksumMismatch",
+            "The Content-Md5 you specified did not match what we received",
             id="checksum",
         ),
     ],
 )
-async def test_presigned_upload_minio(
-    minio_client, test_bucket, content, checksum, size, expected_error
+async def test_presigned_upload_seaweedfs(
+    seaweedfs_client, test_bucket, content, checksum, size, expected_error
 ):
-    """Test the presigned upload with Minio.
+    """Test the presigned upload with seaweedfs.
 
     This is a more complete test that checks that the presigned upload works
-    and is properly validated by Minio. This is not possible with moto as it
+    and is properly validated by seaweedfs. This is not possible with moto as it
     doesn't actually validate the signature.
     """
     key = f"{checksum}.dat"
     # Prepare the signed URL
     upload_info = await generate_presigned_upload(
-        minio_client, test_bucket, key, "sha256", checksum, size, 60
+        seaweedfs_client, test_bucket, key, "sha256", checksum, size, 60
     )
     # Ensure the URL doesn't work
     async with httpx2.AsyncClient() as client:
@@ -171,8 +172,8 @@ async def test_presigned_upload_minio(
 
     if expected_error is None:
         assert r.status_code == 204, r.text
-        assert await s3_object_exists(minio_client, test_bucket, key)
+        assert await s3_object_exists(seaweedfs_client, test_bucket, key)
     else:
         assert r.status_code == 400, r.text
         assert expected_error in r.text
-        assert not (await s3_object_exists(minio_client, test_bucket, key))
+        assert not (await s3_object_exists(seaweedfs_client, test_bucket, key))

--- a/diracx-testing/src/diracx/testing/scripts/collect_demo_coverage.sh
+++ b/diracx-testing/src/diracx/testing/scripts/collect_demo_coverage.sh
@@ -98,7 +98,7 @@ fi
 
 # Shutdown the pods so we collect coverage data
 pods=$(kubectl get pods -o json | jq -r '.items[] | .metadata.name')
-for pod_name in $(echo "${pods}" | grep -vE '(dex|minio|mysql|rabbitmq|opensearch)'); do
+for pod_name in $(echo "${pods}" | grep -vE '(dex|seaweedfs|mysql|rabbitmq|opensearch)'); do
     kubectl delete pod/"${pod_name}"
 done
 


### PR DESCRIPTION
Move from MinIO to Seaweedfs. This should unlock s3 testing part
Modify test_s3.py in order to fit diracx-charts new seaweedfs config (values.yaml)
With Minio, the checksum test was waiting for a clear error word "ContentChecksumMismatch" which is not the case for seaweedfs where we have now a sentence like "The Content-Md5 you specified did not match what we received"
So for the moment the test is expected this exact sentence, maybe it's too long...? Tell me.
We have to pay attention in case this sentence changes in the future releases of seaweedfs and also if we need to move again to another s3 software