### PR TITLE
fix(dev): wait for /api/health/ready before reporting local-start ready

### DIFF
--- a/run_local.sh
+++ b/run_local.sh
@@ -65,6 +65,7 @@ function wait_for_service() {
 }
 
 function redis_ready() { redis-cli -p 6379 ping 2>/dev/null | grep -q PONG; }
+function diracx_ready() { wget --quiet --output-document=/dev/null --tries=1 --timeout=2 http://localhost:8000/api/health/ready; }
 
 # Make a keystore
 keystore="${tmp_dir}/keystore/jwks.json"
@@ -217,9 +218,9 @@ function restart_process() {
   all_pid_values[$i]=$!
 }
 
-# Wait for uvicorn
+# Wait for DiracX readiness
 if wait_for_service "uvicorn" "$diracx_pid" "${tmp_dir}/logs/uvicorn.log" \
-     curl --silent --max-time 2 --head http://localhost:8000; then
+     diracx_ready; then
   status_line="✅ DiracX is running on http://localhost:8000"
 else
   status_line="❌ Failed to start DiracX — check ${tmp_dir}/logs/uvicorn.log"

--- a/run_local.sh
+++ b/run_local.sh
@@ -65,7 +65,7 @@ function wait_for_service() {
 }
 
 function redis_ready() { redis-cli -p 6379 ping 2>/dev/null | grep -q PONG; }
-function diracx_ready() { wget --quiet --output-document=/dev/null --tries=1 --timeout=2 http://localhost:8000/api/health/ready; }
+function diracx_ready() { curl --silent --show-error --fail --output /dev/null --max-time 2 http://localhost:8000/api/health/ready; }
 
 # Make a keystore
 keystore="${tmp_dir}/keystore/jwks.json"


### PR DESCRIPTION
## Summary
- make local-start poll GET /api/health/ready with wget
- keep startup gating in run_local.sh aligned with readiness semantics


Closes #1015