### PR TITLE
fix: minor fixes to the advanced tutorial

### DIFF
--- a/docs/dev/tutorials/advanced-tutorial/index.md
+++ b/docs/dev/tutorials/advanced-tutorial/index.md
@@ -37,6 +37,7 @@ git checkout -b my-tutorial # clean starting point
 pixi run tutorial-reset    # strips tutorial code from gubbins
 pixi run pre-commit run --all-files
 git add extensions/gubbins/
+git add extensions/gubbins-charts/
 git commit -m "docs: Reset tutorial code"
 ```
 

--- a/docs/dev/tutorials/advanced-tutorial/router.md
+++ b/docs/dev/tutorials/advanced-tutorial/router.md
@@ -63,13 +63,13 @@ For the full guide on building routes, see
 
 ## Register entry points
 
-Service entry point:
+Service entry point (add under `[project.entry-points."diracx.services"]`):
 
 ```toml title="gubbins-routers/pyproject.toml"
 --8<-- "extensions/gubbins/gubbins-routers/pyproject.toml:my_pilots_service_entry_point"
 ```
 
-Access policy entry point:
+Access policy entry point (add under `[project.entry-points."diracx.access_policies"]`):
 
 ```toml title="gubbins-routers/pyproject.toml"
 --8<-- "extensions/gubbins/gubbins-routers/pyproject.toml:my_pilots_access_policy_entry_point"

--- a/scripts/tutorial_reset.py
+++ b/scripts/tutorial_reset.py
@@ -18,6 +18,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 TUTORIAL_PATHS = [
     "extensions/gubbins/gubbins-db/src/gubbins/db/sql/my_pilot_db",
     "extensions/gubbins/gubbins-db/tests/test_my_pilot_db.py",
+    "extensions/gubbins/gubbins-logic/src/gubbins/logic/my_pilots.py",
     "extensions/gubbins/gubbins-tasks/src/gubbins/tasks/my_pilots.py",
     "extensions/gubbins/gubbins-tasks/src/gubbins/tasks/my_pilot_lock_types.py",
     "extensions/gubbins/gubbins-tasks/tests/test_my_pilot_tasks.py",


### PR DESCRIPTION
### PR Description
While going through the [Advanced Tutorial](https://diracx.diracgrid.org/en/latest/dev/tutorials/advanced-tutorial/) I noticed a few of minor inconsistencies which I'm fixing in this PR, specifically:
- one minor clarification in the advanced tutorial docs
- one missing `git add` in the setup instructions
- one file which was not being cleaned by the `pixi run tutorial-reset` command

#### Note:
Technically there is another file that should be updated in this same scope, here:
https://github.com/DIRACGrid/diracx/blob/19cb080cb266210237fab4a2a4733db19e382644/extensions/gubbins/gubbins-logic/pyproject.toml#L16-L19
Which should be changed to
```diff
diff --git a/extensions/gubbins/gubbins-logic/pyproject.toml b/extensions/gubbins/gubbins-logic/pyproject.toml
index 4f7c9a3..f484fbf 100644
--- a/extensions/gubbins/gubbins-logic/pyproject.toml
+++ b/extensions/gubbins/gubbins-logic/pyproject.toml
@@ -15,7 +15,9 @@ classifiers = [
 
 dependencies = [
     "diracx-logic",
+    # --8<-- [start:my_pilots_logic_dependencies]
     "gubbins-db",
+    # --8<-- [end:my_pilots_logic_dependencies]
 ]
```
so that the `"gubbins-db",` line is also cleaned up by the `pixi run tutorial-reset` command (part of the exercise is to re-add this line later on in the tutorial).

Unfortunately when this toml file is changed, the `pixi install` command (invoked by `pixi run pre-commit run --all-files` ) modifies the `pixi.lock` file, which is not an intended change, and I'm too new to the project to know how to handle that exactly. 😄 

### PR Validation
- I've re-run the Advanced Tutorial with the changes proposed in this PR and it works fine.
- I've run `pixi run test-tutorial` successfully
