### PR TITLE
refactor(tasks): remove diracx-task-run alias (#975)

### DIFF
--- a/diracx-tasks/pyproject.toml
+++ b/diracx-tasks/pyproject.toml
@@ -31,7 +31,6 @@ testing = ["diracx-testing", "fakeredis"]
 
 [project.scripts]
 diracx-tasks = "diracx.tasks.task_run:main"
-diracx-task-run = "diracx.tasks.task_run:main"
 
 [project.entry-points."diracx.dbs.sql"]
 TaskDB = "diracx.tasks.plumbing.persistence:TaskDB"

--- a/diracx-tasks/src/diracx/tasks/task_run.py
+++ b/diracx-tasks/src/diracx/tasks/task_run.py
@@ -5,9 +5,6 @@ Usage:
     diracx-tasks submit <entry_point> [--args JSON] [--kwargs JSON] [--redis-url URL]
     diracx-tasks worker [--max-concurrent-tasks N] [--redis-url URL]
     diracx-tasks scheduler [--redis-url URL]
-
-Backward-compatible alias:
-    diracx-task-run <subcommand> [...]
 """
 
 from __future__ import annotations

--- a/docs/admin/how-to/tasks/configure.md
+++ b/docs/admin/how-to/tasks/configure.md
@@ -31,8 +31,6 @@ The scheduler is a singleton process responsible for submitting periodic tasks a
 diracx-tasks scheduler --redis-url redis://redis-host:6379
 ```
 
-`diracx-task-run` remains supported as a backward-compatible alias during migration.
-
 Only one scheduler instance should run at a time. This is enforced by a Redis mutex — if a second scheduler starts, it will wait for the first to release the lock before taking over.
 
 ## Helm chart configuration

--- a/docs/admin/how-to/tasks/run-task-manually.md
+++ b/docs/admin/how-to/tasks/run-task-manually.md
@@ -2,8 +2,6 @@
 
 The `diracx-tasks call` command executes a single task interactively, bypassing the broker. This is useful for debugging, manual recovery, and verifying task behaviour.
 
-`diracx-task-run` remains supported as a backward-compatible alias during migration.
-
 ## Basic usage
 
 ```bash
@@ -45,13 +43,13 @@ Both tasks talk to the job databases, so the relevant `DIRACX_DB_URL_*`,
 Run the monitor once to pick up all `Received` jobs:
 
 ```bash
-diracx-task-run call jobs:DummyJobExecutorMonitorTask
+diracx-tasks call jobs:DummyJobExecutorMonitorTask
 ```
 
 Or simulate the execution of a single job by passing its job ID:
 
 ```bash
-diracx-task-run call jobs:DummyJobExecutorTask --args '[42]'
+diracx-tasks call jobs:DummyJobExecutorTask --args '[42]'
 ```
 
 ## Debugging

--- a/docs/dev/explanations/tasks/index.md
+++ b/docs/dev/explanations/tasks/index.md
@@ -160,8 +160,6 @@ The `diracx-tasks` command provides four subcommands:
 - **`worker`** — start a worker process that consumes tasks from the broker.
 - **`scheduler`** — start the singleton scheduler that submits periodic tasks and promotes delayed tasks.
 
-`diracx-task-run` remains supported as a backward-compatible alias during migration.
-
 This command is provided by `diracx-tasks` package and not `diracx-cli` as it is expected to be ran on the same infrastructure as the DiracX tasks workers (e.g. in debug pod in Kubernetes).
 
 ### Extension pattern


### PR DESCRIPTION
Summary

This is Phase 3 of issue #975. It removes the legacy `diracx-task-run` alias now that the new `diracx-tasks` name has been adopted and the corresponding `diracx-charts` change is already in place.

What changed

1. Removed the old `diracx-task-run` console script entry.
2. Removed the compatibility note from the CLI/doc usage text.
3. Updated the remaining task docs and examples to use `diracx-tasks` only.

**Do not merge this PR until the corresponding `diracx-charts` PR is merged and available in the target deployment path.**

Fixes #975
