### PR TITLE
docs: modify rest style comments with doc convert to follow google style.

### DIFF
--- a/diracx-core/src/diracx/core/sources.py
+++ b/diracx-core/src/diracx/core/sources.py
@@ -80,22 +80,14 @@ class CacheableSource(Generic[T], metaclass=ABCMeta):
         """
 
     def read(self) -> T:
-        """Load the source from the backend with appropriate caching.
-
-        :raises: diracx.core.exceptions.NotReadyError if the source is being loaded still
-        :raises: git.exc.BadName if version does not exist
-        """
+        """Load the source from the backend with appropriate caching."""
         hexsha = self._revision_cache.get(
             "latest_revision", self._read_work, blocking=True
         )
         return self._content_cache[hexsha]
 
     async def read_non_blocking(self) -> T:
-        """Load the source from the backend with appropriate caching.
-
-        :raises: diracx.core.exceptions.NotReadyError if the source is being loaded still
-        :raises: git.exc.BadName if version does not exist
-        """
+        """Load the source from the backend with appropriate caching."""
         hexsha = self._revision_cache.get(
             "latest_revision", self._read_work, blocking=False
         )

--- a/diracx-db/src/diracx/db/sql/auth/db.py
+++ b/diracx-db/src/diracx/db/sql/auth/db.py
@@ -160,7 +160,7 @@ class AuthDB(BaseSQLDB):
         Returns the scope field for the given user_code
 
         Raises:
-            NoResultFound if no such user code currently Pending
+            NoResultFound: if no such user code currently Pending
         """
         stmt = select(DeviceFlows.scope).where(
             DeviceFlows.user_code == user_code,
@@ -271,9 +271,10 @@ class AuthDB(BaseSQLDB):
     async def authorization_flow_insert_id_token(
         self, uuid: str, id_token: dict[str, str], max_validity: int
     ) -> tuple[str, str]:
-        """Return code, redirect_uri.
+        """Return the authorization code and redirect URI.
 
-        Raises: AuthorizationError if no such uuid or status not pending.
+        Raises:
+            AuthorizationError: If no such UUID exists or the flow is not pending.
         """
         # Hash the code to avoid leaking information
         code = secrets.token_urlsafe()

--- a/diracx-db/src/diracx/db/sql/auth/db.py
+++ b/diracx-db/src/diracx/db/sql/auth/db.py
@@ -159,7 +159,7 @@ class AuthDB(BaseSQLDB):
 
         Returns the scope field for the given user_code
 
-        :raises:
+        Raises:
             NoResultFound if no such user code currently Pending
         """
         stmt = select(DeviceFlows.scope).where(
@@ -273,7 +273,7 @@ class AuthDB(BaseSQLDB):
     ) -> tuple[str, str]:
         """Return code, redirect_uri.
 
-        :raises: AuthorizationError if no such uuid or status not pending.
+        Raises: AuthorizationError if no such uuid or status not pending.
         """
         # Hash the code to avoid leaking information
         code = secrets.token_urlsafe()

--- a/diracx-db/src/diracx/db/sql/job/db.py
+++ b/diracx-db/src/diracx/db/sql/job/db.py
@@ -205,7 +205,7 @@ class JobDB(BaseSQLDB):
             update_timestamp: if True, update the LastUpdate to now
 
         Returns:
-          rowcount
+            rowcount
 
         """
         # Check that all we always update the same set of properties

--- a/diracx-db/src/diracx/db/sql/job/db.py
+++ b/diracx-db/src/diracx/db/sql/job/db.py
@@ -200,10 +200,12 @@ class JobDB(BaseSQLDB):
 
         All the jobs must update the same properties.
 
-        :param properties: {job_id : {prop1: val1, prop2:val2}
-        :param update_timestamp: if True, update the LastUpdate to now
+        Args:
+            properties: {job_id : {prop1: val1, prop2:val2}
+            update_timestamp: if True, update the LastUpdate to now
 
-        :return rowcount
+        Returns:
+          rowcount
 
         """
         # Check that all we always update the same set of properties
@@ -238,9 +240,10 @@ class JobDB(BaseSQLDB):
         This is instead handled by the `diracx.logic.jobs.status.set_job_statuses`
         as it involves updating multiple databases.
 
-        :param job_id: the job id
-        :param dynamic_data: mapping of the dynamic data to store,
-            e.g. {"AvailableDiskSpace": 123}
+        Args:
+            job_id: the job id
+            dynamic_data: mapping of the dynamic data to store, e.g.
+                {"AvailableDiskSpace": 123}
         """
         if extra_fields := set(dynamic_data) - self.heartbeat_fields:
             raise InvalidQueryError(
@@ -261,8 +264,11 @@ class JobDB(BaseSQLDB):
     async def get_job_commands(self, job_ids: Iterable[int]) -> list[JobCommand]:
         """Get a command to be passed to the job together with the next heartbeat.
 
-        :param job_ids: the job ids
-        :return: mapping of job id to list of commands
+        Args:
+            job_ids: the job ids
+
+        Returns:
+            mapping of job id to list of commands
         """
         # Get the commands
         stmt = (

--- a/diracx-logic/src/diracx/logic/auth/utils.py
+++ b/diracx-logic/src/diracx/logic/auth/utils.py
@@ -244,7 +244,7 @@ def parse_and_validate_scope(
     return dict with group and properties.
 
     Raises:
-        * ValueError in case the scope isn't valid
+        ValueError: in case the scope isn't valid
     """
     scopes = set(scope.split(" "))
 

--- a/diracx-logic/src/diracx/logic/auth/utils.py
+++ b/diracx-logic/src/diracx/logic/auth/utils.py
@@ -243,7 +243,7 @@ def parse_and_validate_scope(
         * properties are known
     return dict with group and properties.
 
-    :raises:
+    Raises:
         * ValueError in case the scope isn't valid
     """
     scopes = set(scope.split(" "))

--- a/diracx-logic/src/diracx/logic/jobs/status.py
+++ b/diracx-logic/src/diracx/logic/jobs/status.py
@@ -104,7 +104,7 @@ async def set_job_statuses(
     as a key and status information dictionary as values.
 
     Raises:
-      JobNotFound if the job is not found in one of the DBs
+        JobNotFound: if the job is not found in one of the DBs
     """
     # check that the datetime contains timezone info
     for job_id, status in status_changes.items():

--- a/diracx-logic/src/diracx/logic/jobs/status.py
+++ b/diracx-logic/src/diracx/logic/jobs/status.py
@@ -103,7 +103,8 @@ async def set_job_statuses(
     logging information in the JobLoggingDB. The status dict has datetime
     as a key and status information dictionary as values.
 
-    :raises: JobNotFound if the job is not found in one of the DBs
+    Raises:
+      JobNotFound if the job is not found in one of the DBs
     """
     # check that the datetime contains timezone info
     for job_id, status in status_changes.items():

--- a/diracx-logic/src/diracx/logic/task_queues/priority.py
+++ b/diracx-logic/src/diracx/logic/task_queues/priority.py
@@ -99,11 +99,15 @@ async def calculate_priority(
 ) -> dict[float, list[int]]:
     """Calculate the priority for each TQ given a share.
 
-    :param tq_dict: dict of {tq_id: prio}
-    :param all_tqs_data: dict of {tq_id: {tq_data}}, where tq_data is a dict of {field: value}
-    :param share: share to be distributed among TQs
-    :param allow_bg_tqs: allow background TQs to be used
-    :return: dict of {priority: [tq_ids]}
+    Args:
+        tq_dict: dict of {tq_id: prio}
+        all_tqs_data: dict of {tq_id: {tq_data}}, where tq_data is a
+            dict of {field: value}
+        share: share to be distributed among TQs
+        allow_bg_tqs: allow background TQs to be used
+
+    Returns:
+        dict of {priority: [tq_ids]}
     """
 
     def is_background(tq_priority: float, allow_bg_tqs: bool) -> bool:

--- a/diracx-routers/src/diracx/routers/access_policies.py
+++ b/diracx-routers/src/diracx/routers/access_policies.py
@@ -9,7 +9,6 @@ Each route should either:
 * have the open_access decorator to make explicit that it does not implement policy
 * have a callable and call it that will perform the access policy
 
-
 Adding a new policy:
 1. Create a class that inherits from BaseAccessPolicy and implement the ``policy`` and ``enrich_tokens`` methods
 2. create an entry in diracx.access_policy entrypoints
@@ -97,9 +96,12 @@ class BaseAccessPolicy(metaclass=ABCMeta):
 
         Content can be whatever is desired inside the access or refresh payload.
 
-        :param access_payload: access token payload
-        :param refresh_payload: refresh token payload
-        :returns: extra content for both payload
+        Args:
+            access_payload: access token payload
+            refresh_payload: refresh token payload
+
+        Returns:
+            extra content for both payload
         """
         return {}, {}
 

--- a/diracx-routers/src/diracx/routers/factory.py
+++ b/diracx-routers/src/diracx/routers/factory.py
@@ -115,21 +115,17 @@ def create_app_inner(
     the actual behavior we are interested in for settings, DBs or policy.
     This allows an extension to override any of these components
 
-
-    :param enabled_system:
-         this contains the name of all the routers we have to load
-    :param all_service_settings:
-        list of instance of each Settings type required
-    :param database_urls:
-        dict <db_name: url>. When testing, sqlite urls are used
-    :param os_database_conn_kwargs:
-        <db_name:dict> containing all the parameters the OpenSearch client takes
-    :param config_source:
-        Source of the configuration to use
-    :param all_access_policies:
-        <policy_name: [implementations]>
-
-
+    Args:
+        enabled_systems: this contains the name of all the routers we
+            have to load
+        all_service_settings: list of instance of each Settings type
+            required
+        database_urls: dict <db_name: url>. When testing, sqlite urls
+            are used
+        os_database_conn_kwargs: <db_name:dict> containing all the
+            parameters the OpenSearch client takes
+        config_source: Source of the configuration to use
+        all_access_policies: <policy_name: [implementations]>
     """
     app = DiracFastAPI()
 

--- a/extensions/gubbins/gubbins-cli/src/gubbins/cli/config.py
+++ b/extensions/gubbins/gubbins-cli/src/gubbins/cli/config.py
@@ -1,6 +1,4 @@
-"""
-This just shows how to extend and modify an existing CLI
-"""
+"""This just shows how to extend and modify an existing CLI"""
 
 # In order to extend it, just import the app from DiracX
 from __future__ import annotations
@@ -12,9 +10,7 @@ from diracx.cli.config import app
 
 @app.async_command()
 async def gubbins_extra():
-    """
-    Add an extra command
-    """
+    """Add an extra command"""
     print("Adding something extra")
 
 

--- a/extensions/gubbins/gubbins-cli/src/gubbins/cli/lollygag.py
+++ b/extensions/gubbins/gubbins-cli/src/gubbins/cli/lollygag.py
@@ -1,6 +1,4 @@
-"""
-This shows how to create a new subcommand
-"""
+"""This shows how to create a new subcommand"""
 
 from __future__ import annotations
 
@@ -15,16 +13,13 @@ app = AsyncTyper()
 
 @app.command()
 def hello():
-    """
-    This is just to make sure that the CLI extension mechanism works
-    """
+    """This is just to make sure that the CLI extension mechanism works"""
     print("Shagadelic, Baby!")
 
 
 @app.async_command()
 async def get_owners():
-    """
-    This makes a proper use of the AsyncGubbinsClient to call
+    """This makes a proper use of the AsyncGubbinsClient to call
     a method specific to Gubbins
     """
     async with AsyncGubbinsClient() as api:
@@ -34,9 +29,7 @@ async def get_owners():
 
 @app.async_command()
 async def sensei():
-    """
-    This function is only here to test the GUBBINS_SENSEI property
-    """
+    """This function is only here to test the GUBBINS_SENSEI property"""
     async with AsyncGubbinsClient() as api:
         secrets = await api.lollygag.get_gubbins_secrets()
         print(secrets)

--- a/extensions/gubbins/gubbins-db/src/gubbins/db/sql/jobs/db.py
+++ b/extensions/gubbins/gubbins-db/src/gubbins/db/sql/jobs/db.py
@@ -7,8 +7,7 @@ from .schema import GubbinsInfo, JobDBBase
 
 
 class GubbinsJobDB(JobDB):
-    """
-    This DB extends the diracx JobDB.
+    """This DB extends the diracx JobDB.
     All methods from the parent DB are accessible
 
     """
@@ -16,17 +15,14 @@ class GubbinsJobDB(JobDB):
     metadata = JobDBBase.metadata
 
     async def insert_gubbins_info(self, job_id: int, info: str):
-        """
-        This is a new method that makes use of a new table.
-        """
+        """This is a new method that makes use of a new table."""
         stmt = insert(GubbinsInfo).values(job_id=job_id, info=info)
         await self.conn.execute(stmt)
 
     async def get_job_jdls(  # type: ignore[override]
         self, job_ids, original: bool = False, with_info=False
     ) -> dict:
-        """
-        This method modifies the one in the parent class:
+        """This method modifies the one in the parent class:
         * adds an extra argument
         * changes the return type
 
@@ -50,8 +46,7 @@ class GubbinsJobDB(JobDB):
         return result
 
     async def set_job_attributes(self, job_data):
-        """
-        This method modified the one in the parent class,
+        """This method modified the one in the parent class,
         without changing the argument nor the return type
 
         Also, this method is called by the router via the status_utility

--- a/extensions/gubbins/gubbins-db/src/gubbins/db/sql/lollygag/db.py
+++ b/extensions/gubbins/gubbins-db/src/gubbins/db/sql/lollygag/db.py
@@ -9,8 +9,7 @@ from .schema import Cars, Owners
 
 
 class LollygagDB(BaseSQLDB):
-    """
-    This LollygagDB is just to illustrate some important aspect of writing
+    """This LollygagDB is just to illustrate some important aspect of writing
     DB classes in DiracX.
 
     It is mostly pure SQLAlchemy, with a few convention

--- a/extensions/gubbins/gubbins-routers/src/gubbins/routers/lollygag/access_policy.py
+++ b/extensions/gubbins/gubbins-routers/src/gubbins/routers/lollygag/access_policy.py
@@ -1,5 +1,4 @@
-"""
-Lollygag dummy AccessPolicy
+"""Lollygag dummy AccessPolicy
 Makes sure we can use Gubbins specific property
 
 """

--- a/extensions/gubbins/gubbins-routers/src/gubbins/routers/lollygag/lollygag.py
+++ b/extensions/gubbins/gubbins-routers/src/gubbins/routers/lollygag/lollygag.py
@@ -1,5 +1,4 @@
-"""
-This router makes use of the new LollygagDB.
+"""This router makes use of the new LollygagDB.
 It uses the the Lollygag AccessPolicy (which itself requires the Gubbins property)
 """
 

--- a/extensions/gubbins/gubbins-routers/src/gubbins/routers/well_known.py
+++ b/extensions/gubbins/gubbins-routers/src/gubbins/routers/well_known.py
@@ -1,5 +1,4 @@
-"""
-Illustrate how to extend/overwrite a diracx router.
+"""Illustrate how to extend/overwrite a diracx router.
 It :
 * changes slightly the return type
 * uses the Gubbins specific configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,8 @@ max-line-length = 120
 [tool.ruff.format]
 docstring-code-format = true
 
+[tool.ruff.lint.pydocstyle]
+convention = "google"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
A minimal change, only convert rest style comments to google style comments. Don't modify comments themselves, when possible. Fixes #927 