### PR TITLE
fix(db,routers): improve DB URLs error handling

### DIFF
--- a/diracx-db/src/diracx/db/os/utils.py
+++ b/diracx-db/src/diracx/db/os/utils.py
@@ -116,7 +116,15 @@ class BaseOSDB(metaclass=ABCMeta):
         for entry_point in select_from_extension(group=DiracEntryPoint.OS_DB):
             db_name = entry_point.name
             # Get the field value from the OpenSearchDBSettings model
-            if field_value := factory_settings.opensearch_dbs.get(db_name):
+            field_value = factory_settings.opensearch_dbs.get(db_name)
+            if field_value == "" or not field_value:
+                logger.warning(
+                    "%s found but no URL connection set: please set "
+                    "DIRACX_OS_DB_%s env variable to enable it.",
+                    db_name,
+                    db_name.upper(),
+                )
+            else:
                 try:
                     conn_kwargs[db_name] = json.loads(field_value)
                 except Exception:

--- a/diracx-db/src/diracx/db/sql/utils/base.py
+++ b/diracx-db/src/diracx/db/sql/utils/base.py
@@ -135,7 +135,15 @@ class BaseSQLDB(metaclass=ABCMeta):
         for entry_point in select_from_extension(group=DiracEntryPoint.SQL_DB):
             db_name = entry_point.name
             # Get the field value from the SqlDBSettings model
-            if db_url := factory_settings.sql_dbs.get(db_name):
+            db_url = factory_settings.sql_dbs.get(db_name)
+            if db_url == "" or not db_url:
+                logger.warning(
+                    "%s found but no URL connection set: please set "
+                    "DIRACX_DB_URL_%s env variable to enable it.",
+                    db_name,
+                    db_name.upper(),
+                )
+            else:
                 try:
                     if db_url == "sqlite+aiosqlite:///:memory:":
                         db_urls[db_name] = db_url

--- a/diracx-routers/src/diracx/routers/factory.py
+++ b/diracx-routers/src/diracx/routers/factory.py
@@ -208,7 +208,14 @@ def create_app_inner(
             logger.exception("Failed to initialize DB %s", db_name)
 
     if fail_startup:
-        raise Exception("No SQL database could be initialized, aborting")
+        raise Exception(
+            "No SQL database could be initialized, aborting. "
+            "Please set the following env variables to enable it:\n "
+            + "\n ".join(
+                "DIRACX_DB_URL_" + ep.name.upper()
+                for ep in select_from_extension(group=DiracEntryPoint.SQL_DB)
+            )
+        )
 
     # Instantiate the cacheable sources and override their create methods,
     # mirroring the SQL DB wiring above. A single instance is used for each
@@ -277,22 +284,31 @@ def create_app_inner(
                     f"Cannot enable {system_name=} as it requires {cls=}"
                 )
 
-        # Ensure required DBs are available
+        # Ensure required SQL DBs are available
         missing_sql_dbs = (
             set(find_dependents(router, BaseSQLDB)) - available_sql_db_classes
         )
-
         if missing_sql_dbs:
             raise NotImplementedError(
-                f"Cannot enable {system_name=} as it requires {missing_sql_dbs=}"
+                f"Cannot enable {system_name=} please set the following env "
+                "variables to enable it:\n "
+                + "\n ".join(
+                    "DIRACX_DB_URL_" + x.__name__.upper() for x in missing_sql_dbs
+                )
             )
+
+        # Ensure required OpenSearch DBs are available
         missing_os_dbs = (
             set(find_dependents(router, BaseOSDB))  # type: ignore[type-abstract]
             - available_os_db_classes
         )
         if missing_os_dbs:
             raise NotImplementedError(
-                f"Cannot enable {system_name=} as it requires {missing_os_dbs=}"
+                f"Cannot enable {system_name=} please set the following env "
+                "variables to enable it:\n "
+                + "\n ".join(
+                    "DIRACX_OS_DB_" + x.__name__.upper() for x in missing_os_dbs
+                )
             )
 
         # Ensure required cacheable sources have been wired, i.e. that the


### PR DESCRIPTION
#### PR Description
In this PR I'm improving the error reporting when DB_URL env variables are missing as suggested in the "Proposed Changes" section of #46.

### PR Validation
Manually tweaking `BaseSQLDB.available_urls()` and `BaseOSDB.available_urls()` I was able to generate the desired warning messages:
- SQL:
  ```
  2026-09-05 17:02:04,332 - WARNING - TaskQueueDB found but no URL connection set: please set DIRACX_DB_URL_TASKQUEUEDB env variable to enable it.
  ```
- OpenSearch:
  ```
  2026-09-07 18:48:02,885 - WARNING - JobParametersDB found but no URL connection set: please set DIRACX_OS_DB_JOBPARAMETERSDB env variable to enable it.
  ```
Additionally, manually tweaking `diracx-db/src/diracx/db/__main__.py.generate_local_urls()` I was able to reproduce the desired error messages:
- For "No SQL database could be initialized":
  ```
  Exception: No SQL database could be initialized, aborting. Please set the following env variables to enable it:
   DIRACX_DB_URL_JOBDB
   DIRACX_DB_URL_LOLLYGAGDB
   DIRACX_DB_URL_MYPILOTDB
   DIRACX_DB_URL_AUTHDB
   DIRACX_DB_URL_JOBDB
   DIRACX_DB_URL_JOBLOGGINGDB
   DIRACX_DB_URL_PILOTAGENTSDB
   DIRACX_DB_URL_RESOURCESTATUSDB
   DIRACX_DB_URL_SANDBOXMETADATADB
   DIRACX_DB_URL_TASKQUEUEDB
   DIRACX_DB_URL_TASKDB
  ```
- For "Cannot enable system…":
  - SQL:
    ```
    NotImplementedError: Cannot enable system_name='jobs' please set the following env variables to enable it:
     DIRACX_DB_URL_TASKQUEUEDB
     DIRACX_DB_URL_JOBDB
    ``` 
  - OpenSearch:
    ```
    NotImplementedError: Cannot enable system_name='jobs' please set the following env variables to enable it:
     DIRACX_OS_DB_JOBPARAMETERSDB
    ``` 


#### DoD
- [X] Starting a service whose DB env variable is unset produces an error message that contains the literal environment variable name to set (e.g. DIRACX_DB_URL_JOBDB).
- [X] Starting with no DB URLs configured at all produces an error explaining that connection URLs are provided via DIRACX_DB_URL_ / DIRACX_OS_DB_ variables.
- [X] DBs that are discovered but unconfigured are logged (warning level) at startup instead of being silently skipped, for both SQL and OpenSearch databases.
- [ ] Behavior is covered by tests (missing single DB, no DBs at all, OpenSearch variant) if possible.
- [X] Malformed-URL error handling is unchanged.


Closes https://github.com/DIRACGrid/diracx/issues/46
