### PR TITLE
fix!: make redis a mandatory parameter of task_wrapper

### DIFF
--- a/diracx-tasks/src/diracx/tasks/plumbing/factory.py
+++ b/diracx-tasks/src/diracx/tasks/plumbing/factory.py
@@ -59,7 +59,7 @@ async def _lock_watchdog(
 async def task_wrapper(  # noqa: D417
     cls: type[BaseTask],
     *args: Any,
-    _redis: LockCoordinator | None = None,
+    _redis: LockCoordinator,
     _interactive: bool = False,
     **kwargs: Any,
 ) -> Any:
@@ -70,8 +70,7 @@ async def task_wrapper(  # noqa: D417
 
     Parameters
     ----------
-        _redis: Redis connection for lock acquisition. When None, locks
-            are skipped with a warning.
+        _redis: Redis connection for lock acquisition.
         _interactive: When True, ``BaseLimiter`` subclasses (rate limiters,
             concurrency limiters) are skipped entirely — only hard locks
             (mutex, RW) are acquired.
@@ -84,10 +83,6 @@ async def task_wrapper(  # noqa: D417
         for lock in task.execution_locks:
             # In interactive mode, skip limiters entirely
             if _interactive and isinstance(lock, BaseLimiter):
-                continue
-
-            if _redis is None:
-                logger.warning("No Redis connection — skipping lock %s", lock.redis_key)
                 continue
 
             acquired = await lock.acquire(_redis)

--- a/diracx-tasks/src/diracx/tasks/task_run.py
+++ b/diracx-tasks/src/diracx/tasks/task_run.py
@@ -22,6 +22,8 @@ import traceback
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Iterable
 
+from redis.asyncio import Redis
+
 from diracx.core.settings import FactorySettings
 
 if TYPE_CHECKING:
@@ -314,8 +316,8 @@ async def call_task(
     """Execute a task interactively (no broker).
 
     Uses ``task_wrapper`` with ``_interactive=True`` so that structural
-    locks (Mutex, RW) are acquired when Redis is available, while
-    limiters (rate/concurrency) are skipped.
+    locks (Mutex, RW) are acquired, while limiters (rate/concurrency)
+    are skipped.
 
     Dependency injection (databases, config, settings) is resolved
     automatically from environment variables via
@@ -337,13 +339,8 @@ async def call_task(
         print(f"Task {entry_point!r} not found. Available: {sorted(registry)}")
         sys.exit(1)
 
-    # Try to connect to Redis for lock acquisition
-    redis: LockCoordinator | None = None
-    redis_url = _factory_settings.tasks_redis_url
-    if redis_url:
-        from redis.asyncio import Redis
-
-        redis = Redis.from_url(redis_url)
+    # Connect to Redis for lock acquisition
+    redis: LockCoordinator = Redis.from_url(_factory_settings.tasks_redis_url)
 
     wrapped = wrap_task(task_cls)
 
@@ -388,5 +385,4 @@ async def call_task(
             pdb.post_mortem(traceback_info[2])
         finally:
             await async_exit_stack.aclose()
-            if redis is not None:
-                await redis.aclose()
+            await redis.aclose()

--- a/diracx-tasks/tests/test_task_wrapper.py
+++ b/diracx-tasks/tests/test_task_wrapper.py
@@ -17,12 +17,6 @@ from diracx.tasks.plumbing.locks import BaseLock, MutexLock, RateLimiter
 from .conftest import LockedTask
 
 
-async def test_task_wrapper_no_redis_skips_locks():
-    """When _redis is None, locks should be skipped with a warning."""
-    result = await task_wrapper(LockedTask, _redis=None)
-    assert result == "locked_ok"
-
-
 async def test_task_wrapper_with_redis_acquires_locks():
     """When _redis is provided, locks should be acquired."""
     mock_redis = AsyncMock()

--- a/diracx-tasks/tests/test_task_wrapper.py
+++ b/diracx-tasks/tests/test_task_wrapper.py
@@ -17,6 +17,12 @@ from diracx.tasks.plumbing.locks import BaseLock, MutexLock, RateLimiter
 from .conftest import LockedTask
 
 
+async def test_task_wrapper_requires_redis():
+    """_redis has no default — omitting it must fail before any task code runs."""
+    with pytest.raises(TypeError, match="_redis"):
+        await task_wrapper(LockedTask)  # type: ignore[call-arg]
+
+
 async def test_task_wrapper_with_redis_acquires_locks():
     """When _redis is provided, locks should be acquired."""
     mock_redis = AsyncMock()


### PR DESCRIPTION
Closes #973

Makes `_redis` a required keyword-only parameter of `task_wrapper` and removes the dead None-skip branch. `call_task()` now always opens a real Redis connection instead of conditionally leaving it unset.

**Breaking:** `task_wrapper` (exported from `diracx.tasks.plumbing`) now requires `_redis`; callers relying on the old `None` default will get a `TypeError`.