### PR TITLE
docs(rtd): fix broken 404-page asset paths

### DIFF
--- a/docs/admin/how-to/install-without-kubernetes/installing-in-a-container.md
+++ b/docs/admin/how-to/install-without-kubernetes/installing-in-a-container.md
@@ -71,7 +71,7 @@ DIRACX_SANDBOX_STORE_BUCKET_NAME="notsetyet"
 # disable the jobs router (and hopefully S3)
 DIRACX_SERVICE_JOBS_ENABLED=false
 # we are using a local git repo on the node, this is not fully supported yet.
-# Please see: https://diracx.io/en/latest/RUN_PROD/#cs for the approved way.
+# Please see: https://diracx.diracgrid.org/en/latest/RUN_PROD/#cs for the approved way.
 DIRACX_CONFIG_BACKEND_URL="git+file:///cs_store?revision=main"
 DIRACX_DB_URL_AUTHDB=mysql+aiomysql://YourUser:YourPassword@host.containers.internal:3306/DiracXAuthDB
 # these are the users and passwords you have chosen for the databases in DIRAC; they can be found in

--- a/docs/dev/explanations/documentation-system.md
+++ b/docs/dev/explanations/documentation-system.md
@@ -4,7 +4,7 @@ This page explains how the DiracX documentation system works, including its arch
 
 ## Overview
 
-The DiracX documentation is built using [MkDocs](https://www.mkdocs.org/) with the [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) theme. The documentation is hosted at [diracx.io](https://diracx.io/).
+The DiracX documentation is built using [MkDocs](https://www.mkdocs.org/) with the [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) theme. The documentation is hosted at [diracx.diracgrid.org](https://diracx.diracgrid.org/).
 
 ## The Divio Documentation System
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ extra_css:
 
 site_name: DiracX
 repo_url: https://github.com/DIRACGrid/diracx
-site_url: https://diracx.io/
+site_url: !ENV [READTHEDOCS_CANONICAL_URL, 'https://diracx.diracgrid.org/']
 site_description: >-
   DiracX is the modern, next-generation successor to the DIRAC distributed computing framework,
   originally developed by LHCb at CERN for large-scale scientific data management and workload processing.


### PR DESCRIPTION
`site_url` pointed at an unused domain with no path, so mkdocs generated root-absolute asset links for version-less pages like 404.html. Read the Docs serves this project under a /en/latest/ prefix, so those requests 404 and the 404 page renders unstyled.

Fixed via mkdocs's built-in !ENV tag, which picks up Read the Docs' READTHEDOCS_CANONICAL_URL at build time and falls back to a static default locally. No new dependency needed.