### PR TITLE
feat(tasks): support both diracx-tasks and diracx-task-run (phase 1, #975)

### DIFF
--- a/diracx-tasks/pyproject.toml
+++ b/diracx-tasks/pyproject.toml
@@ -30,6 +30,7 @@ dynamic = ["version"]
 testing = ["diracx-testing", "fakeredis"]
 
 [project.scripts]
+diracx-tasks = "diracx.tasks.task_run:main"
 diracx-task-run = "diracx.tasks.task_run:main"
 
 [project.entry-points."diracx.dbs.sql"]

--- a/diracx-tasks/src/diracx/tasks/task_run.py
+++ b/diracx-tasks/src/diracx/tasks/task_run.py
@@ -1,10 +1,13 @@
 """CLI entry point for interactive task execution.
 
 Usage:
-    diracx-task-run call <entry_point> [--args JSON] [--kwargs JSON] [--debugger {none,before,exception}]
-    diracx-task-run submit <entry_point> [--args JSON] [--kwargs JSON] [--redis-url URL]
-    diracx-task-run worker [--max-concurrent-tasks N] [--redis-url URL]
-    diracx-task-run scheduler [--redis-url URL]
+    diracx-tasks call <entry_point> [--args JSON] [--kwargs JSON] [--debugger {none,before,exception}]
+    diracx-tasks submit <entry_point> [--args JSON] [--kwargs JSON] [--redis-url URL]
+    diracx-tasks worker [--max-concurrent-tasks N] [--redis-url URL]
+    diracx-tasks scheduler [--redis-url URL]
+
+Backward-compatible alias:
+    diracx-task-run <subcommand> [...]
 """
 
 from __future__ import annotations

--- a/docs/admin/explanations/tasks.md
+++ b/docs/admin/explanations/tasks.md
@@ -4,7 +4,7 @@ This page explains the DiracX task system from an operational perspective. For t
 
 ## Task lifecycle
 
-1. A task is **submitted** — either by application code, the scheduler (for periodic tasks), or the CLI (`diracx-task-run call`)
+1. A task is **submitted** — either by application code, the scheduler (for periodic tasks), or the CLI (`diracx-tasks call`)
 2. The broker places it on one of **nine Redis Streams**, selected by the task's priority (realtime, normal, background) and size (small, medium, large)
 3. A **worker** picks up the message from the stream, consuming in strict priority order (realtime first)
 4. The worker **acquires locks** required by the task (mutex, RW, limiters). If a lock cannot be acquired, the task is rescheduled with a short delay

--- a/docs/admin/how-to/tasks/configure.md
+++ b/docs/admin/how-to/tasks/configure.md
@@ -15,7 +15,7 @@ If unset, defaults to `redis://localhost`.
 Workers consume tasks from the broker and execute them:
 
 ```bash
-diracx-task-run worker --redis-url redis://redis-host:6379 --max-concurrent-tasks 10
+diracx-tasks worker --redis-url redis://redis-host:6379 --max-concurrent-tasks 10
 ```
 
 - **`--max-concurrent-tasks`**: maximum number of tasks a worker runs concurrently (default: 10). Tune based on whether tasks are I/O-bound (higher) or CPU-bound (lower).
@@ -28,8 +28,10 @@ Workers consume tasks from the three priority streams for their configured size 
 The scheduler is a singleton process responsible for submitting periodic tasks and promoting delayed tasks:
 
 ```bash
-diracx-task-run scheduler --redis-url redis://redis-host:6379
+diracx-tasks scheduler --redis-url redis://redis-host:6379
 ```
+
+`diracx-task-run` remains supported as a backward-compatible alias during migration.
 
 Only one scheduler instance should run at a time. This is enforced by a Redis mutex — if a second scheduler starts, it will wait for the first to release the lock before taking over.
 

--- a/docs/admin/how-to/tasks/run-task-manually.md
+++ b/docs/admin/how-to/tasks/run-task-manually.md
@@ -1,17 +1,19 @@
 # Run a task manually
 
-The `diracx-task-run call` command executes a single task interactively, bypassing the broker. This is useful for debugging, manual recovery, and verifying task behaviour.
+The `diracx-tasks call` command executes a single task interactively, bypassing the broker. This is useful for debugging, manual recovery, and verifying task behaviour.
+
+`diracx-task-run` remains supported as a backward-compatible alias during migration.
 
 ## Basic usage
 
 ```bash
-diracx-task-run call <entry_point> --args '<JSON list>'
+diracx-tasks call <entry_point> --args '<JSON list>'
 ```
 
 The entry point name is `<category>:<ClassName>` as registered in `pyproject.toml`. For example:
 
 ```bash
-diracx-task-run call lollygag:SyncOwnersTask --args '["alice"]'
+diracx-tasks call lollygag:SyncOwnersTask --args '["alice"]'
 ```
 
 ## Passing arguments
@@ -20,7 +22,7 @@ diracx-task-run call lollygag:SyncOwnersTask --args '["alice"]'
 - **`--kwargs`**: JSON dict of keyword arguments (default: `{}`)
 
 ```bash
-diracx-task-run call lollygag:SyncOwnersTask --args '["alice"]' --kwargs '{}'
+diracx-tasks call lollygag:SyncOwnersTask --args '["alice"]' --kwargs '{}'
 ```
 
 ## Debugging
@@ -31,7 +33,7 @@ The `--debugger` flag drops into Python's debugger:
 - **`--debugger exception`**: break on unhandled exception (post-mortem)
 
 ```bash
-diracx-task-run call lollygag:SyncOwnersTask --args '["alice"]' --debugger exception
+diracx-tasks call lollygag:SyncOwnersTask --args '["alice"]' --debugger exception
 ```
 
 ## Lock behaviour in interactive mode
@@ -45,6 +47,6 @@ If `DIRACX_TASKS_REDIS_URL` is not set, no locks are acquired at all.
 To see which tasks are registered, run the command with an invalid entry point name:
 
 ```bash
-diracx-task-run call nonexistent
+diracx-tasks call nonexistent
 # Task 'nonexistent' not found. Available: ['lollygag:OwnerCleanupTask', 'lollygag:OwnerReportTask', 'lollygag:SyncOwnersTask']
 ```

--- a/docs/admin/how-to/tasks/run-task-manually.md
+++ b/docs/admin/how-to/tasks/run-task-manually.md
@@ -1,17 +1,19 @@
 # Run a task manually
 
-The `diracx-task-run call` command executes a single task interactively, bypassing the broker. This is useful for debugging, manual recovery, and verifying task behaviour.
+The `diracx-tasks call` command executes a single task interactively, bypassing the broker. This is useful for debugging, manual recovery, and verifying task behaviour.
+
+`diracx-task-run` remains supported as a backward-compatible alias during migration.
 
 ## Basic usage
 
 ```bash
-diracx-task-run call <entry_point> --args '<JSON list>'
+diracx-tasks call <entry_point> --args '<JSON list>'
 ```
 
 The entry point name is `<category>:<ClassName>` as registered in `pyproject.toml`. For example:
 
 ```bash
-diracx-task-run call lollygag:SyncOwnersTask --args '["alice"]'
+diracx-tasks call lollygag:SyncOwnersTask --args '["alice"]'
 ```
 
 ## Passing arguments
@@ -20,7 +22,7 @@ diracx-task-run call lollygag:SyncOwnersTask --args '["alice"]'
 - **`--kwargs`**: JSON dict of keyword arguments (default: `{}`)
 
 ```bash
-diracx-task-run call lollygag:SyncOwnersTask --args '["alice"]' --kwargs '{}'
+diracx-tasks call lollygag:SyncOwnersTask --args '["alice"]' --kwargs '{}'
 ```
 
 ## Run the dummy job executor
@@ -60,7 +62,7 @@ The `--debugger` flag drops into Python's debugger:
 - **`--debugger exception`**: break on unhandled exception (post-mortem)
 
 ```bash
-diracx-task-run call lollygag:SyncOwnersTask --args '["alice"]' --debugger exception
+diracx-tasks call lollygag:SyncOwnersTask --args '["alice"]' --debugger exception
 ```
 
 ## Lock behaviour in interactive mode
@@ -74,6 +76,6 @@ If `DIRACX_TASKS_REDIS_URL` is not set, no locks are acquired at all.
 To see which tasks are registered, run the command with an invalid entry point name:
 
 ```bash
-diracx-task-run call nonexistent
+diracx-tasks call nonexistent
 # Task 'nonexistent' not found. Available: ['lollygag:OwnerCleanupTask', 'lollygag:OwnerReportTask', 'lollygag:SyncOwnersTask']
 ```

--- a/docs/dev/explanations/tasks/class-details.md
+++ b/docs/dev/explanations/tasks/class-details.md
@@ -68,7 +68,7 @@ classDiagram
 
 **Reader-writer locks** (`ExclusiveRWLock` and `SharedRWLock`) share the same Redis hash key (`lock:rw:{obj}:{key}`) — multiple readers can hold the lock concurrently, but a writer requires exclusive access.
 
-**Limiters** inherit from `BaseLock` but are skipped when a task is executed interactively via `diracx-task-run call`. Their `limit` defaults to `None` (disabled); configuration can enable them without code changes.
+**Limiters** inherit from `BaseLock` but are skipped when a task is executed interactively via `diracx-tasks call`. Their `limit` defaults to `None` (disabled); configuration can enable them without code changes.
 
 ## Task subsystem
 

--- a/docs/dev/explanations/tasks/index.md
+++ b/docs/dev/explanations/tasks/index.md
@@ -159,7 +159,7 @@ The `diracx-tasks` command provides four subcommands:
 - **`submit <entry_point>`** — submit a task to the broker for worker execution.
 - **`worker`** — start a worker process that consumes tasks from the broker.
 - **`scheduler`** — start the singleton scheduler that submits periodic tasks and promotes delayed tasks.
-`diracx-task-run` remains supported as a backward-compatible alias during migration.
+    `diracx-task-run` remains supported as a backward-compatible alias during migration.
 
 This command is provided by `diracx-tasks` and not `diracx-cli` as it is expected to be ran on the same infrastructure as the DiracX tasks workers (e.g. in debug pod in Kubernetes).
 

--- a/docs/dev/explanations/tasks/index.md
+++ b/docs/dev/explanations/tasks/index.md
@@ -153,11 +153,13 @@ export DIRACX_TASKS_REDIS_URL="redis://localhost:6379"
 
 ### CLI
 
-The `diracx-task-run` command provides three subcommands:
+The `diracx-tasks` command provides three subcommands:
 
 - **`call <entry_point>`** — execute a single task interactively (limiters are skipped, structural locks are still acquired). Useful for debugging and manual recovery.
 - **`worker`** — start a worker process that consumes tasks from the broker.
 - **`scheduler`** — start the singleton scheduler that submits periodic tasks and promotes delayed tasks.
+
+`diracx-task-run` remains supported as a backward-compatible alias during migration.
 
 This command is provided by `diracx-tasks` and not `diracx-cli` as it is expected to be ran on the same infrastructure as the DiracX tasks workers (e.g. in debug pod in Kubernetes).
 

--- a/docs/dev/explanations/tasks/index.md
+++ b/docs/dev/explanations/tasks/index.md
@@ -162,7 +162,7 @@ The `diracx-tasks` command provides four subcommands:
 
 `diracx-task-run` remains supported as a backward-compatible alias during migration.
 
-This command is provided by `diracx-tasks` and not `diracx-cli` as it is expected to be ran on the same infrastructure as the DiracX tasks workers (e.g. in debug pod in Kubernetes).
+This command is provided by `diracx-tasks` package and not `diracx-cli` as it is expected to be ran on the same infrastructure as the DiracX tasks workers (e.g. in debug pod in Kubernetes).
 
 ### Extension pattern
 

--- a/docs/dev/explanations/tasks/index.md
+++ b/docs/dev/explanations/tasks/index.md
@@ -153,12 +153,12 @@ export DIRACX_TASKS_REDIS_URL="redis://localhost:6379"
 
 ### CLI
 
-The `diracx-tasks` command provides three subcommands:
+The `diracx-tasks` command provides four subcommands:
 
 - **`call <entry_point>`** — execute a single task interactively (limiters are skipped, structural locks are still acquired). Useful for debugging and manual recovery.
+- **`submit <entry_point>`** — submit a task to the broker for worker execution.
 - **`worker`** — start a worker process that consumes tasks from the broker.
 - **`scheduler`** — start the singleton scheduler that submits periodic tasks and promotes delayed tasks.
-
 `diracx-task-run` remains supported as a backward-compatible alias during migration.
 
 This command is provided by `diracx-tasks` and not `diracx-cli` as it is expected to be ran on the same infrastructure as the DiracX tasks workers (e.g. in debug pod in Kubernetes).

--- a/docs/dev/explanations/tasks/index.md
+++ b/docs/dev/explanations/tasks/index.md
@@ -159,7 +159,7 @@ The `diracx-tasks` command provides four subcommands:
 - **`submit <entry_point>`** — submit a task to the broker for worker execution.
 - **`worker`** — start a worker process that consumes tasks from the broker.
 - **`scheduler`** — start the singleton scheduler that submits periodic tasks and promotes delayed tasks.
-    
+
 `diracx-task-run` remains supported as a backward-compatible alias during migration.
 
 This command is provided by `diracx-tasks` and not `diracx-cli` as it is expected to be ran on the same infrastructure as the DiracX tasks workers (e.g. in debug pod in Kubernetes).

--- a/docs/dev/explanations/tasks/index.md
+++ b/docs/dev/explanations/tasks/index.md
@@ -159,7 +159,8 @@ The `diracx-tasks` command provides four subcommands:
 - **`submit <entry_point>`** — submit a task to the broker for worker execution.
 - **`worker`** — start a worker process that consumes tasks from the broker.
 - **`scheduler`** — start the singleton scheduler that submits periodic tasks and promotes delayed tasks.
-    `diracx-task-run` remains supported as a backward-compatible alias during migration.
+    
+`diracx-task-run` remains supported as a backward-compatible alias during migration.
 
 This command is provided by `diracx-tasks` and not `diracx-cli` as it is expected to be ran on the same infrastructure as the DiracX tasks workers (e.g. in debug pod in Kubernetes).
 

--- a/docs/dev/how-to/add-a-task.md
+++ b/docs/dev/how-to/add-a-task.md
@@ -154,10 +154,10 @@ async def execute(self, lollygag_db: LollygagDB, **kwargs):
 
 ### Test interactively
 
-Use `diracx-task-run call` to execute a task directly:
+Use `diracx-tasks call` to execute a task directly:
 
 ```bash
-diracx-task-run call lollygag:SyncOwnersTask --args '["alice"]'
+diracx-tasks call lollygag:SyncOwnersTask --args '["alice"]'
 ```
 
 The `call` subcommand resolves dependencies and acquires structural locks, but skips limiters (`RateLimiter`, `ConcurrencyLimiter`), making it suitable for debugging and manual recovery.

--- a/docs/dev/reference/pixi-tasks.md
+++ b/docs/dev/reference/pixi-tasks.md
@@ -14,7 +14,7 @@ This page documents the available pixi tasks.
 - `description`: Run pre-commit hooks
 - `local-shell`: Open a shell with the local DiracX environment configured
 - `local-start`: Launch the full DiracX stack locally (seaweedfs, Redis, uvicorn, scheduler, workers)
-- `local-tasks`: Run diracx-task-run with the local environment variables
+- `local-tasks`: Run diracx-tasks with the local environment variables
 - `test-tutorial`: Run only the advanced tutorial tests
 - `tutorial-reset`: Strip tutorial code from gubbins for the advanced tutorial
 

--- a/docs/dev/reference/tasks.md
+++ b/docs/dev/reference/tasks.md
@@ -6,7 +6,7 @@ All locks are Redis-backed with ownership tracking. Each lock instance generates
 
 Locks are split into two categories:
 
-- **Structural locks** (`MutexLock`, `ExclusiveRWLock`, `SharedRWLock`) — always acquired, including in interactive mode (`diracx-task-run call`).
+- **Structural locks** (`MutexLock`, `ExclusiveRWLock`, `SharedRWLock`) — always acquired, including in interactive mode (`diracx-tasks call`).
 - **Limiters** (`RateLimiter`, `ConcurrencyLimiter`) — skipped in interactive mode. These are subclasses of `BaseLimiter`.
 
 ### MutexLock

--- a/pixi.toml
+++ b/pixi.toml
@@ -145,7 +145,7 @@ cmd = "bash run_local.sh"
 description = "Launch the full DiracX stack locally (seaweedfs, Redis, uvicorn, scheduler, workers)"
 [feature.run-local.tasks.local-tasks]
 cmd = "bash run_local_tasks.sh"
-description = "Run diracx-task-run with the local environment variables"
+description = "Run diracx-tasks with the local environment variables"
 [feature.run-local.tasks.local-shell]
 cmd = "bash run_local_shell.sh"
 description = "Open a shell with the local DiracX environment configured"

--- a/run_local.sh
+++ b/run_local.sh
@@ -172,13 +172,13 @@ fi
 # Start application services
 uvicorn --factory diracx.testing.routers:create_app --reload > "${tmp_dir}/logs/uvicorn.log" 2>&1 &
 diracx_pid=$!
-diracx-task-run scheduler > "${tmp_dir}/logs/scheduler.log" 2>&1 &
+diracx-tasks scheduler > "${tmp_dir}/logs/scheduler.log" 2>&1 &
 scheduler_pid=$!
-diracx-task-run worker --worker-size small --max-concurrent-tasks 3 > "${tmp_dir}/logs/worker-sm.log" 2>&1 &
+diracx-tasks worker --worker-size small --max-concurrent-tasks 3 > "${tmp_dir}/logs/worker-sm.log" 2>&1 &
 worker_small_pid=$!
-diracx-task-run worker --worker-size medium --max-concurrent-tasks 2 > "${tmp_dir}/logs/worker-md.log" 2>&1 &
+diracx-tasks worker --worker-size medium --max-concurrent-tasks 2 > "${tmp_dir}/logs/worker-md.log" 2>&1 &
 worker_medium_pid=$!
-diracx-task-run worker --worker-size large --max-concurrent-tasks 1 > "${tmp_dir}/logs/worker-lg.log" 2>&1 &
+diracx-tasks worker --worker-size large --max-concurrent-tasks 1 > "${tmp_dir}/logs/worker-lg.log" 2>&1 &
 worker_large_pid=$!
 
 all_pid_names=(seaweedfs redis uvicorn scheduler worker-sm worker-md worker-lg)
@@ -196,10 +196,10 @@ all_commands=(
   "weed mini -dir=${tmp_dir}/seaweedfs -s3.config=${tmp_dir}/seaweedfs_s3.json"
   "redis-server --port 6379 --save \"\" --appendonly no"
   "uvicorn --factory diracx.testing.routers:create_app --reload"
-  "diracx-task-run scheduler"
-  "diracx-task-run worker --worker-size small --max-concurrent-tasks 1"
-  "diracx-task-run worker --worker-size medium --max-concurrent-tasks 1"
-  "diracx-task-run worker --worker-size large --max-concurrent-tasks 1"
+  "diracx-tasks scheduler"
+  "diracx-tasks worker --worker-size small --max-concurrent-tasks 1"
+  "diracx-tasks worker --worker-size medium --max-concurrent-tasks 1"
+  "diracx-tasks worker --worker-size large --max-concurrent-tasks 1"
 )
 all_restart_counts=(0 0 0 0 0 0 0)
 

--- a/run_local.sh
+++ b/run_local.sh
@@ -175,13 +175,13 @@ fi
 # Start application services
 uvicorn --factory diracx.testing.routers:create_app --reload > "${tmp_dir}/logs/uvicorn.log" 2>&1 &
 diracx_pid=$!
-diracx-task-run scheduler > "${tmp_dir}/logs/scheduler.log" 2>&1 &
+diracx-tasks scheduler > "${tmp_dir}/logs/scheduler.log" 2>&1 &
 scheduler_pid=$!
-diracx-task-run worker --worker-size small --max-concurrent-tasks 3 > "${tmp_dir}/logs/worker-sm.log" 2>&1 &
+diracx-tasks worker --worker-size small --max-concurrent-tasks 3 > "${tmp_dir}/logs/worker-sm.log" 2>&1 &
 worker_small_pid=$!
-diracx-task-run worker --worker-size medium --max-concurrent-tasks 2 > "${tmp_dir}/logs/worker-md.log" 2>&1 &
+diracx-tasks worker --worker-size medium --max-concurrent-tasks 2 > "${tmp_dir}/logs/worker-md.log" 2>&1 &
 worker_medium_pid=$!
-diracx-task-run worker --worker-size large --max-concurrent-tasks 1 > "${tmp_dir}/logs/worker-lg.log" 2>&1 &
+diracx-tasks worker --worker-size large --max-concurrent-tasks 1 > "${tmp_dir}/logs/worker-lg.log" 2>&1 &
 worker_large_pid=$!
 
 all_pid_names=(seaweedfs redis uvicorn scheduler worker-sm worker-md worker-lg)
@@ -199,10 +199,10 @@ all_commands=(
   "weed mini -dir=${tmp_dir}/seaweedfs -s3.config=${tmp_dir}/seaweedfs_s3.json"
   "redis-server --port 6379 --save \"\" --appendonly no"
   "uvicorn --factory diracx.testing.routers:create_app --reload"
-  "diracx-task-run scheduler"
-  "diracx-task-run worker --worker-size small --max-concurrent-tasks 1"
-  "diracx-task-run worker --worker-size medium --max-concurrent-tasks 1"
-  "diracx-task-run worker --worker-size large --max-concurrent-tasks 1"
+  "diracx-tasks scheduler"
+  "diracx-tasks worker --worker-size small --max-concurrent-tasks 1"
+  "diracx-tasks worker --worker-size medium --max-concurrent-tasks 1"
+  "diracx-tasks worker --worker-size large --max-concurrent-tasks 1"
 )
 all_restart_counts=(0 0 0 0 0 0 0)
 

--- a/run_local_tasks.sh
+++ b/run_local_tasks.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Run diracx-task-run with the local environment variables
+# Run diracx-tasks with the local environment variables
 set -euo pipefail
 
 env_file_pointer="$(cd "$(dirname "$0")" && pwd)/.run-local-env"
@@ -20,4 +20,4 @@ fi
 # shellcheck disable=SC1090
 source "$env_file"
 
-exec diracx-task-run "$@"
+exec diracx-tasks "$@"


### PR DESCRIPTION
Summary

This PR implements Phase 1 of issue https://github.com/DIRACGrid/diracx/issues/975 by introducing the new CLI name while preserving backward compatibility with the old one.

What changed

1. Added a new console script name: diracx-tasks.
2. Kept the existing console script name: diracx-task-run.
3. Updated local launcher scripts to use the new primary name.
4. Updated user-facing docs to prefer diracx-tasks.
5. Added explicit compatibility notes in docs where useful, stating that diracx-task-run remains supported during migration.

Migration plan context (3 phases)

1. Phase 1 (this PR, diracx):
2. Support both names in diracx so current deployments and charts do not break.
3. Phase 2 (diracx-charts):
4. Switch charts to only use diracx-tasks after Phase 1 is merged/released.
5. Phase 3 (diracx):
6. Remove the old alias diracx-task-run once chart migration is complete and safe.

Why this is safe

1. No breaking change in this PR: old command still works.
2. Local workflows move to the new command immediately, reducing future churn.
3. Rollback is straightforward: if needed, operators can continue using diracx-task-run without changing this release.

Rollback safety note

If any environment is still wired to diracx-task-run, it will continue to function in Phase 1.
In case of operational issues with the new command name rollout, usage can be temporarily reverted to diracx-task-run with no packaging change required in this PR.

Validation

1. Pre-commit hooks passed on committed changes.
2. Local scripts now invoke diracx-tasks.
3. Legacy name references that remain are intentional compatibility references.

Closes

Fixes https://github.com/DIRACGrid/diracx/issues/975